### PR TITLE
updates to authz articles

### DIFF
--- a/aspnet/security/authorization/claims.rst
+++ b/aspnet/security/authorization/claims.rst
@@ -3,9 +3,9 @@
 Claims-Based Authorization
 ==========================
 
-When an identity is created it may be assigned one or more claims issued by a trusted party. A claim is key value pair, the key being the claim name and the value being the claim value. A claim is what the subject is, not what the subject can do. For example you may have a Drivers License, issued by a local driving license authority. Your driver's license has your date of birth on it. In this case the claim name would be DateOfBirth, the claim value would be your date of birth, for example 8th June 1970 and the issuer would be the driving license authority. Claims based authorization, at its simplest, checks the value of a claim and allows access to a resource based upon that value. For example if you want access to a night club the authorization process might be:
+When an identity is created it may be assigned one or more claims issued by a trusted party. A claim is key value pair, the key being the claim name and the value being the claim value. A claim is what the subject is, not what the subject can do. For example you may have a Drivers License, issued by a local driving license authority. Your driver's license has your date of birth on it. In this case the claim name would be ``DateOfBirth``, the claim value would be your date of birth, for example ``8th June 1970`` and the issuer would be the driving license authority. Claims based authorization, at its simplest, checks the value of a claim and allows access to a resource based upon that value. For example if you want access to a night club the authorization process might be:
 
-The door security officer would evaluate the value of your date of birth  claim and whether they trust the issuer (the driving license authority) before granting you access.
+The door security officer would evaluate the value of your date of birth claim and whether they trust the issuer (the driving license authority) before granting you access.
 
 An identity can contain multiple claims with multiple values and can contain multiple claims of the same type.
 
@@ -30,9 +30,9 @@ First you need to build and register the policy. This takes place as part of the
      });
  }
 
-In this case the EmployeeOnly policy checks for the presence of an EmployeeNumber claim on the current identity.
+In this case the ``EmployeeOnly`` policy checks for the presence of an ``EmployeeNumber`` claim on the current identity.
 
-You then apply the policy using the ``Policy`` parameter on the ``Authorize`` attribute to specify the policy name;
+You then apply the policy using the :dn:prop:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute.Policy` property on the :dn:class:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute` attribute to specify the policy name;
 
 .. code-block:: c#
 
@@ -42,7 +42,7 @@ You then apply the policy using the ``Policy`` parameter on the ``Authorize`` at
      return View();
  }
 
-The ``Authorize`` attribute can be applied to an entire controller, in this instance only identities matching the policy will be allowed access to any Action on the controller.
+The :dn:class:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute` attribute can be applied to an entire controller, in this instance only identities matching the policy will be allowed access to any Action on the controller.
 
 .. code-block:: c#
 
@@ -54,7 +54,7 @@ The ``Authorize`` attribute can be applied to an entire controller, in this inst
       }
   }
 
-If you have a controller that is protected by the ``Authorize`` attribute, but want to allow anonymous access to particular actions you apply the ``AllowAnonymous`` attribute;
+If you have a controller that is protected by the :dn:class:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute` attribute, but want to allow anonymous access to particular actions you apply the :dn:class:`~Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute` attribute;
 
 .. code-block:: c#
 
@@ -106,6 +106,6 @@ If you apply multiple policies to a controller or action then all policies must 
       }
   }
 
-In the above example any identity which fulfills the EmployeeOnly policy can access the Payslip action as that policy is enforced on the controller. However in order to call the UpdateSalary action the identity must fulfill *both* the EmployeeOnly policy and the HumanResources policy.
+In the above example any identity which fulfills the ``EmployeeOnly`` policy can access the ``Payslip`` action as that policy is enforced on the controller. However in order to call the ``UpdateSalary`` action the identity must fulfill *both* the ``EmployeeOnly`` policy and the ``HumanResources`` policy.
 
 If you want more complicated policies, such as taking a date of birth claim, calculating an age from it then checking the age is 21 or older then you need to write :ref:`custom policy handlers <security-authorization-policies-based>`.

