### PR TITLE
Update using-gulp.rst

### DIFF
--- a/aspnet/client-side/using-gulp.rst
+++ b/aspnet/client-side/using-gulp.rst
@@ -157,6 +157,8 @@ If you haven’t already created a new Web app, create a new ASP.NET Web Applica
 	
 It's worth noting that the bindings you set up with **Task Runner Explorer** are **not** stored in the *project.json*.  Rather they are stored in the form of a comment at the top of your *gulpfile.js*.  It is possible (as demonstrated in the default project templates) to have gulp tasks kicked off by the *scripts* section of your *project.json*.  **Task Runner Explorer** is a way you can configure tasks to run using Visual Studio.  If you are using a different editor (for example, Visual Studio Code) then using the *project.json* will probably be the most straightforward way to bring together the various stages (prebuild, build, etc.)  and the running of gulp tasks. 
 
+.. note:: *project.json* stages are not triggered when building in Visual Studio by default.  If you want to ensure that they are set this option in the Visual Studio project properties: Build tab -> Produce outputs on build.  This will add a *ProduceOutputsOnBuild* element to your *.xproj* file which will cause Visual studio to trigger the *project.json* stages when building.
+
 Defining and Running a New Task
 -------------------------------
 

--- a/aspnet/client-side/using-gulp.rst
+++ b/aspnet/client-side/using-gulp.rst
@@ -155,7 +155,7 @@ If you haven’t already created a new Web app, create a new ASP.NET Web Applica
 
 	The **Before Build** binding option allows the clean task to run automatically before each build of the project.
 	
-It's worth noting that the bindings you set up with **Task Runner Explorer** are **not** stored in the *project.json*.  Rather they are stored in the form of a comment at the top of your *gulpfile.js*.  It is possible (as demonstrated in the default project templates) to have gulp tasks kicked off by the *scripts* section of your *project.json*.  **Task Runner Explorer** is a way you can configure tasks to run using Visual Studio.  If you are using Visual Studio Code or something else then using the *project.json* will probably be the most straightforward way to bring together the various stages (eg build) and the running of gulp tasks.
+It's worth noting that the bindings you set up with **Task Runner Explorer** are **not** stored in the *project.json*.  Rather they are stored in the form of a comment at the top of your *gulpfile.js*.  It is possible (as demonstrated in the default project templates) to have gulp tasks kicked off by the *scripts* section of your *project.json*.  **Task Runner Explorer** is a way you can configure tasks to run using Visual Studio.  If you are using a different editor (for example, Visual Studio Code) then using the *project.json* will probably be the most straightforward way to bring together the various stages (prebuild, build, etc.)  and the running of gulp tasks. 
 
 Defining and Running a New Task
 -------------------------------

--- a/aspnet/client-side/using-gulp.rst
+++ b/aspnet/client-side/using-gulp.rst
@@ -154,6 +154,8 @@ If you haven’t already created a new Web app, create a new ASP.NET Web Applica
  	.. image:: using-gulp/_static/05-TaskRunner-BeforeBuild.png 
 
 	The **Before Build** binding option allows the clean task to run automatically before each build of the project.
+	
+It's worth noting that the bindings you set up with **Task Runner Explorer** are **not** stored in the *project.json*.  Rather they are stored in the form of a comment at the top of your *gulpfile.js*.  It is possible (as demonstrated in the default project templates) to have gulp tasks kicked off by the *scripts* section of your *project.json*.  **Task Runner Explorer** is a way you can configure tasks to run using Visual Studio.  If you are using Visual Studio Code or something else then using the *project.json* will probably be the most straightforward way to bring together the various stages (eg build) and the running of gulp tasks.
 
 Defining and Running a New Task
 -------------------------------


### PR DESCRIPTION
Clarified that the Task Runner Explorer was not the only way to kick off gulp tasks when working in ASP.Net 5. When reading the article as was I initially came away with the (false) impression that I couldn't use `project.json` to kick off Gulp tasks.  I thought this was worth highlighting for others that might be confused.