### PR TITLE
Add info about double underscores in env variables

### DIFF
--- a/aspnet/fundamentals/configuration.rst
+++ b/aspnet/fundamentals/configuration.rst
@@ -69,6 +69,8 @@ Adding support for additional configuration file sources is accomplished through
 
 The order in which configuration sources are specified is important, as this establishes the precedence with which settings will be applied if they exist in multiple locations. In the example above, if the same setting exists in both ``config.json`` and in an environment variable, the setting from the environment variable will be the one that is used. Essentially, the last configuration source specified "wins" if a setting exists in more than one location.
 
+.. note:: To override nested keys through environment variables in shells that don't support ``:`` in variable names replace them with ``__`` (double underscore).
+
 It can be useful to have environment-specific configuration files. This can be achieved using the following:
 
 .. literalinclude:: /../common/samples/WebApplication1/src/WebApplication1/Startup.cs


### PR DESCRIPTION
There's no readily available info on how to override nested confguration keys in shells that don't support colons in variable names.

This adds short note about how to handle this in such cases

The only info I could find was in the source code.