### PR TITLE
Update accconfirm.rst

### DIFF
--- a/docs/security/accconfirm.rst
+++ b/docs/security/accconfirm.rst
@@ -217,6 +217,12 @@ Currently once a user completes the registration form, they are logged in. You g
             {
                 if (!await UserManager.IsEmailConfirmedAsync(user))
                 {
+		    // Send an email with confirmation link
+                    var code = await UserManager.GenerateEmailConfirmationTokenAsync(user);
+                    var callbackUrl = Url.Action("ConfirmEmail", "Account", new { userId = user.Id, code = code }, protocol: Context.Request.Scheme);
+                    await MessageServices.SendEmailAsync(model.Email, "Confirm your account",
+                        "Please confirm your account by clicking this link: <a href=\"" + callbackUrl + "\">link</a>");
+                        
                     ModelState.AddModelError(string.Empty, "You must have a confirmed email to log in.");
                     return View(model);
                 }


### PR DESCRIPTION
A confirmation email should be resent at this point for cases when the user lost the original email.  Without this email the user would not be able to confirm their identity and they would have no other means to generate an email, they would be stuck in limbo.          

This matches the pattern in Rick Anderson's similar article: http://www.asp.net/mvc/overview/security/create-an-aspnet-mvc-5-web-app-with-email-confirmation-and-password-reset