### PR TITLE
Add CLA completion link in contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ You'll need a basic understanding of [Git and GitHub.com](https://guides.github.
 * Open an [issue](https://github.com/aspnet/Docs/issues/new) describing what you want to do, such as change an existing article or create a new one. Wait for approval from the ASP.NET documentation team before you invest much time. 
 * Fork the [aspnet/Docs](https://github.com/aspnet/Docs/) repo and create a branch for your changes.
 * Submit a pull request (PR) to master with your changes.
+* If your PR has the label 'cla-required' assigned, [complete the Contribution License Agreement (CLA)](https://cla2.dotnetfoundation.org/)
 * Respond to PR feedback.
 
 ## Markdown syntax


### PR DESCRIPTION
Add the CLA completion link in contributing.md, with others details about complex PR.

I had to complete the CLA and it was difficult to know what the procedure is. On google, you'll find multiple links and posts, all wrong or obsolete : https://www.google.fr/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=CLA+microsoft+github&start=0

The only one good information I found was here : https://github.com/aspnet/Home/blob/dev/CONTRIBUTING.md