### PR TITLE
missing space in text

### DIFF
--- a/aspnet/fundamentals/dependency-injection.rst
+++ b/aspnet/fundamentals/dependency-injection.rst
@@ -39,7 +39,7 @@ The ``ConfigureServices`` method in the ``Startup`` class is responsible for def
   :dedent: 8
   :emphasize-lines: 5,8,12
 
-The features and middleware provided by ASP.NET, such as MVC, follow a convention of using a single Add\ *Service*\ extension method to register all of the services required by that feature. 
+The features and middleware provided by ASP.NET, such as MVC, follow a convention of using a single Add\ *Service*\  extension method to register all of the services required by that feature. 
 
 .. tip:: You can request certain framework-provided services within ``Startup`` methods through their parameter lists - see :doc:`startup` for more details.
 


### PR DESCRIPTION
More obvious when you look at the doc itself - two spaces are needed after the "*\" in order to get a space between the words "Service" and "extension".