--- a/aspnet/security/authorization/dependencyinjection.rst
+++ b/aspnet/security/authorization/dependencyinjection.rst
@@ -5,7 +5,7 @@ Dependency Injection in Requirement Handlers
 
 As :ref:`handlers must be registered <security-authorization-policies-based-handler-registration>` in the service collection they support :ref:`dependency injection <fundamentals-dependency-injection>`. If, for example, you had a repository of rules you want to evaluate inside a handler and that repository is registered in the service collection authorization will resolve and inject that into your constructor.
 
-For example, if you wanted to use ASP.NET's logging infrastructure you would to inject ``ILoggerFactory`` into your handler. Such a handler might look like this;
+For example, if you wanted to use ASP.NET's logging infrastructure you would to inject :dn:iface:`~Microsoft.Extensions.Logging.ILoggerFactory` into your handler. Such a handler might look like this;
 
 .. code-block:: c#
 
@@ -18,7 +18,7 @@ For example, if you wanted to use ASP.NET's logging infrastructure you would to 
          _logger = loggerFactory.CreateLogger(this.GetType().FullName);
      }
 
-     protected override void Handle(AuthorizationContext context, MyRequirement requirement)
+     protected override void Handle(AuthorizationHandlerContext context, MyRequirement requirement)
      {
         _logger.LogInformation("Inside my handler");
         // Check if the requirement is fulfilled.
@@ -31,4 +31,4 @@ Then you register handlers with ``services.AddSingleton()``, for example
 
  services.AddSingleton<IAuthorizationHandler, LoggingAuthorizationHandler>();
 
-An instance of the handler will be created when your application starts, and DI will inject the registered ILoggerFactory into your constructor.
+An instance of the handler will be created when your application starts, and DI will inject the registered :dn:iface:`~Microsoft.Extensions.Logging.ILoggerFactory` into your constructor.

--- a/aspnet/security/authorization/introduction.rst
+++ b/aspnet/security/authorization/introduction.rst
@@ -15,4 +15,4 @@ In ASP.NET Core authorization now provides simple declarative :ref:`role <securi
 Namespaces
 ----------
 
-The authorization attribute is part of the MVC namespace, specifically you must add  ``using Microsoft.AspNetCore.Authorization;``
+Authorization components, including the :dn:class:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute` and :dn:class:`~Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute` attributes are found in the :dn:namespace:`Microsoft.AspNetCore.Authorization` namespace.

--- a/aspnet/security/authorization/limitingidentitybyscheme.rst
+++ b/aspnet/security/authorization/limitingidentitybyscheme.rst
@@ -31,8 +31,7 @@ In this configuration two authentication middlewares have been added, one for co
 Selecting the scheme with the Authorize attribute
 -------------------------------------------------
 
-As no authentication middleware is configured to automatically run and create an identity you must, at the point of authorization choose which middleware will be used. The simplest way to select the middleware you wish to authorize wish is to use the :dn:prop:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute.AuthenticationSchemes` property. This property accepts a comma delimited list of Authentication Schemes to use. For example;
-
+As no authentication middleware is configured to automatically run and create an identity you must, at the point of authorization choose which middleware will be used. The simplest way to select the middleware you wish to authorize wish is to use the :dn:prop:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute.ActiveAuthenticationSchemes` property. This property accepts a comma delimited list of Authentication Schemes to use. For example;
 .. code-block:: c#
 
  [Authorize(ActiveAuthenticationSchemes = "Cookie,Bearer")]

--- a/aspnet/security/authorization/limitingidentitybyscheme.rst
+++ b/aspnet/security/authorization/limitingidentitybyscheme.rst
@@ -3,9 +3,9 @@
 Limiting identity by scheme
 ===========================
 
-In some scenarios, such as Single Page Applications it is possible to end up with multiple authentication methods, cookie authentication to log in and bearer authentication for javascript request. In some cases you may have multiple instances of an authentication middleware, for example, two cookie middlewares where one contains a basic identity and one is created when a multi-factor authentication has triggered because the user requested an operation that requires extra security.
+In some scenarios, such as Single Page Applications it is possible to end up with multiple authentication methods. For example, your application may use cookie-based authentication to log in and bearer authentication for JavaScript requests. In some cases you may have multiple instances of an authentication middleware. For example, two cookie middlewares where one contains a basic identity and one is created when a multi-factor authentication has triggered because the user requested an operation that requires extra security.
 
-Authentication schemes are named when authentication middleware is configured during authentication, for example 
+Authentication schemes are named when authentication middleware is configured during authentication, for example
 
 .. code-block:: c#
 
@@ -31,25 +31,25 @@ In this configuration two authentication middlewares have been added, one for co
 Selecting the scheme with the Authorize attribute
 -------------------------------------------------
 
-As no authentication middleware is configured to automatically run and create an identity you must, at the point of authorization choose which middleware will be used. The simplest way to select the middleware you wish to authorize wish is to use the ``AuthenticationSchemes`` parameter. This parameter accepts a comma delimited list of Authentication Schemes to use. For example;
+As no authentication middleware is configured to automatically run and create an identity you must, at the point of authorization choose which middleware will be used. The simplest way to select the middleware you wish to authorize wish is to use the :dn:prop:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute.AuthenticationSchemes` property. This property accepts a comma delimited list of Authentication Schemes to use. For example;
 
 .. code-block:: c#
 
- [Authorize(AuthenticationSchemes = "Cookie,Bearer")]
+ [Authorize(ActiveAuthenticationSchemes = "Cookie,Bearer")]
  public class MixedController : Controller
 
 In the example above both the cookie and bearer middlewares will run and have a chance to create and append an identity for the current user. By specifying a single scheme only the specified middleware will run;
 
 .. code-block:: c#
 
-    [Authorize(AuthenticationSchemes = "Bearer")]
+    [Authorize(ActiveAuthenticationSchemes = "Bearer")]
 
 In this case only the middleware with the Bearer scheme would run, and any cookie based identities would be ignored.
 
 Selecting the scheme with policies
 ----------------------------------
 
-If you prefer to specify the desired schemes in :ref:`policy <security-authorization-policies-based>` you can set the ``AuthenticationSchemes`` collection when adding your policy. 
+If you prefer to specify the desired schemes in :ref:`policy <security-authorization-policies-based>` you can set the :dn:prop:`~Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder.AuthenticationSchemes` collection when adding your policy.
 
 
 .. code-block:: c#
@@ -61,4 +61,4 @@ If you prefer to specify the desired schemes in :ref:`policy <security-authoriza
      policy.Requirements.Add(new Over18Requirement());
  });
 
