### PR TITLE
Added note to not change the authentication method when creating project

### DIFF
--- a/aspnet/tutorials/your-first-aspnet-application.rst
+++ b/aspnet/tutorials/your-first-aspnet-application.rst
@@ -207,7 +207,7 @@ After the above line has been added, the completed *Startup.cs* file will appear
     :language: c#
     :emphasize-lines: 101
 
-Notice in *ConfigureServices* the app calls ``Configuration.Get`` to get the database connection string. During development, this setting comes from the *appsettings.json* file. When you deploy the app to a production environment, you set the connection string in an environment variable on the host. If the Configuration API finds an environment variable with the same key, it returns the environment variable instead of the value that is in *appsettings.json*.
+Notice in *ConfigureServices* the app calls ``Configuration["Data:DefaultConnection:ConnectionString"]`` to get the database connection string. During development, this setting comes from the *appsettings.json* file. When you deploy the app to a production environment, you set the connection string in an environment variable on the host. If the Configuration API finds an environment variable with the same key, it returns the environment variable instead of the value that is in *appsettings.json*.
 	
 Build the web application
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/aspnet/tutorials/your-first-aspnet-application.rst
+++ b/aspnet/tutorials/your-first-aspnet-application.rst
@@ -28,6 +28,8 @@ In the **New ASP.NET Project** dialog, select **Web Application** under **ASP.NE
 
 .. image:: your-first-aspnet-application/_static/03-web-site-template.png
 
+.. note:: Do not change the authentication method. Leave it as the default **Individual User Accounts** for this tutorial. 
+
 Running the default app
 ^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
I had changed the authentication method and then had to recreate the tutorial when I saw the note later on about how I should've created it with Individual User Accounts. Adding this note at the time of creation to stop people like me from messing with it and having to start over.