### PR TITLE
Limit the branches that build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 sudo: false
+branches:
+  only:
+    - master
+    - release
+    - dev
+    - /^(.*\/)?ci-.*$/
 language: python
 python:
   - "3.4"


### PR DESCRIPTION
@danroth27  We have a similar setup in all of our repos to reduce the amount of churn on travis and I'm wondering if we should do the same for the Docs repo. The idea is to restrict building branches to PRs, main branches (master, release and dev) and branches specifically tagged with <alias>/ci-<branch name>.