-In this example the Over18 policy will only run against the identity created by the Bearer middleware.
+In this example the Over18 policy will only run against the identity created by the ``Bearer`` middleware.

--- a/aspnet/security/authorization/policies.rst
+++ b/aspnet/security/authorization/policies.rst
@@ -24,7 +24,8 @@ An authorization policy is made up of one or more requirements and registered at
 
 Here you can see an "Over21" policy is created with a single requirement, that of a minimum age, which is passed as a parameter to the requirement.
 
-Policies are applied using the ``Authorize`` attribute simply by specifying the policy name, for example
+Policies are applied using the :dn:class:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute` attribute simply by specifying the policy name, for example
+
 
 .. code-block:: c#
 
@@ -42,7 +43,7 @@ Policies are applied using the ``Authorize`` attribute simply by specifying the 
 
 Requirements
 ------------
-An authorization requirement is a collection of data parameters that a policy can use to evaluate the current user principal. In our Minimum Age policy the requirement we have a single parameter, the minimum age. A requirement must implement ``IAuthorizationRequirement``. This is an empty, marker interface. A parameterized minimum age requirement might be implemented as follows;
+An authorization requirement is a collection of data parameters that a policy can use to evaluate the current user principal. In our Minimum Age policy the requirement we have a single parameter, the minimum age. A requirement must implement :dn:iface:`~Microsoft.AspNetCore.Authorization.IAuthorizationRequirement`. This is an empty, marker interface. A parameterized minimum age requirement might be implemented as follows;
 
 .. code-block:: c#
 
@@ -63,7 +64,7 @@ A requirement doesn't need to have data or properties.
 Authorization Handlers
 ----------------------
 
-An authorization handler is responsible for the evaluation of any properties of a requirement. The  authorization handler must evaluate them against a provided ``AuthorizationContext`` to decide if authorization is allowed. A requirement can have :ref:`multiple handlers <security-authorization-policies-based-multiple-handlers>`. Handlers must inherit ``AuthorizationHandler<T>`` where T is the requirement it handles. 
+An authorization handler is responsible for the evaluation of any properties of a requirement. The  authorization handler must evaluate them against a provided :dn:class:`~Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext` to decide if authorization is allowed. A requirement can have :ref:`multiple handlers <security-authorization-policies-based-multiple-handlers>`. Handlers must inherit :dn:class:`~Microsoft.AspNetCore.Authorization.AuthorizationHandler<TRequirement>` where ``TRequirement`` is the requirement it handles. 
 
 .. _security-authorization-handler-example:
 
@@ -73,7 +74,7 @@ The minimum age handler might look like this:
 
  public class MinimumAgeHandler : AuthorizationHandler<MinimumAgeRequirement>
  {
-     protected override void Handle(AuthorizationContext context, MinimumAgeRequirement requirement)
+     protected override void Handle(AuthorizationHandlerContext context, MinimumAgeRequirement requirement)
      {
          if (!context.User.HasClaim(c => c.Type == ClaimTypes.DateOfBirth && 
                                     c.Issuer == "http://contoso.com"))
@@ -97,7 +98,7 @@ The minimum age handler might look like this:
      }
  }
 
-In the code above we first look to see if the current user principal has a date of birth claim which has been issued by an Issuer we know and trust. If the claim is missing we can't authorize so we return. If we have a claim, we figure out how old the user is, and if they meet the minimum age passed in by the requirement then authorization has been successful. Once authorization is successful we call ``context.Succeed()`` passing in the requirement that has been successful as a parameter.
+In the code above we first look to see if the current user principal has a date of birth claim which has been issued by an Issuer we know and trust. If the claim is missing we can't authorize so we return. If we have a claim, we figure out how old the user is, and if they meet the minimum age passed in by the requirement then authorization has been successful. Once authorization is successful we call :dn:method:`~Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext.Succeed` on the provided context, passing in the requirement that has been successful as a parameter.
 
 .. _security-authorization-policies-based-handler-registration:
 
@@ -118,18 +119,18 @@ Handlers must be registered in the services collection during configuration, for
      services.AddSingleton<IAuthorizationHandler, MinimumAgeHandler>();
  }
 
-Each handler is added to the services collection by using ``services.AddSingleton<IAuthorizationHandler, YourHandlerClass>();`` passing in your handler class.
+Each handler is added to the services collection by using ``services.AddSingleton<IAuthorizationHandler, YourHandlerClass>();``, replacing ``YourHandlerClass`` with the name of your authorization handler.
 
 What should a handler return?
 -----------------------------
 
 You can see in our :ref:`handler example <security-authorization-handler-example>` that the ``Handle()`` method has no return value, so how do we indicate success or failure?
 
-* A handler indicates success by calling ``context.Succeed(IAuthorizationRequirement requirement)``, passing the requirement that has been successfully validated.
+* A handler indicates success by calling :dn:method:`~Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext.Succeed` on the provided context, passing the requirement that has been successfully validated.
 * A handler does not need to handle failures generally, as other handlers for the same requirement may succeed.
-* To guarantee failure even if other handlers for a requirement succeed, call ``context.Fail``. 
+* To guarantee failure even if other handlers for a requirement succeed, call :dn:method:`~Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext.Fail` on the provided context.
  
-Regardless of what you call inside your handler all handlers for a requirement will be called when a policy requires the requirement. This allows requirements to have side effects, such as logging, which will always take place even if ``context.Fail()`` has been called in another handler.
+Regardless of what you call inside your handler all handlers for a requirement will be called when a policy requires the requirement. This allows requirements to have side effects, such as logging, which will always take place even if :dn:method:`~Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext.Fail` has been called in another handler.
 
 .. _security-authorization-policies-based-multiple-handlers:
 
@@ -146,7 +147,7 @@ In cases where you want evaluation to be on an **OR** basis you implement multip
 
  public class BadgeEntryHandler : AuthorizationHandler<EnterBuildingRequirement>
  {
-     protected override void Handle(AuthorizationContext context, EnterBuildingRequirement requirement)
+     protected override void Handle(AuthorizationHandlerContext context, EnterBuildingRequirement requirement)
      {
          if (context.User.HasClaim(c => c.Type == ClaimTypes.BadgeId && 
                                         c.Issuer == "http://microsoftsecurity"))
@@ -158,7 +159,7 @@ In cases where you want evaluation to be on an **OR** basis you implement multip
 
  public class HasTemporaryStickerHandler : AuthorizationHandler<EnterBuildingRequirement>
  {
-     protected override void Handle(AuthorizationContext context, EnterBuildingRequirement requirement)
+     protected override void Handle(AuthorizationHandlerContext context, EnterBuildingRequirement requirement)
      {
          if (context.User.HasClaim(c => c.Type == ClaimTypes.TemporaryBadgeId && 
                                         c.Issuer == "http://microsoftsecurity"))
@@ -174,11 +175,11 @@ Now, assuming both handlers are :ref:`registered <security-authorization-policie
 Accessing Request Context In Handlers
 -------------------------------------
 
