### PR TITLE
Added link to EF's docs

### DIFF
--- a/aspnet/index.rst
+++ b/aspnet/index.rst
@@ -16,6 +16,7 @@ Frameworks
 ----------
 
 * :ref:`MVC <mvc:index>`
+* `EF <https://ef.readthedocs.org>`
 
 Topics
 ------


### PR DESCRIPTION
No clue if that's the right syntax for an external link. I guessed.