### PR TITLE
remove unnecessary code

### DIFF
--- a/aspnet/tutorials/first-web-api/sample/src/TodoApi/Models/TodoRepository.cs
+++ b/aspnet/tutorials/first-web-api/sample/src/TodoApi/Models/TodoRepository.cs
@@ -35,7 +35,6 @@ namespace TodoApi.Models
         public TodoItem Remove(string key)
         {
             TodoItem item;
-            _todos.TryGetValue(key, out item);
             _todos.TryRemove(key, out item);
             return item;
         }


### PR DESCRIPTION
The TODO item will be retrieved by _todos.TryRemove method, so no need call _todos.TryGetValue first.