### PR TITLE
add CommandLine package id comment

### DIFF
--- a/aspnetcore/fundamentals/configuration/sample/src/CommandLine/Program.cs
+++ b/aspnetcore/fundamentals/configuration/sample/src/CommandLine/Program.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 // Add NuGet  <package id="Microsoft.Extensions.Configuration.Binder"
+// Add NuGet  <package id="Microsoft.Extensions.Configuration.CommandLine"
 public class Program
 {
     static public IConfigurationRoot Configuration { get; set; }


### PR DESCRIPTION
To use .AddCommandLine the Microsoft.Extensions.Configuration.CommandLine package needs to be added to dependencies.