### PR TITLE
Added namespace change line emphasis to docs.

### DIFF
--- a/aspnet/getting-started.rst
+++ b/aspnet/getting-started.rst
@@ -32,7 +32,7 @@ Getting Started
 
   .. literalinclude:: getting-started/sample/aspnetcoreapp/Program.cs
     :language: c#
-    :emphasize-lines: 2,10-15
+    :emphasize-lines: 2,4,10-15
 
 7. Run the app  (the ``dotnet run`` command will build the app when it's out of date):
 


### PR DESCRIPTION
Default dotnet new on Mac has ConsoleApplication as namespace. This PR highlights the `Program.cs` namespace line as a change. Resolves Issue #1652