### PR TITLE
Title change

### DIFF
--- a/mvc/tutorials/mvc-with-entity-framework.rst
+++ b/mvc/tutorials/mvc-with-entity-framework.rst
@@ -1,4 +1,4 @@
-Get Started with Entity Framework 7 Code using ASP.NET MVC 6
+Get Started with Entity Framework 7 using ASP.NET MVC 6
 ============================================================
 
 By `Mike Wasson`_  and `Rick Anderson`_


### PR DESCRIPTION
"Entity Framework 7 Code" doesn't make sense. Should be either "Entity Framework 7 Code _First_" or just "Entity Framework 7".

Prefer just "Entity Framework 7", as the phrase "Code First" only makes sense to people who already know EF.