### PR TITLE
Added docs video link and updated autobuild instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,29 +4,44 @@ Information on contributing to this repo is in the [Contributing Guide](https://
 
 The documentation is built using [Sphinx](http://sphinx-doc.org) and [reStructuredText](http://sphinx-doc.org/rest.html), and then hosted by [ReadTheDocs](http://aspnet.readthedocs.org).
 
+## Video: Getting Started ##
+[Watch a video](http://ardalis.com/contributing-to-asp-net-5-documentation) showing how to get started building the documentation locally:
+
 ## Building the Docs ##
 
 Once you have cloned the Docs to your local machine, the following instructions will walk you through installing the tools necessary to build and test.
 
-1. [Download python](https://www.python.org/downloads/) version 2.7.10 or higher. (Version 3.4 is recommended.)
+1. [Download python](https://www.python.org/downloads/) version 2.7.10 or higher (Version 3.4 is recommended).
 
-2. If you are installing on Windows, add both the Python install directory and the Python scripts directory to your `PATH` environment variable. For example, if you install Python into the c:\python34 directory, you would add `c:\python34;c:\python34\scripts` to your `PATH` environment variable.  
+2. If you are installing on Windows, ensure both the Python install directory and the Python scripts directory have been added to your `PATH` environment variable. For example, if you install Python into the c:\python34 directory, you would add `c:\python34;c:\python34\scripts` to your `PATH` environment variable.
 
 3. Install Sphinx by opening a command prompt and running the following Python command. (Note that this operation might take a few minutes to complete.)
 
-	pip install sphinx
+    ```pip install sphinx```
 
 4. By default, when you install Sphinx, it will install the ReadTheDocs custom theme automatically. If you need to update the installed version of this theme, you should run:
 
-	pip install -U sphinx_rtd_theme
+    ```pip install -U sphinx_rtd_theme```
 
-5. Navigate to one of the the main project subdirectories in the Docs repo - such as `mvc` or `aspnet`.
+5. Navigate to one of the main project subdirectories in the Docs repo - such as `mvc`, `aspnet`, or `webhooks`.
 
 6. Run the `make.bat` file using `html` argument to build the stand-alone version of the project in question.
 
-	make html
+    ```make html```
 
 7. Once make completes, the generated docs will be in the .../docs/<project>/_build/html directory. Simply open the `index.html` file in your browser to see the built docs for that project.
+
+## Use autobuild to easily view site changes locally ##
+
+You can also install sphinx-autobuild which will run a local web server and automatically refresh whenever changes to the source files are detected. To do so:
+    
+1. Install sphinx-autobuild
+
+    ```pip install sphinx-autobuild```
+
+2. Run sphinx-autobuild from the one of the main project subdirectories in the Docs repo, such as `mvc`, `aspnet`, or `webhooks`
+ 
+    ```sphinx-autobuild . _build/html```
 
 ## Adding Content ##
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Information on contributing to this repo is in the [Contributing Guide](https://
 The documentation is built using [Sphinx](http://sphinx-doc.org) and [reStructuredText](http://sphinx-doc.org/rest.html), and then hosted by [ReadTheDocs](http://aspnet.readthedocs.org).
 
 ## Video: Getting Started ##
-[Watch a video](http://ardalis.com/contributing-to-asp-net-5-documentation) showing how to get started building the documentation locally:
+[Watch a video](http://ardalis.com/contributing-to-asp-net-5-documentation) showing how to get started building the documentation locally.
 
 ## Building the Docs ##
 


### PR DESCRIPTION
Clarified the Windows python install instructions.
Added the link to the youtube video demonstrating getting started.
Added back the autobuild instructions.
Clarified that the root doc file folders included webhooks.