### PR TITLE
Update tutorial to reflect latest generator-aspnet output

### DIFF
--- a/aspnet/tutorials/your-first-mac-aspnet.rst
+++ b/aspnet/tutorials/your-first-mac-aspnet.rst
@@ -101,12 +101,12 @@ The sample we're using is configured to use Kestrel as its web server. You can s
     },
   
     "commands": {
-      "kestrel": "Microsoft.AspNet.Server.Kestrel"
+      "web": "Microsoft.AspNet.Server.Kestrel"
     },
     // more deleted
   }
 
-Run the ``dnx kestrel`` command to launch the web application locally:
+Run the ``dnx web`` command to launch the web application locally:
 
 .. image:: your-first-mac-aspnet/_static/dnx-kestrel.png
 


### PR DESCRIPTION
I was running through this tutorial and "just following the directions" to evaluate the experience of a Mac developer trying it out for the first time. I noticed that generator-aspnet now sets the command to `web` rather than `kestrel`, so I thought I'd suggest this update.