### PR TITLE
Update global.config section sources to projects

### DIFF
--- a/docs/conceptual-overview/understanding-aspnet5-apps.rst
+++ b/docs/conceptual-overview/understanding-aspnet5-apps.rst
@@ -82,12 +82,12 @@ The **scripts** section is used to specify when certain build automation scripts
 The global.json File
 --------------------
 
-The global.json file is used to configure the solution as a whole. It includes just two sections, ``sources`` and ``sdk`` by default.
+The global.json file is used to configure the solution as a whole. It includes just two sections, ``projects`` and ``sdk`` by default.
 
 .. literalinclude:: understanding-aspnet5-apps/sample/global.json
 	:language: javascript
 
-The *sources* property designates which folders contain source code for the solution. By default the project structure places source files in a *src* folder, allowing build artifacts to be placed in a sibling folder, making it easier to exclude such things from source control.
+The *projects* property designates which folders contain source code for the solution. By default the project structure places source files in a *src* folder, allowing build artifacts to be placed in a sibling folder, making it easier to exclude such things from source control.
 
 .. image:: understanding-aspnet5-apps/_static/solution-files.png
 


### PR DESCRIPTION
As per the [announcement](https://github.com/aspnet/Announcements/issues/18), `sources` has been renamed to `projects`. `sources` will be removed in beta5. 