### PR TITLE
Bugfix/routing regex

### DIFF
--- a/aspnet/fundamentals/routing.rst
+++ b/aspnet/fundamentals/routing.rst
@@ -353,7 +353,7 @@ The following table demonstrates some route constraints and their expected behav
     - Steve
     - String must consist of alphabetical characters.
   * - ``regex(expression)``
-    - {ssn:regex(\d{3}-\d{2}-\d{4})}
+    - {ssn:regex(^\d{3}-\d{2}-\d{4}$)}
     - 123-45-6789
     - String must match the provided regular expression.
   * - ``required``

--- a/aspnet/fundamentals/routing/sample/RoutingSample/Startup.cs
+++ b/aspnet/fundamentals/routing/sample/RoutingSample/Startup.cs
@@ -27,7 +27,7 @@ namespace RoutingSample
 
             routeBuilder.MapRoute(
                 "Track Package Route",
-                "package/{operation:regex(track|create|detonate)}/{id:int}");
+                "package/{operation:regex(^track|create|detonate$)}/{id:int}");
 
             routeBuilder.MapGet("hello/{name}", context =>
             {


### PR DESCRIPTION
Following the discussion in aspnet/Routing#347, since the current behaviour has to stay, the documentation should be patched to correctly show how to use the inline regex route constraints.