### PR TITLE
Fix typos under External Login Providers

### DIFF
--- a/aspnet/security/authentication/sociallogins.rst
+++ b/aspnet/security/authentication/sociallogins.rst
@@ -138,7 +138,7 @@ You are now logged in using your Facebook credentials.
 Optionally set password
 -----------------------
 
-When you register with an external login providers you do not have a password registered with the app. The aleviates you from creating and remembering a password for the site, but it also makes you dependant on the external loging provider. If the external login provider is unavailable, you won't be able to log into to the web site.
+When you register with an external login provider, you do not have a password registered with the app. This alleviates you from creating and remembering a password for the site, but it also makes you dependent on the external login provider. If the external login provider is unavailable, you won't be able to log in to the web site.
 
 To create a password and login using your email that you set during the login process with external providers:
 


### PR DESCRIPTION
- Remove trailing 'g' from "loging"
- Change "aleviates" to "alleviates"
- Change "dependant" to "dependent"
- Change "log into to the" to "log in to the"