### PR TITLE
Correct line numbers intended to reference service registration with different life cycles

### DIFF
--- a/aspnet/fundamentals/dependency-injection.rst
+++ b/aspnet/fundamentals/dependency-injection.rst
@@ -130,7 +130,7 @@ Next, in ``ConfigureServices``, each type is added to the container according to
 
 .. literalinclude:: dependency-injection/sample/src/DependencyInjectionSample/Startup.cs
   :language: c#
-  :lines: 88-93
+  :lines: 66-71
   :linenos:
   :dedent: 12
 


### PR DESCRIPTION
The articles was incorrectly referencing a portion of Startup.cs from lines 88-91 which was unrelated about development settings. The intention was to show the portion of Startup.cs on lines 66-71 where the services are registered with different life cycles (transient, scoped, singleton, and instance).