### PR TITLE
Update OS X first app instructions to 1.0.0-beta8

### DIFF
--- a/aspnet/tutorials/your-first-mac-aspnet.rst
+++ b/aspnet/tutorials/your-first-mac-aspnet.rst
@@ -37,7 +37,7 @@ In your solution folder add a global.json file to indicate the DNX version:
 
   {
     "sdk": {
-      "version": "1.0.0-beta7"
+      "version": "1.0.0-beta8"
     }
   }
 
@@ -110,9 +110,9 @@ The sample we're using is configured to use Kestrel as its web server. You can s
     "version": "1.0.0-*",
   
     "dependencies": {
-      "Microsoft.AspNet.Server.IIS": "1.0.0-beta7",
-      "Microsoft.AspNet.Server.WebListener": "1.0.0-beta7",
-      "Microsoft.AspNet.Server.Kestrel": "1.0.0-beta7"
+      "Microsoft.AspNet.Server.IIS": "1.0.0-beta8",
+      "Microsoft.AspNet.Server.WebListener": "1.0.0-beta8",
+      "Microsoft.AspNet.Server.Kestrel": "1.0.0-beta8"
     },
   
     "commands": {


### PR DESCRIPTION
Following installation instructions from [Installing ASP.NET 5 On Mac OS X](https://docs.asp.net/en/latest/getting-started/installing-on-mac.html) installs 1.0.0-beta8. Continuing through to [Your First ASP.NET 5 Application on a Mac](https://docs.asp.net/en/latest/tutorials/your-first-mac-aspnet.html), examples still reference 1.0.0-beta7.