### PR TITLE
Fix link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ DocFX requires the .NET Framework on Windows, or Mono for Linux or macOS.
 ### Mono instructions
 
 * Install Mono via Homebrew - `brew install mono`.
-* Download the [latest version of DocFX](https://github.com/dotnet/docfx/releases/tag/v2.7.2).
+* Download the [latest version of DocFX](https://github.com/dotnet/docfx/releases).
 * Extract to `\bin\docfx`.
 * Create an alias for **docfx**:
 


### PR DESCRIPTION
Fix link for latest version of DocFX. now the latest version of DocFX is v2.8.2.
https://github.com/dotnet/docfx/releases/tag/v2.7.2 => https://github.com/dotnet/docfx/releases