### PR TITLE
console app folder name is important

### DIFF
--- a/aspnet/dnx/console.rst
+++ b/aspnet/dnx/console.rst
@@ -28,7 +28,7 @@ Creating a console application is extremely straightforward. For this article, w
 	:linenos:
 	:language: c#
 	
-It really doesn't get any simpler than this. Create a file with these contents and save it as ``Program.cs`` in your current folder.
+It really doesn't get any simpler than this. First create a new folder named `ConsoleApp1` (the name is important, so don't try to use another name). Then, create a file with these contents and save it as `Program.cs` in the `ConsoleApp1` folder.
 
 Specifying Project Settings
 ---------------------------


### PR DESCRIPTION
Make it clear that the name of the console app directory is important. It must match the target of the command in the sample code.