### PR TITLE
TagHelpers authoring - SetContent() => SetHtmlContent()

### DIFF
--- a/mvc/views/tag-helpers/authoring.rst
+++ b/mvc/views/tag-helpers/authoring.rst
@@ -176,7 +176,7 @@ The bold Tag Helper
 **Notes:** 
 
 - The ``[TargetElement]`` attribute passes an attribute parameter that specifies that any HTML element that contains an HTML attribute named "bold" will match, and the ``Process`` override method in the class will run. In our sample, the ``Process``  method removes the "bold" attribute and surrounds the containing markup with ``<strong></strong>``.
--  Because we don't want to replace the existing tag content, we must write the opening ``<strong>`` tag with the ``PreContent.SetContent`` method and the closing ``</strong>`` tag with the ``PostContent.SetContent`` method.
+-  Because we don't want to replace the existing tag content, we must write the opening ``<strong>`` tag with the ``PreContent.SetHtmlContent`` method and the closing ``</strong>`` tag with the ``PostContent.SetHtmlContent`` method.
 
 2. Modify the *About.cshtml* view to contain a ``bold`` attribute value. The completed code is shown below.
 

--- a/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/BoldTagHelper.cs
+++ b/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/BoldTagHelper.cs
@@ -8,8 +8,8 @@ namespace AuthoringTagHelpers.TagHelpers
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
             output.Attributes.RemoveAll("bold");
-            output.PreContent.SetContent("<strong>");
-            output.PostContent.SetContent("</strong>");
+            output.PreContent.SetHtmlContent("<strong>");
+            output.PostContent.SetHtmlContent("</strong>");
         }
     }
 }

--- a/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/WebsiteInformationTagHelper.cs
+++ b/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/WebsiteInformationTagHelper.cs
@@ -11,7 +11,7 @@ namespace AuthoringTagHelpers.TagHelpers
       public override void Process(TagHelperContext context, TagHelperOutput output)
       {
          output.TagName = "section";
-         output.Content.SetContent(
+         output.Content.SetHtmlContent(
 $@"<ul><li><strong>Version:</strong> {Info.Version}</li>
 <li><strong>Copyright Year:</strong> {Info.CopyrightYear}</li>
 <li><strong>Approved:</strong> {Info.Approved}</li>

--- a/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/z1AutoLinker.cs
+++ b/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/z1AutoLinker.cs
@@ -11,7 +11,7 @@ namespace AuthoringTagHelpers.TagHelpers2
         {
             var childContent = await context.GetChildContentAsync();
             // Find Urls in the content and replace them with their anchor tag equivalent.
-            output.Content.SetContent(Regex.Replace(
+            output.Content.SetHtmlContent(Regex.Replace(
                  childContent.GetContent(),
                  @"\b(?:https?://)(\S+)\b",
                   "<a target=\"_blank\" href=\"$0\">$0</a>"));  // http link version}
@@ -25,7 +25,7 @@ namespace AuthoringTagHelpers.TagHelpers2
         {
             var childContent = await context.GetChildContentAsync();
             // Find Urls in the content and replace them with their anchor tag equivalent.
-            output.Content.SetContent(Regex.Replace(
+            output.Content.SetHtmlContent(Regex.Replace(
                 childContent.GetContent(),
                  @"\b(www\.)(\S+)\b",
                  "<a target=\"_blank\" href=\"http://$0\">$0</a>"));  // www version

--- a/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/z1AutoLinkerCopy.cs
+++ b/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/z1AutoLinkerCopy.cs
@@ -13,7 +13,7 @@ namespace AuthoringTagHelpers.TagHe1pers
                 (await context.GetChildContentAsync()).GetContent();
 
             // Find Urls in the content and replace them with their anchor tag equivalent.
-            output.Content.SetContent(Regex.Replace(
+            output.Content.SetHtmlContent(Regex.Replace(
                  childContent,
                  @"\b(?:https?://)(\S+)\b",
                   "<a target=\"_blank\" href=\"$0\">$0</a>"));  // http link version}
@@ -29,7 +29,7 @@ namespace AuthoringTagHelpers.TagHe1pers
                 (await context.GetChildContentAsync()).GetContent();
   
             // Find Urls in the content and replace them with their anchor tag equivalent.
-            output.Content.SetContent(Regex.Replace(
+            output.Content.SetHtmlContent(Regex.Replace(
                  childContent,
                  @"\b(www\.)(\S+)\b",
                  "<a target=\"_blank\" href=\"http://$0\">$0</a>"));  // www version

--- a/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/z2AutoLinkerCopy.cs
+++ b/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/z2AutoLinkerCopy.cs
@@ -19,7 +19,7 @@ namespace AuthoringTagHelpers.TagHelpers
                 (await context.GetChildContentAsync()).GetContent();
 
             // Find Urls in the content and replace them with their anchor tag equivalent.
-            output.Content.SetContent(Regex.Replace(
+            output.Content.SetHtmlContent(Regex.Replace(
                  childContent,
                  @"\b(?:https?://)(\S+)\b",
                   "<a target=\"_blank\" href=\"$0\">$0</a>"));  // http link version}
@@ -35,7 +35,7 @@ namespace AuthoringTagHelpers.TagHelpers
                 (await context.GetChildContentAsync()).GetContent();
   
             // Find Urls in the content and replace them with their anchor tag equivalent.
-            output.Content.SetContent(Regex.Replace(
+            output.Content.SetHtmlContent(Regex.Replace(
                  childContent,
                  @"\b(www\.)(\S+)\b",
                  "<a target=\"_blank\" href=\"http://$0\">$0</a>"));  // www version

--- a/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/zBoldTagHelperCopy.cs
+++ b/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/zBoldTagHelperCopy.cs
@@ -9,8 +9,8 @@ namespace AuthoringTagHelpers.TagHelpers3
       public override void Process(TagHelperContext context, TagHelperOutput output)
       {
          output.Attributes.RemoveAll("bold");
-         output.PreContent.SetContent("<strong>");
-         output.PostContent.SetContent("</strong>");
+         output.PreContent.SetHtmlContent("<strong>");
+         output.PostContent.SetHtmlContent("</strong>");
       }
    }
 }


### PR DESCRIPTION
to prevent unwanted encoding of HTML elements