### PR TITLE
Update TOC caching middleware link to title casing

### DIFF
--- a/aspnetcore/performance/caching/toc.md
+++ b/aspnetcore/performance/caching/toc.md
@@ -1,4 +1,4 @@
 # [In Memory Caching](memory.md)
 # [Working with a Distributed Cache](distributed.md)
 # [Response Caching](response.md)
-# [Response caching middleware](middleware.md)
+# [Response Caching Middleware](middleware.md)


### PR DESCRIPTION
I've taken care of this in my branch `middleware.md` doc. I won't sweat the placeholder middeware doc, since that will go away soon.