### PR TITLE
Include the package the Configure<T>(IConfiguration) extension method…

### DIFF
--- a/aspnet/fundamentals/configuration.rst
+++ b/aspnet/fundamentals/configuration.rst
@@ -135,7 +135,7 @@ You configure options using the ``Configure<TOption>`` extension method. You can
   :language: c#
   :lines: 26-42
   :dedent: 8
-  :emphasize-lines: 7,10-13
+  :emphasize-lines: 7-10,13
 
 When you bind options to configuration each property in your options type is bound to a configuration key of the form ``property:subproperty:...``. For example, the ``MyOptions.Option1`` property is bound to the key ``Option1``, which is read from the ``option1`` property in *appsettings.json*. Note that configuration keys are case insensitive.
 

--- a/aspnet/fundamentals/configuration/sample/src/UsingOptions/Startup.cs
+++ b/aspnet/fundamentals/configuration/sample/src/UsingOptions/Startup.cs
@@ -28,14 +28,14 @@ namespace UsingOptions
             // Setup options with DI
             services.AddOptions();
 
-            // Configure MyOptions using config
-            services.Configure<MyOptions>(Configuration);
-
             // Configure MyOptions using code
             services.Configure<MyOptions>(myOptions =>
             {
                 myOptions.Option1 = "value1_from_action";
             });
+
+            // Configure MyOptions using config by installing Microsoft.Extensions.Options.ConfigurationExtensions
+            services.Configure<MyOptions>(Configuration);
 
             // Add framework services.
             services.AddMvc();


### PR DESCRIPTION
… comes from in the sample comment

This will make it easier for people migrating to RC2 or reading the docs around configuration to know they need to install an additional package to make the code sample work without checking out the references in the source sample project.