### PR TITLE
Fix typo in Understanding ASP.NET 5 Web Apps

### DIFF
--- a/aspnet/conceptual-overview/understanding-aspnet5-apps.rst
+++ b/aspnet/conceptual-overview/understanding-aspnet5-apps.rst
@@ -210,7 +210,7 @@ Then, update the controller as shown:
 		public IActionResult About()
 		{
 			string appName = _config["ApplicationName"];
-			ViewData["Message"] = "You application name: " + appName;
+			ViewData["Message"] = "Your application name: " + appName;
 
 			return View();
 		}


### PR DESCRIPTION
This PR fixes a small typo in the "Configuring the Application" section of the "Understanding ASP.NET 5 Web Apps" doc. The screenshot provided shows that it should say "Your" instead of "You".