-The ``Handle`` method you must implement in an authorization handler has two parameters, an ``AuthorizationContext`` and the ``Requirement`` you are handling. Frameworks such as MVC or Jabbr are free to add any object to the ``Resource`` property on the ``AuthorizationContext`` to pass through extra information.
+The :dn:method:`~Microsoft.AspNetCore.Authorization.AuthorizationHandler<TRequirement>.Handle` method you must implement in an authorization handler has two parameters, an :dn:class:`~Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext` and the Requirement you are handling. Frameworks such as MVC are free to add any object to the :dn:property:`~Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext.Resource` property on the :dn:class:`~Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext` to pass through extra information.
 
-For example MVC passes an instance of ``Microsoft.AspNetCore.Mvc.Filters.AuthorizationFilterContext`` in the resource property which is used to access HttpContext, RouteData and everything else MVC provides.
+For example MVC passes an instance of :dn:class:`~Microsoft.AspNetCore.Mvc.Filters.AuthorizationFilterContext` in the resource property which is used to access HttpContext, RouteData and everything else MVC provides.
 
-The use of the ``Resource`` property is framework specific. Using information in the ``Resource`` property will limit your authorization policies to particular frameworks. You should cast the ``Resource`` property using the ``as`` keyword, and then check the cast has succeed to ensure your code doesn't crash with ``InvalidCastExceptions`` when run on other frameworks;
+The use of the :dn:property:`~Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext.Resource` property is framework specific. Using information in the :dn:property:`~Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext.Resource` property will limit your authorization policies to particular frameworks. You should cast the :dn:property:`~Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext.Resource` property using the ``as`` keyword, and then check the cast has succeed to ensure your code doesn't crash with ``InvalidCastException`` when run on other frameworks;
 
 .. code-block:: c#
  

