### PR TITLE
Update accconfirm.rst

### DIFF
--- a/aspnet/security/authentication/accconfirm.rst
+++ b/aspnet/security/authentication/accconfirm.rst
@@ -110,6 +110,8 @@ Add ``AuthMessageSenderOptions`` to the service container at the end of the ``Co
    :emphasize-lines: 4
    :dedent: 8
 
+.. note:: You may need to add the dependency 'Microsoft.Extensions.Options.ConfigurationExtensions' in the project.json file in order to use the configure extension method.
+
 .. ToDo figure out bolding in next line
 
 Configure the ``AuthMessageSender`` class

--- a/aspnet/security/authentication/accconfirm.rst
+++ b/aspnet/security/authentication/accconfirm.rst
@@ -101,6 +101,7 @@ At this time, the contents of the *project.json* file are not encrypted. The *pr
 
 Configure startup to use ``AuthMessageSenderOptions``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Add the dependecy ``Microsoft.Extensions.Options.ConfigurationExtensions`` in the project.json file.
 
 Add ``AuthMessageSenderOptions`` to the service container at the end of the ``ConfigureServices`` method in the *Startup.cs* file:
 
@@ -109,8 +110,6 @@ Add ``AuthMessageSenderOptions`` to the service container at the end of the ``Co
    :lines: 81-85
    :emphasize-lines: 4
    :dedent: 8
-
-.. note:: You may need to add the dependency 'Microsoft.Extensions.Options.ConfigurationExtensions' in the project.json file in order to use the configure extension method.
 
 .. ToDo figure out bolding in next line
 


### PR DESCRIPTION
The RC2 web app template does not include the dependency 'Microsoft.Extensions.Options.ConfigurationExtensions' which is required to use the configure extension method needed for this tutorial.