### PR TITLE
Rename aspnet5 to aspnet core 1

### DIFF
--- a/aspnet/index.rst
+++ b/aspnet/index.rst
@@ -5,10 +5,10 @@
 
 .. _index:
 
-ASP.NET 5 Documentation
+ASP.NET Core 1.0 Documentation
 =======================
 
-.. attention:: ASP.NET 5 RC1 is now available! Please see the :doc:`Getting Started <getting-started/index>` instructions for installing the latest version.
+.. attention:: ASP.NET Core 1.0 RC1 is now available! Please see the :doc:`Getting Started <getting-started/index>` instructions for installing the latest version.
 
 .. include:: ../common/stub-overview.txt
 


### PR DESCRIPTION
I just updated the title in the docs to the new  "aspnet core 1.0".

I really like the docs in docs.asp.net. Thanks for all your work! :)