### PR TITLE
Updating link to Entity Framework core to point to correct URL

### DIFF
--- a/aspnet/data/index.rst
+++ b/aspnet/data/index.rst
@@ -5,7 +5,7 @@ Working with Data
   :titlesonly:
 
   entity-framework-6
-  Getting Started With ASP.NET Core and Entity Framework Core <http://docs.efproject.net/en/latest/platforms/aspnetcore/getting-started.html>
+  Getting Started With ASP.NET Core and Entity Framework Core <http://docs.efproject.net/en/latest/platforms/aspnetcore/index.html>
   azure-storage/index
 
 


### PR DESCRIPTION
The Working with Data page has a topic for working with Entity Framework core that currently results in a 404. 

This PR Fixes #1239  