### PR TITLE
Updated document to reflect new cli command

### DIFF
--- a/aspnetcore/getting-started.md
+++ b/aspnetcore/getting-started.md
@@ -18,35 +18,22 @@ uid: getting-started
     ````console
     mkdir aspnetcoreapp
     cd aspnetcoreapp
-    dotnet new
+    dotnet new -t web
     ````
 
-3.  Update the *project.json* file to add the Kestrel HTTP server package as a dependency:
-
-    [!code-csharp[Main](./getting-started/sample/aspnetcoreapp/project.json?highlight=15)]
-
-4.  Restore the packages:
+3.  Restore the packages:
 
     ````console
     dotnet restore
     ````
-5.  Add a *Startup.cs* file that defines the request handling logic:
 
-    [!code-csharp[Main](getting-started/sample/aspnetcoreapp/Startup.cs)]
-
-6.  Update the code in *Program.cs* to setup and start the Web host:
-
-    [!code-csharp[Main](./getting-started/sample/aspnetcoreapp/Program.cs?highlight=2,4,10,11,12,13,14,15)]
-
-7.  Run the app  (the `dotnet run` command will build the app when it's out of date):
+4.  Run the app  (the `dotnet run` command will build the app when it's out of date):
 
     ````console
     dotnet run
     ````
 
-8.  Browse to http://localhost:5000:
-
-    ![image](getting-started/_static/running-output.png)
+5.  Browse to http://localhost:5000:
 
 ## Next steps
 


### PR DESCRIPTION
I followed this documentation and found several steps unnecessary.   

The new command: "dotnet new -t web" will create the asp.net core web application leaving the user to restore and run only.

This simplifies the steps need for a user to get up and running, from 8 steps to 5.

![image](https://cloud.githubusercontent.com/assets/1145888/20269391/cbecaba2-aa7a-11e6-9acf-cffca0bc24ae.png)
