### PR TITLE
fixed bug in linuxproduction systemd service. some other minor change…

### DIFF
--- a/aspnetcore/publishing/apache-proxy.md
+++ b/aspnetcore/publishing/apache-proxy.md
@@ -140,7 +140,7 @@ An example service file for our application.
 ```
 
 > [!NOTE]
-> **User** -- If *apache* is not used by your configuration, the user defined here must be created first and given proper ownership for files
+> **User** -- If the user *apache* is not used by your configuration, the user defined here must be created first and given proper ownership for files
 
 Save the file and enable the service.
 

--- a/aspnetcore/publishing/index.md
+++ b/aspnetcore/publishing/index.md
@@ -20,5 +20,6 @@ ms.prod: aspnet-core
 - [Publishing to an Azure Web App with Continuous Deployment](azure-continuous-deployment.md)
 - [🔧 Publishing to a Windows Virtual Machine on Azure](azure-windows-vm.md)
 - [Publish to a Docker Image](https://azure.microsoft.com/documentation/articles/vs-azure-tools-docker-hosting-web-apps-in-docker)
-- [Publish to a Linux Production Environment (using nginx)](linuxproduction.md)
+- [Publish to a Linux Production Environment (Nginx on Ubuntu)](linuxproduction.md)
+- [Publish to a Linux Production Environment (Apache on CentOS)](apache-proxy.md)
 - [Use VSTS to Build and Publish to an Azure Web App with Continuous Deployment](vsts-continuous-deployment.md)

--- a/aspnetcore/publishing/linuxproduction.md
+++ b/aspnetcore/publishing/linuxproduction.md
@@ -106,10 +106,10 @@ An example service file for our application.
 
 ```text
 [Unit]
-    Description=Example .NET Web API Application running on CentOS 7
+    Description=Example .NET Web API Application running on Ubuntu
 
     [Service]
-    ExecStart=/usr/local/bin/dotnet /var/aspnetcore/hellomvc/hellomvc.dll
+    ExecStart=/usr/bin/dotnet /var/aspnetcore/hellomvc/hellomvc.dll
     Restart=always
     RestartSec=10                                          # Restart service after 10 seconds if dotnet service crashes
     SyslogIdentifier=dotnet-example
@@ -120,7 +120,8 @@ An example service file for our application.
     WantedBy=multi-user.target
 ```
 
->note **User** If *www-data* is not used by your configuration, the user defined here must be created first and given proper ownership for files
+> [!NOTE]
+> **User** -- If the user *www-data* is not used by your configuration, the user defined here must be created first and given proper ownership for files
 
 Save the file and enable the service.
 


### PR DESCRIPTION
…s for consistency, clarity.

linuxproduction.md: systemd service definition file was copied from the apache-proxy.md (CentOS) article but had two mistakes as a result. It said 'CentOS' instead of Ubuntu in a comment, and it gave the location of dotnet as 'usr/local/bin' instead of '/usr/bin' (correct for CentOS but not for Ubuntu, I *think*)
Also made the formatting of the [!NOTE] that follows that codeblock consistent with the apache-proxy article it was reused from.
apache-proxy.md: one time where it said 'apache' it meant 'the username apache' -- and i tried to make this extra clear to help beginners like me.
index.md: added link to the apache-proxy.md article. i think it was just an oversight that this link wasn't included earlier.