### PR TITLE
Update mvc-with-entity-framework.rst

### DIFF
--- a/mvc/tutorials/mvc-with-entity-framework.rst
+++ b/mvc/tutorials/mvc-with-entity-framework.rst
@@ -73,7 +73,7 @@ Open the *project.json* file. In the dependencies section, add the following lin
 
   "dependencies": {
     ...
-    "EntityFramework.SqlServer": "7.0.0-rc1-final"
+    "EntityFramework.MicrosoftSqlServer": "7.0.0-rc1-final"
   },
 
 When you save *project.json*, Visual Studio automatically resolves the new package reference.


### PR DESCRIPTION
The package has been renamed from EntityFramework.SqlServer to EntityFramework.MicrosoftSqlServer for side by side execution of EF 6 & 7. Please make this change in the documentation. 