### PR TITLE
Correct the example to access a setting

### DIFF
--- a/aspnet/fundamentals/configuration.rst
+++ b/aspnet/fundamentals/configuration.rst
@@ -44,7 +44,7 @@ It's not unusual to store configuration values in a hierarchical structure, espe
   :linenos:
   :language: json
 
-The application uses configuration to configure the right connection string. Access to the ``ConnectionString`` setting is achieved through this key: ``Data:DefaultConnection:ConnectionString``.
+The application uses configuration to configure the right connection string. Access to the ``DefaultConnection`` setting is achieved through this key: ``ConnectionStrings:DefaultConnection``.
 
 The settings required by your application and the mechanism used to specify those settings (configuration being one example) can be decoupled using the :ref:`options pattern <options-config-objects>`. To use the options pattern you create your own settings class (probably several different classes, corresponding to different cohesive groups of settings) that you can inject into your application using an options service. You can then specify your settings using configuration or whatever mechanism you choose.
 


### PR DESCRIPTION
The key "Data:DefaultConnection:ConnectionString" does not exists in the reference appsettings.json.