### PR TITLE
Stop and kill as group

### DIFF
--- a/aspnet/publishing/linuxproduction.rst
+++ b/aspnet/publishing/linuxproduction.rst
@@ -124,6 +124,8 @@ To have supervisor monitor our application, we will add a file to the ``/etc/sup
     environment=ASPNETCORE_ENVIRONMENT=Production
     user=www-data
     stopsignal=INT
+    stopasgroup=true
+    killasgroup=true
 
 Once you are done editing the configuration file, restart the ``supervisord`` process to change the set of programs controlled by supervisord.
 


### PR DESCRIPTION
When running `dotnet` two processes are started: one started by the user,
and one spawned as a child process. Example after running `dotnet run -p
/var/www/HelloWorld/src/HelloWorld`:

```
root     27452  0.5  5.6 3070112 57064 ?       SLl  16:50   0:01 /usr/bin/dotnet run -p /var/www/HelloWorld/src/HelloWorld
root     27470  0.1  3.5 7014752 36028 ?       SLl  16:50   0:00 /usr/share/dotnet/dotnet exec --additionalprobingpath /var/www/.nuget/packages /var/www/HelloWorld/src/HelloWorld/bin/Debug/netcoreapp1.0/HelloWorld.dll
```

When starting a site with supervisor, the same thing happens. When trying to
stop a site through `supervisorctl` with (in this case) `stop helloworld` the
original process is stopped (the one with id `27452`) but that process doesn't
pass on the `SIGINT` to its child process. The result is that the site is not
really shutting down, first of all, and second of all, trying start the site
again with (in this case) `start helloworld` will result in a bunch of errors
because the port kestrel wants to listen on is already in use.

To avoid this, set the `stopasgroup` and `killasgroup` configuration parameters
to true. This makes `supervisor` send the `SIGINT` to all child processes.