### PR TITLE
Add link to latest release notes

### DIFF
--- a/aspnet/index.rst
+++ b/aspnet/index.rst
@@ -18,8 +18,9 @@ Topics
 .. toctree::
     :titlesonly:
 
-    Introduction <intro> 
-    getting-started     
+    Introduction <intro>
+    getting-started
+    Release notes <https://github.com/aspnet/home/releases>
     tutorials/index
     fundamentals/index
     mvc/index
@@ -34,7 +35,7 @@ Topics
     migration/index
     API <https://docs.asp.net/projects/api>
     contribute/index
-    
+
 
 Related Resources
 -----------------


### PR DESCRIPTION
 - fixes #235 

I placed the link to the releases page below the Getting started and Introduction items as I thought that it would be helpful for very-new people to read those two pages first; I'm happy to move it though if you feel it more appropriately placed elsewhere in the TOC.