### PR TITLE
Fixed reference for AuthMessageSenderOptions

### DIFF
--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -123,7 +123,7 @@ Add the dependency `Microsoft.Extensions.Options.ConfigurationExtensions` in the
 
 Add `AuthMessageSenderOptions` to the service container at the end of the `ConfigureServices` method in the *Startup.cs* file:
 
-[!code-csharp[Main](../../security/authentication/accconfirm/sample/WebApplication3/src/WebApplication3/Startup.cs?highlight=4&range=58-6#L65)]
+[!code-csharp[Main](../../security/authentication/accconfirm/sample/WebApplication3/src/WebApplication3/Startup.cs?highlight=4&range=58-62#L65)]
 
 ### Configure the `AuthMessageSender` class
 

--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -123,7 +123,7 @@ Add the dependency `Microsoft.Extensions.Options.ConfigurationExtensions` in the
 
 Add `AuthMessageSenderOptions` to the service container at the end of the `ConfigureServices` method in the *Startup.cs* file:
 
-[!code-csharp[Main](../../security/authentication/accconfirm/sample/WebApplication3/src/WebApplication3/Startup.cs?highlight=4&range=58-62)]
+[!code-csharp[Main](../../security/authentication/accconfirm/sample/WebApplication3/src/WebApplication3/Startup.cs?highlight=4&range=58-6#L65)]
 
 ### Configure the `AuthMessageSender` class
 


### PR DESCRIPTION
I believe the full url is: https://github.com/aspnet/Docs/blob/master/aspnetcore/security/authentication/accconfirm/sample/WebApplication3/src/WebApplication3/Startup.cs?highlight=4&range=58-6#L65