### PR TITLE
add a note about UseIdentity() being first in order

### DIFF
--- a/aspnetcore/security/authentication/sociallogins.md
+++ b/aspnetcore/security/authentication/sociallogins.md
@@ -95,6 +95,9 @@ Use the following pages to configure your application to use the respective prov
 * [Microsoft](microsoft-logins.md) instructions
 * [Other provider](other-logins.md) instructions
 
+> [NOTE!]
+> `app.UseIdentity()` call in `Configure()` method in `Startup.cs` file should be listed first before any other external providers.
+
 ## Optionally set password
 
 When you register with an external login provider, you do not have a password registered with the app. This alleviates you from creating and remembering a password for the site, but it also makes you dependent on the external login provider. If the external login provider is unavailable, you won't be able to log in to the web site.

--- a/aspnetcore/security/authentication/sociallogins.md
+++ b/aspnetcore/security/authentication/sociallogins.md
@@ -96,7 +96,7 @@ Use the following pages to configure your application to use the respective prov
 * [Other provider](other-logins.md) instructions
 
 > [NOTE!]
-> `app.UseIdentity()` call in `Configure()` method in `Startup.cs` file should be listed first before any other external providers.
+> Call `app.UseIdentity` (in `Configure()`) before any other external providers.
 
 ## Optionally set password
 

--- a/aspnetcore/security/authentication/sociallogins.md
+++ b/aspnetcore/security/authentication/sociallogins.md
@@ -96,7 +96,7 @@ Use the following pages to configure your application to use the respective prov
 * [Other provider](other-logins.md) instructions
 
 > [NOTE!]
-> Call `app.UseIdentity` (in `Configure()`) before any other external providers.
+> Call `app.UseIdentity` (in `Configure`) before any other external providers.
 
 ## Optionally set password
 


### PR DESCRIPTION
Social Logins page should have a note about calling order according to https://github.com/aspnet/Identity/issues/1036
@Rick-Anderson 