### PR TITLE
mark change after RST->MD

### DIFF
--- a/aspnet/security/authorization/policies.rst
+++ b/aspnet/security/authorization/policies.rst
@@ -1,3 +1,5 @@
+.. updated after 9/15 RST->MD 
+
 .. _security-authorization-policies-based:
 
 Custom Policy-Based Authorization


### PR DESCRIPTION
We need a mechanism to mark docs that have changes after the snapshot port from RST -> MD

I propose we add a comment at the top of the file for all commits after the snapshot. Folks working on the conversion should check to make sure the topic has not been updated. Skip docs that have been updated and we will fix them in the next round when the tool is run again.