### PR TITLE
IOptions<T>.Options property is now Value

### DIFF
--- a/aspnet/security/authentication/accconfirm/sample/WebApplication1/src/WebApplication1/Services/MessageServices.cs
+++ b/aspnet/security/authentication/accconfirm/sample/WebApplication1/src/WebApplication1/Services/MessageServices.cs
@@ -13,7 +13,7 @@ namespace WebApplication1.Services
     {
         public AuthMessageSender(IOptions<AuthMessageSenderOptions> optionsAccessor)
         {
-            Options = optionsAccessor.Options;
+            Options = optionsAccessor.Value;
         }
 
         public AuthMessageSenderOptions Options { get; }  // set only via Secret Manager


### PR DESCRIPTION
Options property results in compile error -- looks like it was renamed to Value at some point.