### PR TITLE
Fix wildcard accept header

### DIFF
--- a/aspnetcore/mvc/models/formatting.md
+++ b/aspnetcore/mvc/models/formatting.md
@@ -82,7 +82,7 @@ Content *negotiation* only takes place if an `Accept` header appears in the requ
 negotiation taking place - the server is determining what format it will use.
 
 > [!NOTE]
-> If the Accept header contains `/`, the Header will be ignored unless `RespectBrowserAcceptHeader` is set to true on `MvcOptions`.
+> If the Accept header contains `*/*`, the Header will be ignored unless `RespectBrowserAcceptHeader` is set to true on `MvcOptions`.
 
 ### Browsers and Content Negotiation
 


### PR DESCRIPTION
Per [ObjectResultExecutor](https://github.com/aspnet/Mvc/blob/760c8f38678118734399c58c2dac981ea6e47046/src/Microsoft.AspNetCore.Mvc.Core/Internal/ObjectResultExecutor.cs#L265) the `RespectBrowserAcceptHeader` option controls the behaviour when the Accept header includes the `*/*` media type.