### PR TITLE
Update include reference to match tutorial

### DIFF
--- a/aspnet/mvc/views/tag-helpers/authoring.rst
+++ b/aspnet/mvc/views/tag-helpers/authoring.rst
@@ -59,7 +59,7 @@ That is, an anchor tag that makes this an email link. You might want to do this 
 
 .. wildcard syntax
 
-.. literalinclude:: authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImportsCopyEmail.cshtml
+.. literalinclude:: authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImportsCopy.cshtml
   :language: html
   :emphasize-lines: 2,3
 


### PR DESCRIPTION
The tutorial copy below the include mentions "The code above used the wildcard syntax," but as written it does not. Fixed the include reference to the correct file which shows the wildcard syntax.