### PR TITLE
Reference for code in file incorrect

### DIFF
--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -123,7 +123,7 @@ Add the dependency `Microsoft.Extensions.Options.ConfigurationExtensions` in the
 
 Add `AuthMessageSenderOptions` to the service container at the end of the `ConfigureServices` method in the *Startup.cs* file:
 
-[!code-csharp[Main](../../security/authentication/accconfirm/sample/WebApplication3/src/WebApplication3/Startup.cs?highlight=4&range=58-62)]
+[!code-csharp[Main](../../security/authentication/accconfirm/sample/WebApplication3/src/WebApplication3/Startup.cs?highlight=4&range=62-65)]
 
 ### Configure the `AuthMessageSender` class
 


### PR DESCRIPTION
For the Code block relating to Configure startup to use AuthMessageSenderOptions the referenced line numbers have changed since this page was updated. Edited the line numbers to properly reference the correct lines