### PR TITLE
Use `IOptions<T>.Value` rather than `Options`

### DIFF
--- a/aspnet/fundamentals/configuration/sample/src/UsingOptions/Controllers/HomeController.cs
+++ b/aspnet/fundamentals/configuration/sample/src/UsingOptions/Controllers/HomeController.cs
@@ -12,7 +12,7 @@ namespace UsingOptions.Controllers
     {
         public HomeController(IOptions<MyOptions> optionsAccessor)
         {
-            Options = optionsAccessor.Options;
+            Options = optionsAccessor.Value;
         }
 
         MyOptions Options { get; }


### PR DESCRIPTION
This sample is shown here: http://docs.asp.net/en/latest/fundamentals/configuration.html#using-options-and-configuration-objects