--- a/aspnet/security/authorization/resourcebased.rst
+++ b/aspnet/security/authorization/resourcebased.rst
@@ -8,7 +8,7 @@ Often authorization depends upon the resource being accessed. For example a docu
 Authorizing within your code
 ----------------------------
 
-Authorization is implemented as a service, ``IAuthorizationService``, registered in the service collection and available for DI into Controllers.
+Authorization is implemented as a service, :dn:iface:`~Microsoft.AspNetCore.Authorization.IAuthorizationService`, registered in the service collection and available via :ref:`dependency injection <fundamentals-dependency-injection>` for Controllers to access.
 
 .. code-block:: c#
 
@@ -22,7 +22,7 @@ Authorization is implemented as a service, ``IAuthorizationService``, registered
      }
  }
 
-``IAuthorizationService`` has two methods, one where you pass the resource and the policy name and the other where you pass the resource and a list of requirements to evaluate.
+:dn:iface:`~Microsoft.AspNetCore.Authorization.IAuthorizationService` has two methods, one where you pass the resource and the policy name and the other where you pass the resource and a list of requirements to evaluate.
 
 .. code-block:: c#
 
@@ -36,7 +36,7 @@ Authorization is implemented as a service, ``IAuthorizationService``, registered
 
 .. _security-authorization-resource-based-imperative:
 
-To call the service load your resource within your action then call the ``AuthorizeAsync`` method you require. For example
+To call the service load your resource within your action then call the :dn:method:`~Microsoft.AspNetCore.Authorization.IAuthorizationService.AuthorizeAsync` overload you require. For example
 
 .. code-block:: c#
 
