### PR TITLE
Fixed typo for a Note.

### DIFF
--- a/aspnet/contribute/style-guide.rst
+++ b/aspnet/contribute/style-guide.rst
@@ -62,7 +62,7 @@ Surround text with:
 - Two asterisks for \**strong emphasis\** (**bold**)
 - Two backticks for \``code samples``\ (an ``<html>`` element)
 
-..note:: Inline markup cannot be nested, nor can surrounded content start or end with whitespace (``* foo*`` is wrong).
+.. note:: Inline markup cannot be nested, nor can surrounded content start or end with whitespace (``* foo*`` is wrong).
 
 Escaping is done using the ``\`` backslash.
 


### PR DESCRIPTION
`..note::` -> `.. note::`

The following note doesn't render correctly due to missed space between double dots and note keyword.

"Inline markup cannot be nested, nor can surrounded content start or end with whitespace (`* foo*` is wrong)."