### PR TITLE
error occurs when using MvcOptions

### DIFF
--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -72,6 +72,8 @@ services.Configure<MvcOptions>(options =>
     options.Filters.Add(new RequireHttpsAttribute ());
 });
 ```
+> [!Note]
+> If you get an error for `[services.Configure<MvcOptions>]` You can resolve this by adding the `[using Microsoft.AspNetCore.Mvc;]`  namespace.
 
 Add the `[RequireHttps]` attribute to each controller. The `[RequireHttps]` attribute will redirect all HTTP GET requests to HTTPS GET and will reject all HTTP POSTs. A security best practice is to use HTTPS for all requests.
 

--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -72,8 +72,7 @@ services.Configure<MvcOptions>(options =>
     options.Filters.Add(new RequireHttpsAttribute ());
 });
 ```
-> [!Note]
-> If you get an error for `[services.Configure<MvcOptions>]` You can resolve this by adding the `[using Microsoft.AspNetCore.Mvc;]`  namespace.
+ `[services.Configure<MvcOptions>]` requires `[using Microsoft.AspNetCore.Mvc;]`.
 
 Add the `[RequireHttps]` attribute to each controller. The `[RequireHttps]` attribute will redirect all HTTP GET requests to HTTPS GET and will reject all HTTP POSTs. A security best practice is to use HTTPS for all requests.
 


### PR DESCRIPTION
When following the guide and adding the service.configure for mvcoptions a compile error occurs using a base .netcore mvc project.
The startup.cs file by default does not include the declaration for the namespace microsoft.aspnetcore.mvc which resolves the compile error.
Added a note section below the code block stating if you recieve an error you may need to add the delcaration