### PR TITLE
Highlight the LastName and EnrollmentDate lines

### DIFF
--- a/aspnetcore/data/ef-mvc/sort-filter-page.md
+++ b/aspnetcore/data/ef-mvc/sort-filter-page.md
@@ -56,7 +56,7 @@ The method uses LINQ to Entities to specify the column to sort by. The code crea
 
 Replace the code in *Views/Students/Index.cshtml*, with the following code to rearrange the column order and add column heading hyperlinks. The new column headings are highlighted.
 
-[!code-html[](intro/samples/cu/Views/Students/Index2.cshtml?highlight=16,22)]
+[!code-html[](intro/samples/cu/Views/Students/Index2.cshtml?highlight=16,22,32,38)]
 
 This code uses the information in `ViewData` properties to set up hyperlinks with the appropriate query string values.
 


### PR DESCRIPTION
Highlight the LastName and EnrollmentDate lines that are swapped.  These lines aren't changed, but they are swapped and it took me a second to realize that because they weren't highlighted.  Not sure is you have a policy on lines moving vs. changing and what is highlighted.