### PR TITLE
Fix broken table in Publishing to IIS

### DIFF
--- a/aspnet/publishing/iis.rst
+++ b/aspnet/publishing/iis.rst
@@ -65,11 +65,15 @@ To configure `IISIntegration` service options, include a service configuration f
     ...
   });
 
-| Option | Setting |
-| --- | --- |
-| AutomaticAuthentication | If true, the authentication middleware will alter the request user arriving and respond to generic challenges. If false, the authentication middleware will only provide identity and respond to challenges when explicitly indicated by the AuthenticationScheme. |
-| ForwardClientCertificate | If true and the `MS-ASPNETCORE-CLIENTCERT` request header is present, the `ITLSConnectionFeature` will be populated. |
-| ForwardWindowsAuthentication | If true, authentication middleware will attempt to authenticate using platform handler windows authentication. If false, authentication middleware won't be added. |
++------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Option                       | Setting                                                                                                                                                                                                                                                            |
++==============================+====================================================================================================================================================================================================================================================================+
+| AutomaticAuthentication      | If true, the authentication middleware will alter the request user arriving and respond to generic challenges. If false, the authentication middleware will only provide identity and respond to challenges when explicitly indicated by the AuthenticationScheme. |
++------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ForwardClientCertificate     | If true and the `MS-ASPNETCORE-CLIENTCERT` request header is present, the `ITLSConnectionFeature` will be populated.                                                                                                                                               |
++------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ForwardWindowsAuthentication | If true, authentication middleware will attempt to authenticate using platform handler windows authentication. If false, authentication middleware won't be added.                                                                                                 |
++------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 `publish-iis` tool
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
@Rick-Anderson 

Using the abbreviated table formatting in the update, it was nothing but :cry: tears :cry: ... https://docs.asp.net/en/latest/publishing/iis.html#application-configuration

This PR fixes the broken table format.