### PR TITLE
Added note RE: @RenderSection scripts

### DIFF
--- a/aspnet/tutorials/first-mvc-app/adding-model.rst
+++ b/aspnet/tutorials/first-mvc-app/adding-model.rst
@@ -159,6 +159,11 @@ Test the app
 
 .. note:: If your browser is unable to connect to the movie app you might need to wait for IIS Express to load the app. It can sometimes take up to 30 seconds to build the app and have it ready to respond to requests.
 
+.. note:: You will also need to add this snippet of code within **_Layout.cshtml**, just beneath the **@RenderBody()** function:
+        @RenderSection("scripts", required: false)
+        otherwise you'll receive an internal server error about a non-rendered section when trying to create a new movie.
+
+
 - Run the app and tap the **Mvc Movie** link
 - Tap the **Create New** link and create a movie
 


### PR DESCRIPTION
Found the solution from this StackOverflow post: http://stackoverflow.com/questions/10971149/the-following-sections-have-been-defined-but-have-not-been-rendered-for-the-layo

It means that you have defined a section in your master Layout.cshtml, but you have not included anything for that section in your View.

The final div within _Layout.cshtml should look like this:

    <div class="container body-content">
        @RenderBody()
        @RenderSection("scripts", required: false)
        <hr />
        <footer>
            <p>&copy; 2016 - MvcMovie</p>
        </footer>
    </div>

Another user reported the same issue within the comments on this post. I replicated the issue myself, and this resolved it.