### PR TITLE
Fix regarding "dnx . run" error on OSX.

### DIFF
--- a/aspnet/dnx/console.rst
+++ b/aspnet/dnx/console.rst
@@ -45,11 +45,11 @@ Save your changes.
 Running the App
 ---------------
 
-At this point, we're ready to run the app. You can do this by simply entering ``dnx . run`` from the command prompt. You should see a result like this one:
+At this point, we're ready to run the app. You can do this by simply entering ``dnx run`` from the command prompt. You should see a result like this one:
 
 .. image:: console/_static/dnx-run.png
 
-.. note:: The ``dnx`` command is used to execute a managed entry point (a ``Program.Main`` function) in an assembly. The ``dnx . run`` command is a shorthand for executing the entry point in the current project. It is equivalent to ``dnx . [project_name]``
+.. note:: The ``dnx`` command is used to execute a managed entry point (a ``Program.Main`` function) in an assembly. The ``dnx run`` command is a shorthand for executing the entry point in the current project. It is equivalent to ``dnx [project_name]``
 
 You can select which CLR to run on using the .NET Version Manager (DNVM). To run on CoreCLR first run ``dnvm use [version] -r CoreCLR``. To return to using the .NET Framework CLR run ``dnvm use [version] -r CLR``.
 


### PR DESCRIPTION
Running "dnx . run" gives error on OSX, but "dnx run" works.

I don't know if this suppose to be like this, if yes ignore/close this pull request.