### PR TITLE
Add user's unique email policy configuration

### DIFF
--- a/aspnet/security/authentication/identity.rst
+++ b/aspnet/security/authentication/identity.rst
@@ -103,7 +103,7 @@ In this topic, you'll learn how to use ASP.NET Core Identity to add functionalit
   
    .. literalinclude:: identity/sample/src/ASPNET-IdentityDemo/Startup.cs
     :language: c#
-    :lines: 57-75
+    :lines: 57-77
     :emphasize-lines: 5
     :dedent: 8
 

--- a/aspnet/security/authentication/identity.rst
+++ b/aspnet/security/authentication/identity.rst
@@ -103,7 +103,7 @@ In this topic, you'll learn how to use ASP.NET Core Identity to add functionalit
   
    .. literalinclude:: identity/sample/src/ASPNET-IdentityDemo/Startup.cs
     :language: c#
-    :lines: 57-77
+    :lines: 57-78
     :emphasize-lines: 5
     :dedent: 8
 

--- a/aspnet/security/authentication/identity/sample/src/ASPNET-IdentityDemo/Startup.cs
+++ b/aspnet/security/authentication/identity/sample/src/ASPNET-IdentityDemo/Startup.cs
@@ -72,6 +72,9 @@ namespace webapptemplate
                 options.Cookies.ApplicationCookie.ExpireTimeSpan = TimeSpan.FromDays(150);
                 options.Cookies.ApplicationCookie.LoginPath = "/Account/LogIn";
                 options.Cookies.ApplicationCookie.LogoutPath = "/Account/LogOff";
+                
+                // User settings
+                options.User.RequireUniqueEmail = true;
             });
         }
 


### PR DESCRIPTION
By default, identity doesn't  require unique emails for user. 
Add an example of how configure ASP.NET Identity to have unique user emails, which is the need in a lot of projects.