### PR TITLE
Update "samples on GitHub" link

### DIFF
--- a/aspnet/fundamentals/owin.rst
+++ b/aspnet/fundamentals/owin.rst
@@ -11,7 +11,7 @@ In this article:
 	- `Run ASP.NET 5 on an OWIN-based server and use its WebSockets support`_
 	- `OWIN keys`_
 
-`Browse or download samples on GitHub <https://github.com/aspnet/Docs/tree/master/docs/fundamentals/owin/sample>`_.
+`Browse or download samples on GitHub <https://github.com/aspnet/Docs/tree/master/aspnet/fundamentals/owin/sample>`_.
 
 Running OWIN middleware in the ASP.NET pipeline
 -----------------------------------------------


### PR DESCRIPTION
the current "Browse or download samples on GitHub" shows the GitHub's 404 page