### PR TITLE
tutorials/first-web-api.rst "Building Your First Web API with ASP.NET Core MVC and Visual Studio"

### DIFF
--- a/aspnet/tutorials/first-web-api/sample/src/TodoApi/Controllers/TodoController.cs
+++ b/aspnet/tutorials/first-web-api/sample/src/TodoApi/Controllers/TodoController.cs
@@ -38,7 +38,7 @@ namespace TodoApi.Controllers
                 return BadRequest();
             }
             TodoItems.Add(item);
-            return CreatedAtRoute("GetTodo", new { controller = "Todo", id = item.Key }, item);
+            return CreatedAtAction("GetTodo", new { id = item.Key }, item);
         }
 
         [HttpPut("{id}")]


### PR DESCRIPTION
Replaces `CreatedAtRoute` by `CreatedAtAction` call, as we use action name in arguments.

By the way, action name from `HttpGet` attribute (`"GetTodo"`) is not working for me. I get same error: `InvalidOperationException: No route matches the supplied values.`. Using action method name `"GetById"` fixes this error. Maybe this is a bug in MVC.