### PR TITLE
Remove extra colon from Sections heading in Web API doc

### DIFF
--- a/aspnet/migration/webapi.rst
+++ b/aspnet/migration/webapi.rst
@@ -7,7 +7,7 @@ By `Steve Smith`_ and `Scott Addie`_
 
 Web APIs are HTTP services that reach a broad range of clients, including browsers and mobile devices. ASP.NET Core MVC includes support for building Web APIs providing a single, consistent way of building web applications. In this article, we demonstrate the steps required to migrate a Web API implementation from ASP.NET Web API to ASP.NET Core MVC.
 
-.. contents:: Sections::
+.. contents:: Sections:
   :local:
   :depth: 1
 


### PR DESCRIPTION
This PR removes an extra colon in the "Sections" heading of the Web API migration doc.