### PR TITLE
Set HOME environment variable

### DIFF
--- a/aspnet/publishing/linuxproduction.rst
+++ b/aspnet/publishing/linuxproduction.rst
@@ -121,7 +121,7 @@ To have supervisor monitor our application, we will add a file to the ``/etc/sup
     autorestart=true
     stderr_logfile=/var/log/hellomvc.err.log
     stdout_logfile=/var/log/hellomvc.out.log
-    environment=ASPNETCORE_ENVIRONMENT=Production
+    environment=HOME=/var/www/,ASPNETCORE_ENVIRONMENT=Production
     user=www-data
     stopsignal=INT
 


### PR DESCRIPTION
It is necessary to set the `HOME` environment variable when running a dotnet
core site through supervisor. If it is not set, the following exception is
thrown:

```
Unhandled Exception: System.ArgumentNullException: Value cannot be null.
Parameter name: path1
   at System.IO.Path.Combine(String path1, String path2, String path3)
   at Microsoft.DotNet.ProjectModel.Resolution.PackageDependencyProvider.ResolvePackagesPath(String rootDirectory, GlobalSettings settings)
   at Microsoft.DotNet.Configurer.NuGetCacheSentinel.get_NuGetCachePath()
   at Microsoft.DotNet.Configurer.NuGetCacheSentinel.Exists()
   at Microsoft.DotNet.Configurer.DotnetFirstTimeUseConfigurer.ShouldPrimeNugetCache()
   at Microsoft.DotNet.Configurer.DotnetFirstTimeUseConfigurer.Configure()
   at Microsoft.DotNet.Cli.Program.ConfigureDotNetForFirstTimeUse(INuGetCacheSentinel nugetCacheSentinel)
   at Microsoft.DotNet.Cli.Program.ProcessArgs(String[] args, ITelemetry telemetryClient)
   at Microsoft.DotNet.Cli.Program.Main(String[] args)
```

I guess that `path1` in this case is the value of the `HOME` variable (which is
`null` unless set in `supervisord.conf`) and it seems to be used for the
default nuget package path for the www-data user. By including `HOME` as part
of the `environment` configuration, this expection is no longer thrown and the
site starts up as expected.