### PR TITLE
Replacing references of hosting.ini with hosting.json

### DIFF
--- a/aspnet/fundamentals/servers.rst
+++ b/aspnet/fundamentals/servers.rst
@@ -131,14 +131,16 @@ Alternately, a configuration file can be referenced, instead:
 
 .. code-block:: javascript
 
-	"kestrel": "Microsoft.AspNet.Hosting --config hosting.ini"
+	"kestrel": "Microsoft.AspNet.Hosting --config hosting.json"
 
-Then, ``hosting.ini`` can include the settings the server will use (including the server parameter, as well):
+Then, ``hosting.json`` can include the settings the server will use (including the server parameter, as well):
 
-.. code-block:: text
-
-	server=Kestrel
-	server.urls=http://localhost:5004
+.. code-block:: json
+	
+	{
+		"server": "Kestrel",
+		"server.urls": "http://localhost:5004"
+	}
 
 Programmatic configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
In RC1, the Microsoft.AspNet.Hosting library has been modified to parse JSON as opposed to INI files.