### PR TITLE
set gcServer to true

### DIFF
--- a/aspnet/migration/rc1-to-rc2.rst
+++ b/aspnet/migration/rc1-to-rc2.rst
@@ -45,7 +45,7 @@ Additionally, you must turn on server garbage collection in ``project.json`` or,
 
   {
     "runtimeOptions": {
-      "gcServer": false,
+      "gcServer": true,
       "gcConcurrent": true
     }
   }  


### PR DESCRIPTION
example says "you must turn on server garbage collection" but sample config gives: `gcServer: false` which I believe needs to be other way around.