### PR TITLE
Fix travis status by fixing exit code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ python:
 # command to install dependencies
 install: "pip install -q -r requirements.txt"
 # command to run tests
-script: ./build.sh
+script:
+  - sphinx-build -nW -b html -d aspnet/_build/doctrees aspnet aspnet/_build/html
+  - sphinx-build -nW -b html -d mvc/_build/doctrees mvc mvc/_build/html
 # Flags used here, not in `make html`:
 #  -n   Run in nit-picky mode. Currently, this generates warnings for all missing references.
 #  -W   Turn warnings into errors. This means that the build stops at the first warning and sphinx-build exits with exit status 1.

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,0 @@
-echo "Trying to build the aspnet directory..." && cd aspnet && sphinx-build -nW -b html -d _build/doctrees . _build/html
-echo "Trying to build the mvc directory..." && cd ../mvc && sphinx-build -nW -b html -d _build/doctrees . _build/html


### PR DESCRIPTION
If you look at [this](https://travis-ci.org/aspnet/Docs/builds/85531288), the Travis build says successful despite failing. This was happening because the `build.sh` file always exited with status code 0. Now instead of using a `build.sh` file, we just specify both the build commands in the `.travis.yml` file