### PR TITLE
Update casing of NuGet.Config

### DIFF
--- a/aspnet/getting-started/installing-on-linux.rst
+++ b/aspnet/getting-started/installing-on-linux.rst
@@ -75,11 +75,11 @@ Now that we have DNVM and the other tools needed to run an ASP.NET 5 application
 
 The nightly package source is: `https://www.myget.org/F/aspnetvnext/api/v2/`
 
-You specify your package sources through your NuGet.config file.
+You specify your package sources through your NuGet.Config file.
 
-Edit: ``~/.config/NuGet/NuGet.config``
+Edit: ``~/.config/NuGet/NuGet.Config``
 
-The NuGet.config file should look something like the following
+The NuGet.Config file should look something like the following
 
 .. code-block:: xml
 


### PR DESCRIPTION
The case of the `NuGet.Config` file in the Linux instructions is incorrect, and Linux file systems are generally case-sensitive, so it doesn't work as cased in the instructions.

/cc @danroth27 @glennc 