### PR TITLE
fix the issue that the code doesn't do as stated in the doc

### DIFF
--- a/aspnet/fundamentals/configuration.rst
+++ b/aspnet/fundamentals/configuration.rst
@@ -133,7 +133,7 @@ You configure options using the :dn:method:`~Microsoft.Extensions.DependencyInje
   :language: c#
   :lines: 26-42
   :dedent: 8
-  :emphasize-lines: 7-10,13
+  :emphasize-lines: 7,10-13
 
 When you bind options to configuration, each property in your options type is bound to a configuration key of the form ``property:subproperty:...``. For example, the ``MyOptions.Option1`` property is bound to the key ``Option1``, which is read from the ``option1`` property in *appsettings.json*. Note that configuration keys are case insensitive.
 

--- a/aspnet/fundamentals/configuration/sample/src/UsingOptions/Startup.cs
+++ b/aspnet/fundamentals/configuration/sample/src/UsingOptions/Startup.cs
@@ -28,14 +28,14 @@ namespace UsingOptions
             // Setup options with DI
             services.AddOptions();
 
+            // Configure MyOptions using config by installing Microsoft.Extensions.Options.ConfigurationExtensions
+            services.Configure<MyOptions>(Configuration);
+
             // Configure MyOptions using code
             services.Configure<MyOptions>(myOptions =>
             {
                 myOptions.Option1 = "value1_from_action";
             });
-
-            // Configure MyOptions using config by installing Microsoft.Extensions.Options.ConfigurationExtensions
-            services.Configure<MyOptions>(Configuration);
 
             // Add framework services.
             services.AddMvc();


### PR DESCRIPTION
The doc states that:

> the value of Option1 is overridden by the configured delegate with the value “value1_from_action”

In order to make this statement true, the configurd delegate should be put last.

This issue is introducted by PR #1331