### PR TITLE
Fixing typo in project.json settings

### DIFF
--- a/aspnet/publishing/iis.rst
+++ b/aspnet/publishing/iis.rst
@@ -111,7 +111,6 @@ To include the `publish-iis` tool in your application, add entries to the `tools
 
   "tools": {
     "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview2-final"
-    }
   },
   "scripts": {
     "postpublish": "dotnet publish-iis --publish-folder %publish:OutputPath% --framework %publish:FullTargetFramework%"


### PR DESCRIPTION
The modifications that are needed for the `tools` and `scripts` sections of *project.json* no longer has a stray `}` to make it easier for folks who are copy and pasting.