### PR TITLE
Update installing-on-linux.rst

### DIFF
--- a/docs/getting-started/installing-on-linux.rst
+++ b/docs/getting-started/installing-on-linux.rst
@@ -36,7 +36,7 @@ To install Mono::
     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
     echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
     sudo apt-get update
-    sudo apt-get install Mono-Complete
+    sudo apt-get install mono-complete
 
 Install libuv
 ^^^^^^^^^^^^^


### PR DESCRIPTION
When try to install mono-complete on my Raspberry Pi, I found out the the packages are case-sensitive.
When using executing "sudo apt-get install Mono-Complete" I received a message telling me that the package was not found, trying it with the "sudo apt-get install mono-complete" worked like a charm.