### PR TITLE
Rename variable in Getting Started section of Styling Apps doc

### DIFF
--- a/aspnet/client-side/less-sass-fa.rst
+++ b/aspnet/client-side/less-sass-fa.rst
@@ -123,7 +123,7 @@ Now open gulpfile.js. Add a variable at the top to represent less:
 
 	var gulp = require("gulp"),
             rimraf = require("rimraf"),
-            fx = require("fs"),
+            fs = require("fs"),
             less = require("gulp-less");
 
 add another variable to allow you to access project properties:


### PR DESCRIPTION
There's a small typo in a variable name in the "Getting Started" section of the Styling Applications doc. Change the variable name from `fx` to `fs` so that it matches the variable name used in the Sass section's code snippet.