### PR TITLE
Updated references in Identity Migration Doc

### DIFF
--- a/aspnet/migration/identity.rst
+++ b/aspnet/migration/identity.rst
@@ -14,17 +14,11 @@ In the previous article we :doc:`migrated configuration from an ASP.NET MVC proj
 Configure Identity and Membership
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In ASP.NET MVC, authentication and identity features are configured using ASP.NET Identity in Startup.Auth.cs and IdentityConfig.cs, located in the App_Start folder. In ASP.NET Core MVC, these features are configured in *Startup.cs*. Before pulling in the required services and configuring them, we should add the required dependencies to the project. Open *project.json* and add ``Microsoft.AspNetCore.Identity.EntityFrameworkCore`` and ``Microsoft.AspNetCore.Authentication.Cookies`` to the list of dependencies:
+In ASP.NET MVC, authentication and identity features are configured using ASP.NET Identity in Startup.Auth.cs and IdentityConfig.cs, located in the App_Start folder. In ASP.NET Core MVC, these features are configured in *Startup.cs*. 
 
-.. code-block:: none
+Add ``Microsoft.AspNetCore.Identity.EntityFrameworkCore`` and ``Microsoft.AspNetCore.Authentication.Cookies`` to the list of dependencies in project.json.
 
-  "dependencies": {
-    "Microsoft.AspNetCore.Mvc": "1.0.0",
-    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0",
-    "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0"
-  },
-
-Now, open Startup.cs and update the ConfigureServices() method to use Entity Framework and Identity services:
+Then, open Startup.cs and update the ``ConfigureServices()`` method to use Entity Framework and Identity services:
 
 .. code-block:: c#
 

--- a/aspnet/migration/identity.rst
+++ b/aspnet/migration/identity.rst
@@ -14,14 +14,14 @@ In the previous article we :doc:`migrated configuration from an ASP.NET MVC proj
 Configure Identity and Membership
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In ASP.NET MVC, authentication and identity features are configured using ASP.NET Identity in Startup.Auth.cs and IdentityConfig.cs, located in the App_Start folder. In ASP.NET Core MVC, these features are configured in *Startup.cs*. Before pulling in the required services and configuring them, we should add the required dependencies to the project. Open *project.json* and add ``Microsoft.AspNetCore.Identity.EntityFramework`` and ``Microsoft.AspNetCore.Authentication.Cookies`` to the list of dependencies:
+In ASP.NET MVC, authentication and identity features are configured using ASP.NET Identity in Startup.Auth.cs and IdentityConfig.cs, located in the App_Start folder. In ASP.NET Core MVC, these features are configured in *Startup.cs*. Before pulling in the required services and configuring them, we should add the required dependencies to the project. Open *project.json* and add ``Microsoft.AspNetCore.Identity.EntityFrameworkCore`` and ``Microsoft.AspNetCore.Authentication.Cookies`` to the list of dependencies:
 
 .. code-block:: none
 
   "dependencies": {
     "Microsoft.AspNetCore.Mvc": "1.0.0",
-    "Microsoft.AspNetCore.Identity.EntityFramework": "1.0.0",
-    "Microsoft.AspNetCore.Security.Cookies": "1.0.0"
+    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0",
+    "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0"
   },
 
 Now, open Startup.cs and update the ConfigureServices() method to use Entity Framework and Identity services:
@@ -68,17 +68,9 @@ ApplicationDbContext.cs:
   {
     public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     {
-      private static bool _created = false;
       public ApplicationDbContext()
       {
-        // Create the database and schema if it doesn't exist
-        // This is a temporary workaround to create database until Entity Framework database migrations 
-        // are supported in ASP.NET Core
-        if (!_created)
-        {
-          Database.AsMigrationsEnabled().ApplyMigrations();
-          _created = true;
-        }
+        Database.EnsureCreated();
       }
 
       protected override void OnConfiguring(DbContextOptions options)


### PR DESCRIPTION
Updated references in Identity Migration to use the final namespaces of components:

    "Microsoft.AspNetCore.Identity.EntityFrameworkCore":  "1.0.0",
    "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",

Removed workaround to assure that database is created in Entity Framework Core