### PR TITLE
AddPolicy over21 incorrect brace closer

### DIFF
--- a/aspnetcore/security/authorization/policies.md
+++ b/aspnetcore/security/authorization/policies.md
@@ -31,8 +31,8 @@ public void ConfigureServices(IServiceCollection services)
     {
         options.AddPolicy("Over21",
                           policy => policy.Requirements.Add(new MinimumAgeRequirement(21)));
-    }
-});
+    });
+}
 ```
 
 Here you can see an "Over21" policy is created with a single requirement, that of a minimum age, which is passed as a parameter to the requirement.


### PR DESCRIPTION
code snippet had either 1 too many brace closure (if was just the beginning of the method and remainder was removed for brevity) or the close parenthesis was misplaced.