### PR TITLE
Fix console app not running from generated script

### DIFF
--- a/common/samples/ConsoleApp1/src/ConsoleApp1/project.json
+++ b/common/samples/ConsoleApp1/src/ConsoleApp1/project.json
@@ -14,7 +14,7 @@
   },
 
   "commands": {
-    "ConsoleApp1": "ConsoleApp1"
+    "ConsoleApp1": "run"
   },
 
   "frameworks": {


### PR DESCRIPTION
This fixes:

    Error: Unable to load application or execute command 'ConsoleApp1'. Available commands: ConsoleApp1.

when trying to run ./bin/output/approot/ConsoleApp1 generated by `dnu publish --no-source --framework dnxcore50` on Linux/OS X.