### PR TITLE
Update instructions to include curl with unzip

### DIFF
--- a/aspnet/getting-started/installing-on-linux.rst
+++ b/aspnet/getting-started/installing-on-linux.rst
@@ -20,9 +20,9 @@ Install the .NET Version Manager (DNVM)
 
 Use the .NET Version Manager (DNVM) to install different versions of the .NET Execution Environment (DNX) on Linux.
 
-1. Install ``upzip`` if you don't already have it::
+1. Install ``upzip`` and ``curl`` if you don't already have them::
 
-    sudo apt-get install unzip
+    sudo apt-get install unzip curl
 
 2. Download and install DNVM::
 


### PR DESCRIPTION
On Debian 8 curl is not installed by default. Added to apt-get install command line.