### PR TITLE
Fix Bad Link in summary

### DIFF
--- a/aspnetcore/data/ef-mvc/concurrency.md
+++ b/aspnetcore/data/ef-mvc/concurrency.md
@@ -280,7 +280,7 @@ Replace the code in *Views/Departments/Create.cshtml* to add a Select option to 
 
 ## Summary
 
-This completes the introduction to handling concurrency conflicts. For more information about how to handle concurrency in EF Core, see [Concurrency conflicts](https://ef.readthedocs.io/en/latest/saving/concurrency.html). The next tutorial shows how to implement table-per-hierarchy inheritance for the Instructor and Student entities.
+This completes the introduction to handling concurrency conflicts. For more information about how to handle concurrency in EF Core, see [Concurrency conflicts](https://docs.microsoft.com/en-us/ef/core/saving/concurrency). The next tutorial shows how to implement table-per-hierarchy inheritance for the Instructor and Student entities.
 
 >[!div class="step-by-step"]
 [Previous](update-related-data.md)


### PR DESCRIPTION
Link in summary is to old docs site. updated to point to the new doc site for core.