@@ -68,7 +68,7 @@ Writing a handler for resource based authorization is not that much different to
 
   public class DocumentAuthorizationHandler : AuthorizationHandler<MyRequirement, Document>
   {
-      protected override void Handle(AuthorizationContext context, 
+      protected override void Handle(AuthorizationHandlerContext context, 
                                      OperationAuthorizationRequirement requirement, 
                                      Document resource)
       {
@@ -86,7 +86,7 @@ Don't forget you also need to register your handler in the ``ConfigureServices``
 Operational Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you are making decisions based on operations such as read, write, update and delete an already defined ``OperationAuthorizationRequirement`` class exists in the ``Microsoft.AspNetCore.Authorization.Infrastructure`` namespace. This prebuilt requirement class enables you to write a single handler which has a parameterized operation name, rather than create individual classes for each operation To use it provide an operation name;
+If you are making decisions based on operations such as read, write, update and delete, you can use the :dn:class:`~Microsoft.AspNetCore.Authorization.Infrastructure.OperationAuthorizationRequirement` class in the :dn:ns:`Microsoft.AspNetCore.Authorization.Infrastructure` namespace. This prebuilt requirement class enables you to write a single handler which has a parameterized operation name, rather than create individual classes for each operation. To use it provide some operation names:
 
 .. code-block:: c#
 
@@ -102,15 +102,15 @@ If you are making decisions based on operations such as read, write, update and 
          new OperationAuthorizationRequirement { Name = "Delete" };
  }
 
-Your handler could then be implemented as follows, using a hypothetical Document class as the resource;
+Your handler could then be implemented as follows, using a hypothetical ``Document`` class as the resource;
 
 .. code-block:: c#
 
   public class DocumentAuthorizationHandler : 
       AuthorizationHandler<OperationAuthorizationRequirement, Document>
   {
-      protected override void Handle(AuthorizationContext context, 
-                                     OperationAuthorizationRequirement requirement, 
+      protected override void Handle(AuthorizationHandlerContext context,
+                                     OperationAuthorizationRequirement requirement,
                                      Document resource)
       {
           // Validate the operation using the resource, the identity and
@@ -118,9 +118,9 @@ Your handler could then be implemented as follows, using a hypothetical Document
       }
   }
 
-You can see the handler works on ``OperationAuthorizationRequirement``. The code inside the handler must take the Name property of the supplied requirement into account when making its evaluations.
+You can see the handler works on :dn:class:`~Microsoft.AspNetCore.Authorization.Infrastructure.OperationAuthorizationRequirement`. The code inside the handler must take the Name property of the supplied requirement into account when making its evaluations.
 
-To call an operational resource handler you need to specify the operation when calling ``AuthorizeAsync()`` in your action. For example
+To call an operational resource handler you need to specify the operation when calling :dn:method:`~Microsoft.AspNetCore.Authorization.IAuthorizationService.AuthorizeAsync` in your action. For example
 
 .. code-block:: c#
 
@@ -133,4 +133,4 @@ To call an operational resource handler you need to specify the operation when c
      return new ChallengeResult();
  }
 
-This example checks if the ``User`` is able to perform the Read operation for the current ``document`` instance. If authorization succeeds the view for the document will be returned. If authorization fails returning ChallengeResult() will inform any authentication middleware authorization has failed and the middleware can take the appropriate response, for example returning a 401 or 403 status code, or redirecting the user to a login page for interactive browser clients.
+This example checks if the User is able to perform the Read operation for the current ``document`` instance. If authorization succeeds the view for the document will be returned. If authorization fails returning :dn:class:`~Microsoft.AspNetCore.Mvc.ChallengeResult` will inform any authentication middleware authorization has failed and the middleware can take the appropriate response, for example returning a 401 or 403 status code, or redirecting the user to a login page for interactive browser clients.

--- a/aspnet/security/authorization/roles.rst
+++ b/aspnet/security/authorization/roles.rst
@@ -10,7 +10,7 @@ Adding role checks
 
 Role based authorization checks are declarative - the developer embeds them within their code, against a controller or an action within a controller, specifying roles which the current user must be a member of to access the requested resource.
 
-For example the following code would limit access to any actions on the Administration controller to users who are a member of the Administrator group.
+For example the following code would limit access to any actions on the ``AdministrationController`` to users who are a member of the ``Administrator`` group.
 
 .. code-block:: c#
 
@@ -28,9 +28,9 @@ You can specify multiple roles as a comma separated list;
   {  
   }
 
-This controller would be only accessible by users who are members of the HRManager role or the Finance Role.
+This controller would be only accessible by users who are members of the ``HRManager`` role or the ``Finance`` role.
 
-If you apply multiple attributes then an accessing user must be a member of all the roles specified; the following sample requires that a user must be a member of both the PowerUser and ControlPanelUser role.
+If you apply multiple attributes then an accessing user must be a member of all the roles specified; the following sample requires that a user must be a member of both the ``PowerUser`` and ``ControlPanelUser`` role.
 
 .. code-block:: c#
 
@@ -57,7 +57,7 @@ You can further limit access by applying additional role authorization attribute
       }
   }
 
