### PR TITLE
Fix typo in CookieAuthentication article

### DIFF
--- a/aspnet/security/authentication/cookie.rst
+++ b/aspnet/security/authentication/cookie.rst
@@ -3,7 +3,7 @@
 Using Cookie Middleware without ASP.NET Identity
 ================================================
 
-ASP.NET v5 provides cookie :ref:`middleware <fundamentals-middleware>` which serializes a user principal into an encrypted cookie and then, on subsequent requests, validates the cookie, recreates the principal and assigns it to the ``User`` property on ``HttpContext``. If you want to provide your on login screens and user databases you can use the cookie middleware as a standalone feature.
+ASP.NET v5 provides cookie :ref:`middleware <fundamentals-middleware>` which serializes a user principal into an encrypted cookie and then, on subsequent requests, validates the cookie, recreates the principal and assigns it to the ``User`` property on ``HttpContext``. If you want to provide your own login screens and user databases you can use the cookie middleware as a standalone feature.
 
 .. _security-authentication-cookie-middleware-configuring:
 


### PR DESCRIPTION
I know it's minor, but this little typo initially threw me for a small loop.

If you want to provide your **on** login screens   => If you want to provide your **own** login screens 