### PR TITLE
Update roles.rst

### DIFF
--- a/aspnet/security/authorization/roles.rst
+++ b/aspnet/security/authorization/roles.rst
@@ -23,7 +23,7 @@ You can specify multiple roles as a comma separated list;
 
 .. code-block:: c#
 
-  [Authorize(Roles = "HRManager, Finance")]
+  [Authorize(Roles = "HRManager,Finance")]
   public class SalaryController : Controller
   {  
   }


### PR DESCRIPTION
https://github.com/aspnet/Mvc/blob/51d47c7be18ff55a1d9acca63f1a381f144f0d13/src/Microsoft.AspNet.Mvc.Core/Filters/AuthorizeAttribute.cs#L38

Input is not being trimmed (remove spaces), so if you follow the documentation, the second role will never be able to access the method.