### PR TITLE
Removed basics of web dev placeholder

### DIFF
--- a/aspnet/conceptual-overview/index.rst
+++ b/aspnet/conceptual-overview/index.rst
@@ -8,5 +8,4 @@ Conceptual Overview
    dotnetcore
    /dnx/overview
    nuget
-   web
    understanding-aspnet5-apps

--- a/aspnet/conceptual-overview/web.rst
+++ b/aspnet/conceptual-overview/web.rst
@@ -1,8 +1,0 @@
-.. include:: /../common/stub-topic.txt
-
-|stub-icon| Basics of Web Development
-=====================================
-
-.. include:: /../common/stub-notice.txt
-
-.. _issue: https://github.com/aspnet/Docs/issues/45


### PR DESCRIPTION
Removed aspnet/conceptual-overview/web.rst so generated TOC will no longer have link