### PR TITLE
Change Angular 2.0 alpha reference to beta

### DIFF
--- a/aspnet/client-side/angular.rst
+++ b/aspnet/client-side/angular.rst
@@ -444,7 +444,7 @@ For more detail on AngularJS built-in event handler directives, be sure to head 
 Angular 2.0
 -----------
 
-Angular 2.0 is the next version of AngularJS, which is completely reimagined with ES6 and mobile in mind. It's built using Microsoft's TypeScript language. Angular 2.0 is currently an alpha-phase product and is expected to be released in early 2016. Several breaking changes will be introduced in the Angular 2.0 release, so the Angular team is working hard to provide guidance to developers. A migration path will become more clear as the release date approaches. If you wish to play with Angular 2.0 now, the Angular team has created `Angular.io <http://angular.io>`_ to show their progress, to provide early documentation, and to gather feedback. 
+Angular 2.0 is the next version of AngularJS, which is completely reimagined with ES6 and mobile in mind. It's built using Microsoft's TypeScript language. Angular 2.0 is currently a beta product and is expected to be released in early 2016. Several breaking changes will be introduced in the Angular 2.0 release, so the Angular team is working hard to provide guidance to developers. A migration path will become more clear as the release date approaches. If you wish to play with Angular 2.0 now, the Angular team has created `Angular.io <http://angular.io>`_ to show their progress, to provide early documentation, and to gather feedback. 
 
 Summary
 -------


### PR DESCRIPTION
Now that Angular 2.0 has been promoted to a beta product, the alpha reference in the doc should be replaced.