### PR TITLE
Fix a typo in "Limiting identity by scheme" page

### DIFF
--- a/aspnet/security/authorization/limitingidentitybyscheme.rst
+++ b/aspnet/security/authorization/limitingidentitybyscheme.rst
@@ -58,7 +58,7 @@ If you prefer to specify the desired schemes in :ref:`policy <security-authoriza
  {
      policy.AuthenticationSchemes.Add("Bearer");
      policy.RequireAuthenticatedUser();
-     policy => policy.Requirements.Add(new Over18Requirement());
+     policy.Requirements.Add(new Over18Requirement());
  });
 
 In this example the Over18 policy will only run against the identity created by the Bearer middleware.


### PR DESCRIPTION
Probably a typo from copy and pasting from other example. We are already in the context of the lambda.