### PR TITLE
Add reminder to user to include current assembly in _ViewsImport.cshtml

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/intro.md
+++ b/aspnetcore/mvc/views/tag-helpers/intro.md
@@ -58,7 +58,7 @@ If you create a new ASP.NET Core web app named *AuthoringTagHelpers* (with no au
 
 The `@addTagHelper` directive makes Tag Helpers available to the view. In this case, the view file is *Views/_ViewImports.cshtml*, which by default is inherited by all view files in the *Views* folder and sub-directories; making Tag Helpers available. The code above uses the wildcard syntax ("*") to specify that all Tag Helpers in the specified assembly (*Microsoft.AspNetCore.Mvc.TagHelpers*) will be available to every view file in the *Views* directory or sub-directory. The first parameter after `@addTagHelper` specifies the Tag Helpers to load (we are using "*" for all Tag Helpers), and the second parameter "Microsoft.AspNetCore.Mvc.TagHelpers" specifies the assembly containing the Tag Helpers. *Microsoft.AspNetCore.Mvc.TagHelpers* is the assembly for the built-in ASP.NET Core Tag Helpers.
 
-To expose all of the Tag Helpers in this project (which creates an assembly named *AuthoringTagHelpers*), you would use the following:
+It is important to understand that if you author your Tag Helpers in the same project as your MVC web application (this project), that you must explicitly include the assembly name of this project (which is *AuthoringTagHelpers*).  If you do not include your current executing assembly in your *Views/_ViewImports.cshtml* file, your authored Tag Helpers will not be available in your view cshtml files.  Specifically, you would use the following:
 
 [!code-html[Main](../../../mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImportsCopy.cshtml?highlight=3)]
 


### PR DESCRIPTION
It does not seem at all discoverable that to add your own tag helpers you need to add a line to _ViewImports.cshtml (I struggled with this for a while before figuring it out).  I believe the doc is currently not sufficient to address this so I expanded the explanation with a likely failure mode the reader my fall in to (as I did).