### PR TITLE
Update entity-framework-6.rst

### DIFF
--- a/aspnet/data/entity-framework-6.rst
+++ b/aspnet/data/entity-framework-6.rst
@@ -46,7 +46,7 @@ In the ``Startup`` class within ``ConfigureServices`` add factory method of your
     
     public void ConfigureServices(IServiceCollection services)
     {
-        services.AddScoped(() => new ApplicationDbContext(Configuration["Data:DefaultConnection:ConnectionString"]));
+        services.AddScoped((_) => new ApplicationDbContext(Configuration["Data:DefaultConnection:ConnectionString"]));
         
         // Configure remaining services
     }


### PR DESCRIPTION
Hi,

I couldn't get this demo to work unless I added this underscore (source http://bleedingnedge.com/2015/11/01/entity-framework-6-with-asp-net-5/) otherwise I got the error "Cannot convert lambda expression to type 'Type' because it is not a delegate type"

I'm not sure whether this is supposed to happen?

Also, using DNX 4.5.1 I had to use `ConfigurationManager.ConnectionStrings["DefaultConnection"].ConnectionString` to get the connection string from app.config (once I realised I had to manually add an app.config, it wasn't even an option on the add an item menu)

Sorry if this is a total noob error, but I thought I may point it out, as it has taken me a good while to get this to (nearly) work :laughing: 

Cheers,
Rob