### PR TITLE
Convert hard-coded link to Sphinx relative link

### DIFF
--- a/aspnet/client-side/using-gulp.rst
+++ b/aspnet/client-side/using-gulp.rst
@@ -251,7 +251,7 @@ To switch between compiling for different environments, modify the **ASPNET_ENV*
 
 	Notice that the stylesheet links point to the unminified versions of the CSS files.
 	
-For more information related to Visual Studio 2015 environments, see `Working with Multiple Environments <http://docs.asp.net/en/latest/fundamentals/environments.html>`_.
+For more information related to Visual Studio 2015 environments, see :doc:`Working with Multiple Environments <../fundamentals/environments>`.
 	
 Task and Module Details
 -----------------------


### PR DESCRIPTION
The Gulp doc contains a hard-coded link to the "Working with Multiple Environments" doc in the Fundamentals section. This PR converts the link to a relative Sphinx-style link, making it a bit easier to maintain.