### PR TITLE
Remove max-width from content

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -9,3 +9,6 @@ div.photo {
 div.bio {
 	margin-left:10px;
 }
+.wy-nav-content {
+	max-width: inherit !important;    
+}


### PR DESCRIPTION
I don't see the reasoning why Read the docs added a max-width of 800px to the contents of the documents, it only makes the reader have to scroll more and it wastes 40% of the screen space. This small CSS change will remove that so it will use the full width of your screen.