### PR TITLE
Add tip to add error handler before others

### DIFF
--- a/aspnetcore/fundamentals/error-handling.md
+++ b/aspnetcore/fundamentals/error-handling.md
@@ -26,6 +26,9 @@ You configure the pipeline for each request in the `Startup` class's `Configure(
 
 [!code-csharp[Main](../fundamentals/error-handling/sample/src/ErrorHandlingSample/Startup.cs?highlight=6,8&start=21&end=29)]
 
+>[!TIP]
+> Make sure to put `app.UseDeveloperExceptionPage()` before any middleware you want to catch the exception in (i.e. `app.UseMvc()`)
+
 The above code includes a check to ensure the environment is development before adding the call to `UseDeveloperExceptionPage`. This is a good practice, since you typically do not want to share detailed exception information about your application publicly while it is in production. [Learn more about configuring environments](environments.md).
 
 The sample application includes a simple mechanism for creating an exception:


### PR DESCRIPTION
For someone not familiar with the pipeline and just arriving from a google search it's not clear that this needs to be run before the rest of the middleware that actually produces the error, and adding it later will appear to have no effect.