### PR TITLE
Updated docs for asp.net rc

### DIFF
--- a/aspnet/tutorials/your-first-mac-aspnet.rst
+++ b/aspnet/tutorials/your-first-mac-aspnet.rst
@@ -96,8 +96,8 @@ The sample we're using is configured to use Kestrel as its web server. You can s
     "version": "1.0.0-*",
   
     "dependencies": {
-      "Microsoft.AspNet.IISPlatformHandler": "1.0.0-beta8",
-      "Microsoft.AspNet.Server.Kestrel": "1.0.0-beta8"
+      "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc1-final",
+      "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final"
     },
   
     "commands": {


### PR DESCRIPTION
The dnx command should probably be dnx web instead of dnx kestrel because that is what the yo generators create it as.