### PR TITLE
IApplicationEnvironment is now longer available in Startup

### DIFF
--- a/aspnet/fundamentals/startup.rst
+++ b/aspnet/fundamentals/startup.rst
@@ -61,11 +61,8 @@ ASP.NET Core provides certain application services and objects during your appli
 IApplicationBuilder
   Used to build the application request pipeline. Available only to the ``Configure`` method in ``Startup``. Learn more about :doc:`request-features`.
 
-IApplicationEnvironment
-  Provides access to the application properties, such as ``ApplicationName``, ``ApplicationVersion``, and ``ApplicationBasePath``. Available to the ``Startup`` constructor and ``Configure`` method.
-
 IHostingEnvironment
-  Provides the current ``EnvironmentName``, ``WebRootPath``, and web root file provider. Available to the ``Startup`` constructor and ``Configure`` method.
+  Provides the current ``EnvironmentName``, ``ContentRootPath``, ``WebRootPath``, and web root file provider. Available to the ``Startup`` constructor and ``Configure`` method.
 
 ILoggerFactory
   Provides a mechanism for creating loggers. Available to the ``Startup`` constructor and ``Configure`` method. Learn more about :doc:`logging`.


### PR DESCRIPTION
See https://docs.asp.net/en/latest/migration/rc1-to-rtm.html#hosting-service-changes