### PR TITLE
Rename aspnet5 to aspnet core

### DIFF
--- a/aspnet/index.rst
+++ b/aspnet/index.rst
@@ -5,8 +5,8 @@
 
 .. _index:
 
-ASP.NET 5 Documentation
-=======================
+ASP.NET Core Documentation
+==========================
 
 .. attention:: ASP.NET 5 RC1 is now available! Please see the :doc:`Getting Started <getting-started/index>` instructions for installing the latest version.
 


### PR DESCRIPTION
I just updated the title in the docs to the new "aspnet core".

+Info: https://github.com/aspnet/Docs/pull/938