### PR TITLE
the sample does not configure AppSettings any more

### DIFF
--- a/aspnet/fundamentals/startup.rst
+++ b/aspnet/fundamentals/startup.rst
@@ -52,7 +52,7 @@ Just as with ``Configure``, it is recommended that features that require substan
 
 Adding services to the services container makes them available within your application via :doc:`dependency injection <dependency-injection>`. Just as the ``Startup`` class is able to specify dependencies its methods require as parameters, rather than hard-coding to a specific implementation, so too can your middleware, MVC controllers and other classes in your application.
 
-The ``ConfigureServices`` method is also where you should add configuration option classes, like ``AppSettings`` in the example above, that you would like to have available in your application. See the :doc:`configuration` topic to learn more about configuring options.
+The ``ConfigureServices`` method is also where you should add configuration option classes that you would like to have available in your application. See the :doc:`configuration` topic to learn more about configuring options.
 
 Services Available in Startup
 -----------------------------

--- a/aspnet/tutorials/first-mvc-app/validation.rst
+++ b/aspnet/tutorials/first-mvc-app/validation.rst
@@ -3,7 +3,7 @@ Adding Validation
 
 By `Rick Anderson`_
 
-In this this section you'll add validation logic to the ``Movie`` model, and you'll ensure that the validation rules are enforced any time a user attempts to create or edit a movie.
+In this section you'll add validation logic to the ``Movie`` model, and you'll ensure that the validation rules are enforced any time a user attempts to create or edit a movie.
 
 Keeping things DRY
 ---------------------


### PR DESCRIPTION
The line of code to configure `AppSettings` is removed in the commit [Updating WebApplication1 sample to beta5](https://github.com/aspnet/Docs/commit/8080f1b325413c39e011a8623d4a80ae0d623120#diff-931fae37c82f38008d5a4cde9c977604L52)