### PR TITLE
Corrected abbreviation of Ctrl

### DIFF
--- a/aspnet/tutorials/first-mvc-app/start-mvc.rst
+++ b/aspnet/tutorials/first-mvc-app/start-mvc.rst
@@ -48,7 +48,7 @@ Tap **F5** to run the app in debug mode or **Ctl-F5** in non-debug mode.
 .. image:: start-mvc/_static/1.png
 
 - Visual Studio starts `IIS Express <http://www.iis.net/learn/extensions/introduction-to-iis-express/iis-express-overview>`__ and runs your app. Notice that the address bar shows ``localhost:port#`` and not something like ``example.com``. That's because ``localhost`` always points to your own local computer, which in this case is running the app you just created. When Visual Studio creates a web project, a random port is used for the web server. In the image above, the port number is 1234. When you run the app, you'll see a different port number.
-- Launching the app with **Ctl-F5** (non-debug mode) allows you to make code changes, save the file, refresh the browser, and see the code changes. Many developers prefer to use non-debug mode to quickly launch the app and view changes.
+- Launching the app with **Ctrl+F5** (non-debug mode) allows you to make code changes, save the file, refresh the browser, and see the code changes. Many developers prefer to use non-debug mode to quickly launch the app and view changes.
 - You can launch the app in debug or non-debug mode from the **Debug** menu item:
 
 .. image:: start-mvc/_static/debug_menu.png


### PR DESCRIPTION
Changes make the spelling of Ctrl and use of plus-sign consistent with the Debug menu in Visual Studio, as shown in the screenshot.