### PR TITLE
Fix null reference exception

### DIFF
--- a/aspnetcore/data/ef-mvc/intro/samples/cu/Controllers/DepartmentsController.cs
+++ b/aspnetcore/data/ef-mvc/intro/samples/cu/Controllers/DepartmentsController.cs
@@ -143,7 +143,7 @@ namespace ContosoUniversity.Controllers
                 await TryUpdateModelAsync(deletedDepartment);
                 ModelState.AddModelError(string.Empty,
                     "Unable to save changes. The department was deleted by another user.");
-                ViewData["InstructorID"] = new SelectList(_context.Instructors, "ID", "FullName", departmentToUpdate.InstructorID);
+                ViewData["InstructorID"] = new SelectList(_context.Instructors, "ID", "FullName", deletedDepartment.InstructorID);
                 return View(deletedDepartment);
             }
 


### PR DESCRIPTION
Line 146 runs inside of a block for which departmentToUpdate == null. Therefore, the attempt to read departmentToUpdate.InstructorID leads to a null reference exception.

The code is re-displaying the properties of the deletedDepartment, so the selected member of the select list should be deletedDepartment.InstructorID