### PR TITLE
Fixed CORS samples to support ASP.NET Core dependencies

### DIFF
--- a/aspnet/security/cors/sample/src/CorsExample1/project.json
+++ b/aspnet/security/cors/sample/src/CorsExample1/project.json
@@ -1,20 +1,19 @@
 ﻿{
   "webroot": "wwwroot",
-  "version": "1.0.0-*",
+  "version": "1.0.0",
 
   "dependencies": {
-    "Microsoft.AspNet.Cors": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc1-final"
+    "Microsoft.AspNetCore.Cors": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0"
   },
 
   "commands": {
-      "web": "Microsoft.AspNet.Server.Kestrel"
+    "web": "Microsoft.AspNetCore.Server.Kestrel"
   },
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+    "netcoreapp1.0": { }
   },
 
   "publishExclude": [

--- a/aspnet/security/cors/sample/src/CorsExample2/project.json
+++ b/aspnet/security/cors/sample/src/CorsExample2/project.json
@@ -1,20 +1,19 @@
 {
   "webroot": "wwwroot",
-  "version": "1.0.0-*",
+  "version": "1.0.0",
 
   "dependencies": {
-    "Microsoft.AspNet.Cors": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc1-final"
+    "Microsoft.AspNetCore.Cors": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0"
   },
 
   "commands": {
-    "web": "Microsoft.AspNet.Server.Kestrel"
+    "web": "Microsoft.AspNetCore.Server.Kestrel"
   },
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+    "netcoreapp1.0": { }
   },
 
   "publishExclude": [

--- a/aspnet/security/cors/sample/src/CorsExample3/project.json
+++ b/aspnet/security/cors/sample/src/CorsExample3/project.json
@@ -1,20 +1,19 @@
 ﻿{
   "webroot": "wwwroot",
-  "version": "1.0.0-*",
+  "version": "1.0.0",
 
   "dependencies": {
-    "Microsoft.AspNet.Cors": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc1-final"
+    "Microsoft.AspNetCore.Cors": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0"
   },
 
   "commands": {
-    "web": "Microsoft.AspNet.Server.Kestrel"
+    "web": "Microsoft.AspNetCore.Server.Kestrel"
   },
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+    "netcoreapp1.0": { }
   },
 
   "publishExclude": [

--- a/aspnet/security/cors/sample/src/CorsExample4/project.json
+++ b/aspnet/security/cors/sample/src/CorsExample4/project.json
@@ -1,20 +1,19 @@
 ﻿{
   "webroot": "wwwroot",
-  "version": "1.0.0-*",
+  "version": "1.0.0",
 
   "dependencies": {
-    "Microsoft.AspNet.Cors": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc1-final"
+    "Microsoft.AspNetCore.Cors": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0"
   },
 
   "commands": {
-    "web": "Microsoft.AspNet.Server.Kestrel"
+    "web": "Microsoft.AspNetCore.Server.Kestrel"
   },
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+    "netcoreapp1.0": { }
   },
 
   "publishExclude": [

--- a/aspnet/security/cors/sample/src/CorsMvc/Controllers/HomeController.cs
+++ b/aspnet/security/cors/sample/src/CorsMvc/Controllers/HomeController.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.AspNet.Cors.Core;
-using Microsoft.AspNet.Mvc;
+﻿using Microsoft.AspNetCore.Cors.Core;
+using Microsoft.AspNetCore.Mvc;
 
 namespace CorsMvc.Controllers
 {
     [EnableCors("AllowSpecificOrigin")]
     public class HomeController : Controller
     {
-        [EnableCors("AllowSpecificOrigin")] 
+        [EnableCors("AllowSpecificOrigin")]
         public IActionResult Index()
         {
             return View();

--- a/aspnet/security/cors/sample/src/CorsMvc/project.json
+++ b/aspnet/security/cors/sample/src/CorsMvc/project.json
@@ -1,23 +1,22 @@
 ﻿{
   "webroot": "wwwroot",
-  "version": "1.0.0-*",
+  "version": "1.0.0",
 
   "dependencies": {
-    "Microsoft.AspNet.Server.WebListener": "1.0.0-beta8",
-    "Microsoft.AspNet.Mvc": "6.0.0-beta8",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-beta8",
-    "Microsoft.Framework.Logging": "1.0.0-beta8",
-    "Microsoft.Framework.Logging.Console": "1.0.0-beta8",
-    "Microsoft.AspNet.Cors": "6.0.0-beta8"
+    "Microsoft.AspNetCore.Server.WebListener": "1.0.0",
+    "Microsoft.AspNetCore.Mvc": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.Framework.Logging": "1.0.0",
+    "Microsoft.Framework.Logging.Console": "1.0.0",
+    "Microsoft.AspNetCore.Cors": "1.0.0"
   },
 
   "commands": {
-      "web": "Microsoft.AspNet.Server.Kestrel"
+      "web": "Microsoft.AspNetCore.Server.Kestrel"
   },
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+    "netcoreapp1.0": { }
   },
 
   "publishExclude": [
@@ -27,7 +26,7 @@
     "**.user",
     "**.vspscc"
   ],
-  
+
   "exclude": [
     "wwwroot",
     "node_modules",


### PR DESCRIPTION
Hello,
While reading the docs, I found out that the dependencies in CORS samples are targeting ASP.NET instead of ASP.NET Core.
In this pull request I fixed the dependencies in the samples to match ASP.NET Core.
Best,
Anass