### PR TITLE
React to aspnet/Razor#561.

### DIFF
--- a/aspnet/client-side/angular/sample/AngularSample/src/AngularSample/Views/_ViewImports.cshtml
+++ b/aspnet/client-side/angular/sample/AngularSample/src/AngularSample/Views/_ViewImports.cshtml
@@ -1,3 +1,3 @@
 ﻿@using AngularSample
 @using AngularSample.Models
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers

--- a/aspnet/fundamentals/application-insights/sample/AppInsightsDemo/src/AppInsightsDemo/Views/_ViewImports.cshtml
+++ b/aspnet/fundamentals/application-insights/sample/AppInsightsDemo/src/AppInsightsDemo/Views/_ViewImports.cshtml
@@ -1,5 +1,5 @@
 ﻿@using AppInsightsDemo
 @using AppInsightsDemo.Models
 @using Microsoft.AspNet.Identity
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers
 @inject Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration TelemetryConfiguration

--- a/aspnet/security/2fa/sample/WebSMS/src/WebSMS/Views/_ViewImports.cshtml
+++ b/aspnet/security/2fa/sample/WebSMS/src/WebSMS/Views/_ViewImports.cshtml
@@ -3,4 +3,4 @@
 @using WebSMS.ViewModels.Account
 @using WebSMS.ViewModels.Manage
 @using Microsoft.AspNet.Identity
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers

--- a/aspnet/security/accconfirm/sample/WebApplication1/src/WebApplication1/Views/_ViewImports.cshtml
+++ b/aspnet/security/accconfirm/sample/WebApplication1/src/WebApplication1/Views/_ViewImports.cshtml
@@ -3,4 +3,4 @@
 @using WebApplication1.ViewModels.Account
 @using WebApplication1.ViewModels.Manage
 @using Microsoft.AspNet.Identity
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers

--- a/aspnet/tutorials/your-first-aspnet-application/sample/src/WebApplication1/Views/_ViewImports.cshtml
+++ b/aspnet/tutorials/your-first-aspnet-application/sample/src/WebApplication1/Views/_ViewImports.cshtml
@@ -1,4 +1,4 @@
 ﻿@using WebApplication1
 @using WebApplication1.Models
 @using Microsoft.AspNet.Identity
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers

--- a/common/samples/WebApplication1/src/WebApplication1/Views/_ViewImports.cshtml
+++ b/common/samples/WebApplication1/src/WebApplication1/Views/_ViewImports.cshtml
@@ -3,4 +3,4 @@
 @using WebApplication1.ViewModels.Account
 @using WebApplication1.ViewModels.Manage
 @using Microsoft.AspNet.Identity
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers

--- a/mvc/tutorials/mvc-with-entity-framework/sample/src/ContosoBooks/Views/_ViewImports.cshtml
+++ b/mvc/tutorials/mvc-with-entity-framework/sample/src/ContosoBooks/Views/_ViewImports.cshtml
@@ -1,2 +1,2 @@
 ﻿@using ContosoBooks
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers

--- a/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImports.cshtml
+++ b/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImports.cshtml
@@ -1,8 +1,8 @@
 ﻿@using AuthoringTagHelpers
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.EmailTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.WebsiteInformationTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.ConditionTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.AutoLinkerHttpTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.AutoLinkerWwwTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.BoldTagHelper, AuthoringTagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.EmailTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.WebsiteInformationTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.ConditionTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.AutoLinkerHttpTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.AutoLinkerWwwTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.BoldTagHelper, AuthoringTagHelpers

--- a/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImportsCopy.cshtml
+++ b/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImportsCopy.cshtml
@@ -1,3 +1,3 @@
 ﻿@using AuthoringTagHelpers
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
-@addTagHelper "*, AuthoringTagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers
+@addTagHelper *, AuthoringTagHelpers

--- a/mvc/views/tag-helpers/intro.rst
+++ b/mvc/views/tag-helpers/intro.rst
@@ -83,8 +83,8 @@ To add a Tag Helper to a view using an FQN, you first add the FQN (``AuthoringTa
 
 .. code-block:: c#
 
-	@addTagHelper "AuthoringTagHelpers.TagHelpers.E*, AuthoringTagHelpers"
-	@addTagHelper "AuthoringTagHelpers.TagHelpers.Email*, AuthoringTagHelpers"
+	@addTagHelper AuthoringTagHelpers.TagHelpers.E*, AuthoringTagHelpers
+	@addTagHelper AuthoringTagHelpers.TagHelpers.Email*, AuthoringTagHelpers
 
 As mentioned previously, adding the ``@addTagHelper`` directive to the *Views/_ViewImports.cshtml* file makes the Tag Helper available to all view files in the *Views* directory and sub-directories. You can use the ``@addTagHelper`` directive in specific view files if you want to opt-in to exposing the Tag Helper to only those views.
 

--- a/mvc/views/tag-helpers/intro/sample/IntroToTagHelpers/src/IntroToTagHelpers/Views/_ViewImports.cshtml
+++ b/mvc/views/tag-helpers/intro/sample/IntroToTagHelpers/src/IntroToTagHelpers/Views/_ViewImports.cshtml
@@ -3,4 +3,4 @@
 @using IntroToTagHelpers.ViewModels.Account
 @using IntroToTagHelpers.ViewModels.Manage
 @using Microsoft.AspNet.Identity
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers

--- a/mvc/views/tag-helpers/intro/sample/IntroToTagHelpers/src/IntroToTagHelpers/Views/_ViewImportsNoAuth.cshtml
+++ b/mvc/views/tag-helpers/intro/sample/IntroToTagHelpers/src/IntroToTagHelpers/Views/_ViewImportsNoAuth.cshtml
@@ -1,2 +1,2 @@
 ﻿@using IntroToTagHelpers
-@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers


### PR DESCRIPTION
- `TagHelper` directives no longer have quotes.