### PR TITLE
adding dotnet tooling project commandline tip

### DIFF
--- a/aspnetcore/performance/caching/distributed.md
+++ b/aspnetcore/performance/caching/distributed.md
@@ -102,6 +102,9 @@ To use sql-cache tool add SqlConfig.Tools to the tools section of the project.js
 
 [!code-csharp[Main](./distributed/sample/src/DistCacheSample/project.json?highlight=6&range=14-20)]
 
+> [!NOTE]
+> When any of the tools are defined in the project.json file, you must be in the same directory in order to use the tooling commands.
+
 Test SqlConfig.Tools by running the following command
 
 ```none


### PR DESCRIPTION
generally dotnet can be used globally, but i didnt realize that project scoped tools (which makes sense now to me) require the command to be run in the logical root folder of the project to access the referenced tool.
adding a note that other docs have to indicate this requirement to assist those that do not know this.
(other doc that had this helpful note https://github.com/aspnet/Docs/blob/master/aspnetcore/security/app-secrets.md)