-In the previous code snippet both members of the Administrator role and the PowerUser role can access the controller and the SetTime action, but only members of the Administrator role can access the ShutDown action.
+In the previous code snippet both members of the ``Administrator`` role and the ``PowerUser`` role can access the controller and the ``SetTime`` action, but only members of the ``Administrator`` role can access the ``ShutDown`` action.
 
 You can also lock down a controller but allow anonymous, unauthenticated access to individual actions.
 
@@ -95,7 +95,7 @@ Role requirements can also be expressed using the new Policy syntax, where a dev
      }
  }
 
-Policies are applied using the ``Policy`` parameter on the ``Authorize`` attribute;
+Policies are applied using the :dn:prop:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute.Policy` property on the :dn:class:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute` attribute;
 
 .. code-block:: c#
 
@@ -105,11 +105,11 @@ Policies are applied using the ``Policy`` parameter on the ``Authorize`` attribu
      return View();
  }
 
-If you want to specify multiple allowed roles in a requirement then you can specify them as parameters to the ``RequireRole`` method;
+If you want to specify multiple allowed roles in a requirement then you can specify them as parameters to the :dn:method:`~Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder.RequireRole` method;
 
 .. code-block:: c#
 
   options.AddPolicy("ElevatedRights", policy => 
                     policy.RequireRole("Administrator", "PowerUser", "BackupAdministrator"));
 
-This example would authorize any user who has a role of Administrator, PowerUser and/or BackupAdministrator.
+This example would authorize any user who has a role of ``Administrator``, ``PowerUser`` and/or ``BackupAdministrator``.

--- a/aspnet/security/authorization/simple.rst
+++ b/aspnet/security/authorization/simple.rst
@@ -3,9 +3,9 @@
 Simple Authorization
 ====================
 
-Authorization in MVC is controlled through the ``Authorize`` attribute and its various parameters. At its simplest applying the ``Authorize`` attribute to a controller or action limits access to the controller or action to any authorized user.
+Authorization in MVC is controlled through the :dn:class:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute` attribute and its various parameters. At its simplest applying the :dn:class:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute` attribute to a controller or action limits access to the controller or action to any authorized user.
 
-For example, the following code limits access to the AccountController to any authenticated user.
+For example, the following code limits access to the ``AccountController`` to any authenticated user.
 
 .. code-block:: c#
 
@@ -21,7 +21,7 @@ For example, the following code limits access to the AccountController to any au
       }
   }
 
-If you want to apply authorization to an action rather than the controller simply apply the ``Authorize`` attribute to the action itself;
+If you want to apply authorization to an action rather than the controller simply apply the :dn:class:`~Microsoft.AspNetCore.Authorization.AuthorizeAttribute` attribute to the action itself;
 
 .. code-block:: c#
 
@@ -39,7 +39,7 @@ If you want to apply authorization to an action rather than the controller simpl
 
 Now only authenticated users can access the logout function.
 
-You can also use the MVC's ``AllowAnonymous`` attribute to allow access by non-authenticated users to individual actions; for example
+You can also use the :dn:class:`~Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute` attribute to allow access by non-authenticated users to individual actions; for example
 
 .. code-block:: c#
 
