### PR TITLE
Add rss link to layout template 

### DIFF
--- a/common/_templates/layout.html
+++ b/common/_templates/layout.html
@@ -1,0 +1,5 @@
+{% extends "!layout.html" %}
+{% block extrahead %}
+{{ super() }}
+    <link rel="alternate" type="application/rss+xml" href="https://docs.asp.net/en/latest/rss.xml" title="RSS feed for documentation additions and updates">
+{% endblock %}


### PR DESCRIPTION
Fixes #1822 

Provide appropriate headers so that browsers/RSSreaders can find the ASP.NET Core docs RSS feed #1822