### PR TITLE
Upgraded Testing Controllers sample solution to .NET Core 1.1

### DIFF
--- a/aspnetcore/mvc/controllers/testing/sample/TestingControllersSample/TestingControllersSample.sln
+++ b/aspnetcore/mvc/controllers/testing/sample/TestingControllersSample/TestingControllersSample.sln
@@ -38,4 +38,7 @@ Global
 		{A15DE1F5-7271-4F68-A76F-B614A6555F76} = {114DA64A-15B8-4375-B14C-E1D0E3C4B8E9}
 		{15760117-9024-4D26-B725-ADBCB53D7E99} = {0434239A-DE4B-4E5D-80BC-A25AB266E82B}
 	EndGlobalSection
+	GlobalSection(CodealikeProperties) = postSolution
+		SolutionGuid = f224ea55-ff97-4312-84b6-a1351b3a51af
+	EndGlobalSection
 EndGlobal

--- a/aspnetcore/mvc/controllers/testing/sample/TestingControllersSample/global.json
+++ b/aspnetcore/mvc/controllers/testing/sample/TestingControllersSample/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "projects": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0-preview2-003121"
+    "version": "1.0.0-preview2-1-003177"
   }
 }

--- a/aspnetcore/mvc/controllers/testing/sample/TestingControllersSample/src/TestingControllersSample/project.json
+++ b/aspnetcore/mvc/controllers/testing/sample/TestingControllersSample/src/TestingControllersSample/project.json
@@ -20,7 +20,7 @@
   },
 
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "portable-net45+win8"
       ]

--- a/aspnetcore/mvc/controllers/testing/sample/TestingControllersSample/tests/TestingControllersSample.Tests/project.json
+++ b/aspnetcore/mvc/controllers/testing/sample/TestingControllersSample/tests/TestingControllersSample.Tests/project.json
@@ -15,7 +15,7 @@
   },
 
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "portable-net451+win8"


### PR DESCRIPTION
Upgraded the [Testing Controller Logic](https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/testing) sample solution to .NET Core 1.1. See issue #2453