@@ -56,7 +56,7 @@ You can also use the MVC's ``AllowAnonymous`` attribute to allow access by non-a
       }
   }
 
-This would allow only authenticated users to the Account controller, except for the Login action, which is accessible by everyone, regardless of their authenticated or unauthenticated / anonymous status.
+This would allow only authenticated users to the ``AccountController``, except for the ``Login`` action, which is accessible by everyone, regardless of their authenticated or unauthenticated / anonymous status.
 
 .. WARNING::
   ``[AllowAnonymous]`` bypasses all authorization statements. If you apply combine ``[AllowAnonymous]`` and any ``[Authorize]`` attribute then the Authorize attributes will always be ignored. For example if you apply ``[AllowAnonymous]`` at the controller level any ``[Authorize]`` attributes on the same controller, or on any action within it will be ignored.

--- a/aspnet/security/authorization/views.rst
+++ b/aspnet/security/authorization/views.rst
@@ -3,9 +3,9 @@
 View Based Authorization
 ========================
 
-Often a developer will want to show, hide or otherwise modify a UI based on the current user identity. You can access the authorization service within MVC views by injecting it. To inject the authorization service into a view you use the ``@inject IAuthorizationService AuthorizationService``. If you want the authorization service in every view the place the ``@inject`` keyword into the ``_ViewImports.cshtml`` file in the ``Views`` directory.
+Often a developer will want to show, hide or otherwise modify a UI based on the current user identity. You can access the authorization service within MVC views via :ref:`dependency injection <fundamentals-dependency-injection>`. To inject the authorization service into a Razor view use the ``@inject`` directive, for example ``@inject IAuthorizationService AuthorizationService``. If you want the authorization service in every view the place the ``@inject`` directive into the ``_ViewImports.cshtml`` file in the ``Views`` directory.
 
-Once you have injected the authorization service you use it by calling the ``AuthorizeAsync`` method in exactly the same way as you would check during :ref:`resource based authorization <security-authorization-resource-based-imperative>`. 
+Once you have injected the authorization service you use it by calling the :dn:method:`~Microsoft.AspNetCore.Authorization.IAuthorizationService.AuthorizeAsync` method in exactly the same way as you would check during :ref:`resource based authorization <security-authorization-resource-based-imperative>`. 
 
 .. code-block:: c#
 
@@ -14,14 +14,14 @@ Once you have injected the authorization service you use it by calling the ``Aut
      <p>This paragraph is displayed because you fulfilled PolicyName.</p>        
  }    
 
-In some cases the resource will be your view model, and you can call ``AuthorizeAsync`` in exactly the same way as you would check during :ref:`resource based authorization <security-authorization-resource-based-imperative>`;
+In some cases the resource will be your view model, and you can call :dn:method:`~Microsoft.AspNetCore.Authorization.IAuthorizationService.AuthorizeAsync` in exactly the same way as you would check during :ref:`resource based authorization <security-authorization-resource-based-imperative>`;
 
 .. code-block:: c#
 
  @if (await AuthorizationService.AuthorizeAsync(User, Model, Operations.Edit))
  {
      <p><a class="btn btn-default" role="button" 
-         href="@Url.Action("Edit", "Document", new {id= Model.Id})">Edit</a></p>        
+         href="@Url.Action("Edit", "Document", new { id = Model.Id })">Edit</a></p>        
  }    
 
 Here you can see the model is passed as the resource authorization should take into consideration.


### PR DESCRIPTION
Preview here: http://vibrantcode.com/AspNetDocsPreview/security/authorization/index.html

/cc @blowdart @Tratcher for tech review
/cc @danroth27 @RickAndMSFT for style review (and one small question, see below)

Note: It looks like the API docs aren't quite up to date for RTM so some of the API links don't render properly. Is there an ETA for getting those updated?

Summary of changes:
* Handle rename of `AuthorizationContext` to `AuthorizationHandlerContext` (https://github.com/aspnet/Security/issues/806)
* Make most (if not all) of the references to methods/types/interfaces/namespaces/etc. into proper API doc links
* Clarify a few sentences where I noticed some wonky text
* Expand "DI" to "dependency injection" (with a link to the DI article), for added clarity