### PR TITLE
Removed code highlight from Modify the Course...

### DIFF
--- a/aspnetcore/data/ef-mvc/complex-data-model.md
+++ b/aspnetcore/data/ef-mvc/complex-data-model.md
@@ -228,9 +228,9 @@ You could put a `[Required]` attribute on the Instructor navigation property to 
 
 ![Course entity](complex-data-model/_static/course-entity.png)
 
-In *Models/Course.cs*, replace the code you added earlier with the following code:
+In *Models/Course.cs*, replace the code you added earlier with the following code. The changes are highlighted.
 
-[!code-csharp[Main](intro/samples/cu/Models/Course.cs?name=snippet_Final)]
+[!code-csharp[Main](intro/samples/cu/Models/Course.cs?name=snippet_Final&highlight=2,10,13,16,21,23)]
 
 The course entity has a foreign key property `DepartmentID` which points to the related Department entity and it has a `Department` navigation property.
 

--- a/aspnetcore/data/ef-mvc/complex-data-model.md
+++ b/aspnetcore/data/ef-mvc/complex-data-model.md
@@ -230,7 +230,7 @@ You could put a `[Required]` attribute on the Instructor navigation property to 
 
 In *Models/Course.cs*, replace the code you added earlier with the following code:
 
-[!code-csharp[Main](intro/samples/cu/Models/Course.cs?name=snippet_Final&highlight=2,3,10,16,23)]
+[!code-csharp[Main](intro/samples/cu/Models/Course.cs?name=snippet_Final)]
 
 The course entity has a foreign key property `DepartmentID` which points to the related Department entity and it has a `Department` navigation property.
 


### PR DESCRIPTION
Removed the code highlighting from the sample code in Modify The Course Entity.  The highlighting was wrong and the tutorial text doesn't reference it, so I simply removed it.