### PR TITLE
Sudo should be use only when necessary

### DIFF
--- a/aspnet/getting-started/installing-on-linux.rst
+++ b/aspnet/getting-started/installing-on-linux.rst
@@ -74,13 +74,14 @@ To build libuv you should do the following::
 
     sudo apt-get install make automake libtool curl
     curl -sSL https://github.com/libuv/libuv/archive/v1.8.0.tar.gz | sudo tar zxfv - -C /usr/local/src
+    chown -R $USER /usr/local/src/libuv-1.8.0
     cd /usr/local/src/libuv-1.8.0
-    sudo sh autogen.sh
-    sudo ./configure
-    sudo make 
+    sh autogen.sh
+    ./configure
+    make 
     sudo make install
-    sudo rm -rf /usr/local/src/libuv-1.8.0 && cd ~/
     sudo ldconfig
+    cd - && sudo rm -rf /usr/local/src/libuv-1.8.0
 
 .. note::
 


### PR DESCRIPTION
sudo usage here should be used only for make install, ldconfig and cleanup up.
If build dir ownership is given to user, all other steps doesn't require privilege elevation except for  deploy and cleaning up.
(possibility to use /tmp to avoid sudo tar and chown but not used here due to possible noexec flag on /tmp mount)