### PR TITLE
Remove output caching from TOC

### DIFF
--- a/aspnet/performance/caching/index.rst
+++ b/aspnet/performance/caching/index.rst
@@ -7,5 +7,3 @@ Caching
   memory
   distributed
   response
-  output
-

--- a/aspnet/performance/caching/output.rst
+++ b/aspnet/performance/caching/output.rst
@@ -1,8 +1,0 @@
-.. include:: /../common/stub-topic.txt
-
-|stub-icon| Output Caching
-=======================================
-
-.. include:: /../common/stub-notice.txt
-
-.. _issue: https://github.com/aspnet/Docs/issues/880


### PR DESCRIPTION
I believe this topic is covered by the response caching topic.