### PR TITLE
Conceptual: Fixed IConfiguration formatting and removed unwanted '&'

### DIFF
--- a/docs/conceptual-overview/understanding-aspnet5-apps.rst
+++ b/docs/conceptual-overview/understanding-aspnet5-apps.rst
@@ -139,7 +139,7 @@ The *References* folder details the server-side references for the project. It s
 Configuring the Application
 ---------------------------
 
-ASP.NET 5 no longer stores configuration settings in XML files (*web.config* and *machine.config*). Configuration is now stored in *config.json*, which was designed specifically for storing app configuration settings. The default ASP.NET project template includes Entity Framework, and so specifies the database connection string details in the *config.json&* file included in the project.
+ASP.NET 5 no longer stores configuration settings in XML files (*web.config* and *machine.config*). Configuration is now stored in *config.json*, which was designed specifically for storing app configuration settings. The default ASP.NET project template includes Entity Framework, and so specifies the database connection string details in the *config.json* file included in the project.
 
 .. image:: understanding-aspnet5-apps/_static/config-json.png
 
@@ -147,11 +147,11 @@ Individual entries within *config.json* are not limited to name-value pairs, but
 
 There's nothing special about the *config.json* filename - it's specified by name in Startup.cs_. You can add as many different configuration files as makes sense for your app, rather than having to add to an ever-growing *web.config* file. You're also not limited to just JSON-formatted files - you can still use XML or even .INI files if you prefer.
 
-Accessing configuration data from your app is best done by injecting the ``IConfiguration <https://github.com/aspnet/Configuration/blob/dev/src/Microsoft.Framework.ConfigurationModel.Interfaces/IConfiguration.cs>``_ interface into your controller, and then simply calling its ``Get`` method with the name of the configuration element you need. For example, to store the application name in config and display it on the About page, you would need to make three changes to the default project. First, add the entry to *project.config*.
+Accessing configuration data from your app is best done by injecting the `IConfiguration <https://github.com/aspnet/Configuration/blob/dev/src/Microsoft.Framework.ConfigurationModel.Interfaces/IConfiguration.cs>`_ interface into your controller, and then simply calling its ``Get`` method with the name of the configuration element you need. For example, to store the application name in config and display it on the About page, you would need to make three changes to the default project. First, add the entry to *project.config*.
 
 .. image:: understanding-aspnet5-apps/_static/add-config.png
 
-Next, make sure ASP.NET knows what to return when a constructor requires an instance of ``IConfiguration``. In this case, we can specify that the configuration value is a singleton, since we don't expect it to change throughout the life of the application. We'll address *Startup.cs* in a moment, but for this step just add one line to the end of the ConfigureServices() method in *Startup.cs*:
+Next, make sure ASP.NET knows what to return when a constructor requires an instance of ``IConfiguration``. In this case, we can specify that the configuration value is a singleton, since we don't expect it to change throughout the life of the application. We'll address *Startup.cs* in a moment, but for this step just add one line to the end of the ``ConfigureServices()`` method in *Startup.cs*:
 
 .. code-block:: c#
 	


### PR DESCRIPTION
1. Removed an supposed to be unwanted & after config.json

2. Fixed an unwanted formatting where it appears that trying to have a link inside a code block causes a non-wrapping code paragraph, which looks like this: 

![](http://i.imgur.com/L24uiRb.png)

3. Added syntax highlighting around ConfigureServices() as it's clearly referencing a specific code method to make it more obvious.