### PR TITLE
middleware fix

### DIFF
--- a/aspnet/intro.rst
+++ b/aspnet/intro.rst
@@ -85,7 +85,7 @@ A service is a component that is intended for common consumption in an applicati
 Middleware
 ----------
 
-In ASP.NET Core you compose your request pipeline using :doc:`/fundamentals/middleware`. ASP.NET Core middleware performs asynchronous logic on an ``HttpContext`` and then either invokes the next middleware in the sequence or terminates the request directly. You generally "Use" middleware by invoking a corresponding ``UseXYZ`` extension method on the ``IApplicationBuilder`` in the ``Configure`` method.
+In ASP.NET Core you compose your request pipeline using :doc:`/fundamentals/middleware`. ASP.NET Core middleware performs asynchronous logic on an ``HttpContext`` and then either invokes the next middleware in the sequence or terminates the request directly. You generally "Use" middleware by taking a dependency on a NuGet package and invoking a corresponding ``UseXYZ`` extension method on the ``IApplicationBuilder`` in the ``Configure`` method.
 
 ASP.NET Core comes with a rich set of prebuilt middleware:
 


### PR DESCRIPTION
In order to use a middleware it is important to take a dependency on a specific and dedicated NuGet package and then use the extension method against IApplicationBuilder interface.

I think it is important piece and was missing.
Lets include this change.