### PR TITLE
Add section to update tools version in global.json

### DIFF
--- a/aspnet/migration/rc2-to-rtm.rst
+++ b/aspnet/migration/rc2-to-rtm.rst
@@ -40,6 +40,31 @@ Becomes:
     }
   }
 
+SDK Version for Visual Studio Projects
+--------------------------------------
+
+Solutions in Visual Studio using the ``global.json`` configuration file must update to the latest SDK tools preview version. For example:
+
+.. code-block:: json
+
+  {
+    "projects": [ "src" ],
+    "sdk": {
+      "version": "1.0.0-preview1-002702"
+    }
+  }
+
+Becomes:
+
+.. code-block:: json
+
+  {
+    "projects": [ "src" ],
+    "sdk": {
+      "version": "1.0.0-preview2-003121"
+    }
+  }
+  
 Hosting
 -------
 


### PR DESCRIPTION
Not updating the `global.json` might cause errors when restoring project.json, see [this issue from dotnet/cli](https://github.com/dotnet/cli/issues/3703). As far as I'm aware, there's no automatic migration within Visual Studio itself. Additionally, a command line restore with the CLI itself will also fail when the wrong SDK version is specified in `global.json`.