### PR TITLE
Middleware doc update

### DIFF
--- a/aspnetcore/fundamentals/middleware.md
+++ b/aspnetcore/fundamentals/middleware.md
@@ -165,13 +165,13 @@ The [CodeLabs middleware tutorial](https://github.com/Microsoft-Build-2016/CodeL
 
 For more complex request handling functionality, the ASP.NET team recommends implementing the middleware in its own class and exposing an `IApplicationBuilder` extension method that can be called from the `Configure` method. The simple logging middleware shown in the previous example can be converted into a middleware class that takes in the next `RequestDelegate` in its constructor and supports an `Invoke` method as shown:
 
-RequestLoggerMiddleware.cs
+*RequestLoggerMiddleware.cs*
 
 [!code-csharp[Main](../fundamentals/middleware/sample/src/MiddlewareSample/RequestLoggerMiddleware.cs?highlight=12,18)]
 
 Middleware should follow the [Explicit Dependencies Principle](http://deviq.com/explicit-dependencies-principle/) by exposing its dependencies in its constructor. Middleware is constructed once per *application lifetime*. See *Per-request dependencies* below if you need to share services with middleware within a request. Use the `UseMiddleware<T>` extension to inject services directly into their constructors (shown in the example below).
 
-RequestLoggerExtensions.cs
+*RequestLoggerExtensions.cs*
 
 [!code-csharp[Main](../fundamentals/middleware/sample/src/MiddlewareSample/RequestLoggerExtensions.cs?name=snippet1&highlight=5)]
 

--- a/aspnetcore/fundamentals/middleware.md
+++ b/aspnetcore/fundamentals/middleware.md
@@ -1,8 +1,8 @@
 ---
 title: Middleware | Microsoft Docs
 author: ardalis
-description: 
-keywords: ASP.NET Core,
+description: The HTTP request handling pipeline of an ASP.NET Core app is specified by easily customizable software components called middleware.
+keywords: ASP.NET Core, middleware, pipeline
 ms.author: riande
 manager: wpickett
 ms.date: 10/14/2016
@@ -14,19 +14,17 @@ uid: fundamentals/middleware
 ---
 # Middleware
 
-<a name=fundamentals-middleware></a>
-
 By [Steve Smith](http://ardalis.com) and [Rick Anderson](https://twitter.com/RickAndMSFT)
 
 [View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/fundamentals/middleware/sample)
 
-## What is middleware
+## What is middleware?
 
 Middleware are software components that are assembled into an application pipeline to handle requests and responses. Each component chooses whether to pass the request on to the next component in the pipeline, and can perform certain actions before and after the next component is invoked in the pipeline. Request delegates are used to build the request pipeline. The request delegates handle each HTTP request.
 
-Request delegates are configured using `Run`, `Map`, and `Use` extension methods on the `IApplicationBuilder` type that is passed into the `Configure` method in the `Startup` class. An individual request delegate can be specified in-line as an anonymous method,or it can be defined in a reusable class. These reusable classes  are *middleware*, or *middleware components*. Each middleware component in the request pipeline is responsible for invoking the next component in the pipeline, or short-circuiting the chain if appropriate.
+Request delegates are configured using `Run`, `Map`, and `Use` extension methods on the `IApplicationBuilder` type that is passed into the `Configure` method in the `Startup` class. An individual request delegate can be specified in-line as an anonymous method, or it can be defined in a reusable class. These reusable classes are *middleware*, or *middleware components*. Each middleware component in the request pipeline is responsible for invoking the next component in the pipeline, or short-circuiting the chain if appropriate.
 
-[Migrating HTTP Modules to Middleware](../migration/http-modules.md) explains the difference between request pipelines in ASP.NET Core and the previous versions and provides more middleware samples.
+[Migrating HTTP Modules to Middleware](xref:migration/http-modules) explains the difference between request pipelines in ASP.NET Core and the previous versions and provides more middleware samples.
 
 ## Creating a middleware pipeline with IApplicationBuilder
 
@@ -34,7 +32,7 @@ The ASP.NET request pipeline consists of a sequence of request delegates, called
 
 ![Request processing pattern showing a request arriving, processing through three middlewares, and the response leaving the application. Each middleware runs its logic and hands off the request to the next middleware at the next() statement. After the third middleware processes the request, it's handed back through the prior two middlewares for additional processing after the next() statements each in turn before leaving the application as a response to the client.](middleware/_static/request-delegate-pipeline.png)
 
-Each delegate has the opportunity to perform operations before and after the next delegate. Any delegate can choose to stop passing the request on to the next delegate, and instead handle the request itself. This is referred to as short-circuiting the request pipeline, and is desirable because it allows unnecessary work to be avoided. For example, an authorization middleware might only call the next delegate if the request is authenticated; otherwise it could short-circuit the pipeline and return a "Not Authorized" response. Exception handling delegates need to be called early on in the pipeline, so they are able to catch exceptions that occur in deeper calls within the pipeline.
+Each delegate has the opportunity to perform operations before and after the next delegate. Any delegate can choose to stop passing the request on to the next delegate, and instead handle the request itself. This is referred to as short-circuiting the request pipeline, and is desirable because it allows unnecessary work to be avoided. For example, an authorization middleware might only call the next delegate if the request is authenticated; otherwise, it could short-circuit the pipeline and return a "Not Authorized" response. Exception handling delegates need to be called early on in the pipeline, so they are able to catch exceptions that occur in deeper calls within the pipeline.
 
 You can see an example of setting up the request pipeline in the default web site template that ships with Visual Studio 2015. The `Configure` method adds the following middleware components:
 
@@ -47,15 +45,14 @@ You can see an example of setting up the request pipeline in the default web sit
 
 In the code above (in non-development environments), `UseExceptionHandler` is the first middleware added to the pipeline, therefore will catch any exceptions that occur in later calls.
 
-The `static file module` provides no authorization checks. Any files served by it, including those under *wwwroot* are publicly available. If you want to serve files based on authorization:
+The `static file module` provides no authorization checks. Any files served by it, including those under *wwwroot*, are publicly available. If you want to serve files based on authorization:
 
 1. Store them outside of *wwwroot* and any directory accessible to the static file middleware.
-
 2. Deliver them through a controller action, returning a `FileResult` where authorization is applied.
 
-A request that is handled by the static file module will short circuit the pipeline. (see [Working with Static Files](static-files.md).) If the request is not handled by the static file module, it's passed on to the `Identity module`, which performs authentication. If the request is not authenticated, the pipeline is short circuited. If the request does not fail authentication, the last stage of this pipeline is called, which is the MVC framework.
+A request that is handled by the static file module will short circuit the pipeline (see [Working with Static Files](xref:fundamentals/static-files)). If the request is not handled by the static file module, it's passed on to the `Identity module`, which performs authentication. If the request is not authenticated, the pipeline is short circuited. If the request does not fail authentication, the last stage of this pipeline is called, which is the MVC framework.
 
-The simplest possible ASP.NET application sets up a single request delegate that handles all requests. In this case, there isn't really a request "pipeline", so much as a single anonymous function that is called in response to every HTTP request.
+The simplest possible ASP.NET application sets up a single request delegate that handles all requests. In this case, there isn't really a request "pipeline" so much as a single anonymous function that is called in response to every HTTP request.
 
 [!code-csharp[Main](middleware/sample/src/MiddlewareSample/Startup.cs?start=23&end=26)]
 
@@ -68,10 +65,10 @@ You chain multiple request delegates together; the `next` parameter represents t
 [!code-csharp[Main](middleware/sample/src/MiddlewareSample/Startup.cs?highlight=5,8,14&start=34&end=49)]
 
 >[!WARNING]
-> Avoid modifying `HttpResponse` after invoking next, one of the next components in the pipeline may have written to the response, causing it to be sent to the client.
+> Avoid modifying `HttpResponse` after invoking next, as one of the next components in the pipeline may have written to the response, causing it to be sent to the client.
 
 > [!NOTE]
-> This `ConfigureLogInline` method is called when the application is run with an environment set to `LogInline`. Learn more about [Working with Multiple Environments](environments.md). We will be using variations of `Configure[Environment]` to show different options in the rest of this article. The easiest way to run the samples in Visual Studio is with the `web` command, which is configured in *project.json*. See also [Application Startup](startup.md).
+> This `ConfigureLogInline` method is called when the application is run with an environment set to `LogInline`. Learn more about [Working with Multiple Environments](xref:fundamentals/environments). We will be using variations of `Configure[Environment]` to show different options in the rest of this article. The easiest way to run the samples in Visual Studio is with the `web` command, which is configured in *project.json*. See also [Application Startup](xref:fundamentals/startup).
 
 In the above example, the call to `await next.Invoke()` will call into the next delegate `await context.Response.WriteAsync("Hello from " + _environment);`. The client will receive the expected response ("Hello from LogInline"), and the server's console output includes both the before and after messages:
 
@@ -79,9 +76,9 @@ In the above example, the call to `await next.Invoke()` will call into the next 
 
 ## Middleware ordering
 
-The order in which you add middleware components is generally the order in which they take effect on the request, and then in reverse for the response. This can be critical to your app’s security, performance, and functionality. In the code above where the Static File Middleware was used with authentication middleware, the Static File Middleware is called early in the pipeline so it can handle requests and short circuit without going through unnecessary components. The authentication middleware is added to the pipeline before anything that handles requests for secure resources. Exception handling must be registered before other middleware components in order to catch exceptions thrown by those components.
+The order in which you add middleware components is generally the order in which they take effect on the request, and they execute in reverse for the response. This can be critical to your app's security, performance, and functionality. In the code above where the Static File Middleware was used with authentication middleware, the Static File Middleware is called early in the pipeline to handle requests and short circuit without going through unnecessary components. The authentication middleware is added to the pipeline before anything that handles requests for secure resources. Exception handling must be registered before other middleware components in order to catch exceptions thrown by those components.
 
-The following example demonstrates a middleware arrangement where requests for static files are fully handled by the Static File Middleware before Response Compression Middleware could ever see the request. Static files cannot be compressed with this ordering of the middleware, but the MVC output downstream of the Response Compression Middleware can be compressed.
+The following example demonstrates a middleware arrangement where requests for static files are fully handled by the Static File Middleware before Response Compression Middleware can see the request. Static files aren't compressed with this ordering of the middleware, but the MVC output downstream of the Response Compression Middleware can be compressed.
 
 ```csharp
 public void Configure(IApplicationBuilder app)
@@ -112,9 +109,9 @@ You configure the HTTP pipeline using `Run`, `Map`,  and `Use`. The `Run` method
 [!code-csharp[Main](middleware/sample/src/MiddlewareSample/Startup.cs?highlight=3,11&start=65&end=79)]
 
 > [!NOTE]
-> The `IApplicationBuilder` interface exposes a single `Use` method, so technically they're not all *extension* methods.
+> The `IApplicationBuilder` interface exposes a single `Use` method; so technically, they're not all *extension* methods.
 
-We've already seen several examples of how to build a request pipeline with `Use`. `Map*` extensions are used as a convention for branching the pipeline. The current implementation supports branching based on the request's path, or using a predicate. The `Map` extension method is used to match request delegates based on a request's path. `Map` simply accepts a path and a function that configures a separate middleware pipeline. In the following example, any request with the base path of `/maptest` will be handled by the pipeline configured in the `HandleMapTest` method.
+We've already seen several examples of how to build a request pipeline with `Use`. `Map*` extensions are used as a convention for branching the pipeline. The current implementation supports branching based on the request's path or using a predicate. The `Map` extension method is used to match request delegates based on a request's path. `Map` simply accepts a path and a function that configures a separate middleware pipeline. In the following example, any request with the base path of `/maptest` will be handled by the pipeline configured in the `HandleMapTest` method:
 
 [!code-csharp[Main](middleware/sample/src/MiddlewareSample/Startup.cs?highlight=11&start=81&end=93)]
 
@@ -129,18 +126,18 @@ Using the configuration shown above, any request that includes a query string va
 
 You can also nest Maps:
 
-```javascript
+```csharp
 app.Map("/level1", level1App => {
-       level1App.Map("/level2a", level2AApp => {
-           // "/level1/level2a"
-           //...
-       });
-       level1App.Map("/level2b", level2BApp => {
-           // "/level1/level2b"
-           //...
-       });
-   });
-   ```
+    level1App.Map("/level2a", level2AApp => {
+        // "/level1/level2a"
+        ...
+    });
+    level1App.Map("/level2b", level2BApp => {
+        // "/level1/level2b"
+        ...
+    });
+});
+```
 
 ## Built-in middleware
 
@@ -151,24 +148,21 @@ ASP.NET ships with the following middleware components:
 | [Authentication](xref:security/authentication/identity) | Provides authentication support. |
 | [CORS](xref:security/cors) | Configures Cross-Origin Resource Sharing. |
 | [Response Caching](xref:performance/caching/middleware) | Provides support for caching responses. |
-| Response Compression | Provides support for compressing responses. |
+| [Response Compression](xref:performance/response-compression) | Provides support for compressing responses. |
 | [Routing](xref:fundamentals/routing) | Defines and constrains request routes. |
 | [Session](xref:fundamentals/app-state) | Provides support for managing user sessions. |
 | [Static Files](xref:fundamentals/static-files) | Provides support for serving static files and directory browsing. |
 | [URL Rewriting Middleware](xref:fundamentals/url-rewriting) | Provides support for rewriting URLs and redirecting requests. |
 
-<a name=middleware-writing-middleware></a>
-
 ## Writing middleware
 
 The [CodeLabs middleware tutorial](https://github.com/Microsoft-Build-2016/CodeLabs-WebDev/tree/master/Module2-AspNetCore) provides a good introduction to writing middleware.
 
-For more complex request handling functionality, the ASP.NET team recommends implementing the middleware in its own class, and exposing an `IApplicationBuilder` extension method that can be called from the `Configure` method. The simple logging middleware shown in the previous example can be converted into a middleware class that takes in the next `RequestDelegate` in its constructor and supports an `Invoke` method as shown:
+For more complex request handling functionality, the ASP.NET team recommends implementing the middleware in its own class and exposing an `IApplicationBuilder` extension method that can be called from the `Configure` method. The simple logging middleware shown in the previous example can be converted into a middleware class that takes in the next `RequestDelegate` in its constructor and supports an `Invoke` method as shown:
 
 RequestLoggerMiddleware.cs
 
 [!code-csharp[Main](../fundamentals/middleware/sample/src/MiddlewareSample/RequestLoggerMiddleware.cs?highlight=12,18)]
-
 
 Middleware should follow the [Explicit Dependencies Principle](http://deviq.com/explicit-dependencies-principle/) by exposing its dependencies in its constructor. Middleware is constructed once per *application lifetime*. See *Per-request dependencies* below if you need to share services with middleware within a request. Use the `UseMiddleware<T>` extension to inject services directly into their constructors (shown in the example below).
 
@@ -193,7 +187,7 @@ Testing the middleware (by setting the `Hosting:Environment` environment variabl
 
 Because middleware are constructed at app startup, not per-request, *scoped* lifetime services used by middleware constructors will not be shared with other dependency-injected types during each request. If you need to share a *scoped* service between your middleware and other types, you should add these services to the `Invoke` method's signature. The `Invoke` method can accept additional parameters that will be populated by dependency injection. For example:
 
-```c#
+```csharp
 public class MyMiddleware
 {
     private readonly RequestDelegate _next;
@@ -211,14 +205,14 @@ public class MyMiddleware
 }
 ```
 
-## Additional Resources
+## Additional resources
 
 * [CodeLabs middleware tutorial](https://github.com/Microsoft-Build-2016/CodeLabs-WebDev/tree/master/Module2-AspNetCore)
 
 * [Sample code used in this doc](https://github.com/aspnet/Docs/tree/master/aspnetcore/fundamentals/middleware/sample)
 
-* [Migrating HTTP Modules to Middleware](../migration/http-modules.md)
+* [Migrating HTTP Modules to Middleware](xref:migration/http-modules)
 
-* [Application Startup](startup.md)
+* [Application Startup](xref:fundamentals/startup)
 
-* [Request Features](request-features.md)
+* [Request Features](xref:fundamentals/request-features)

--- a/aspnetcore/fundamentals/middleware/sample/src/MiddlewareSample/RequestLoggerExtensions.cs
+++ b/aspnetcore/fundamentals/middleware/sample/src/MiddlewareSample/RequestLoggerExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 
 namespace MiddlewareSample
 {
+    #region snippet1
     public static class RequestLoggerExtensions
     {
         public static IApplicationBuilder UseRequestLogger(this IApplicationBuilder builder)
@@ -9,4 +10,5 @@ namespace MiddlewareSample
             return builder.UseMiddleware<RequestLoggerMiddleware>();
         }
     }
+    #endregion
 }

--- a/aspnetcore/fundamentals/middleware/sample/src/MiddlewareSample/Startup.cs
+++ b/aspnetcore/fundamentals/middleware/sample/src/MiddlewareSample/Startup.cs
@@ -54,8 +54,7 @@ namespace MiddlewareSample
         #endregion
 
         #region snippet6
-        public void ConfigureLogMiddleware(IApplicationBuilder app,
-            ILoggerFactory loggerfactory)
+        public void ConfigureLogMiddleware(IApplicationBuilder app, ILoggerFactory loggerfactory)
         {
             loggerfactory.AddConsole(minLevel: LogLevel.Information);
 

--- a/aspnetcore/fundamentals/middleware/sample/src/MiddlewareSample/Startup.cs
+++ b/aspnetcore/fundamentals/middleware/sample/src/MiddlewareSample/Startup.cs
@@ -9,6 +9,7 @@ namespace MiddlewareSample
     public class Startup
     {
         private readonly string _environment;
+        
         public Startup(IHostingEnvironment env)
         {
             _environment = env.EnvironmentName;
@@ -18,6 +19,7 @@ namespace MiddlewareSample
         {
         }
 
+        #region snippet1
         public void Configure(IApplicationBuilder app)
         {
             app.Run(async context =>
@@ -30,7 +32,9 @@ namespace MiddlewareSample
                 await context.Response.WriteAsync("Hello, World, Again!");
             });
         }
+        #endregion
 
+        #region snippet2
         public void ConfigureLogInline(IApplicationBuilder app, ILoggerFactory loggerfactory)
         {
             loggerfactory.AddConsole(minLevel: LogLevel.Information);
@@ -47,7 +51,9 @@ namespace MiddlewareSample
                 await context.Response.WriteAsync("Hello from " + _environment);
             });
         }
+        #endregion
 
+        #region snippet6
         public void ConfigureLogMiddleware(IApplicationBuilder app,
             ILoggerFactory loggerfactory)
         {
@@ -60,8 +66,9 @@ namespace MiddlewareSample
                 await context.Response.WriteAsync("Hello from " + _environment);
             });
         }
+        #endregion
 
-
+        #region snippet3
         public void ConfigureEnvironmentOne(IApplicationBuilder app)
         {
             app.Run(async context =>
@@ -77,7 +84,9 @@ namespace MiddlewareSample
                 await context.Response.WriteAsync("Hello from " + _environment);
             });
         }
+        #endregion
 
+        #region snippet4
         private static void HandleMapTest(IApplicationBuilder app)
         {
             app.Run(async context =>
@@ -91,7 +100,9 @@ namespace MiddlewareSample
             app.Map("/maptest", HandleMapTest);
 
         }
+        #endregion
 
+        #region snippet5
         private static void HandleBranch(IApplicationBuilder app)
         {
             app.Run(async context =>
@@ -111,5 +122,6 @@ namespace MiddlewareSample
                 await context.Response.WriteAsync("Hello from " + _environment);
             });
         }
+        #endregion
     }
 }

--- a/aspnetcore/fundamentals/middleware/sample/src/MiddlewareSample/Startup.cs
+++ b/aspnetcore/fundamentals/middleware/sample/src/MiddlewareSample/Startup.cs
@@ -97,7 +97,6 @@ namespace MiddlewareSample
         public void ConfigureMapping(IApplicationBuilder app)
         {
             app.Map("/maptest", HandleMapTest);
-
         }
         #endregion
 

--- a/aspnetcore/migration/http-modules.md
+++ b/aspnetcore/migration/http-modules.md
@@ -96,7 +96,7 @@ As shown in the [Middleware](../fundamentals/middleware.md) page, an ASP.NET Cor
 
 [!code-csharp[Main](../migration/http-modules/sample/Asp.Net.Core/Middleware/MyMiddleware.cs?highlight=9,13,20,24,28,30,32)]
 
-The above middleware template was taken from the section on [writing middleware](../fundamentals/middleware.md#middleware-writing-middleware).
+The above middleware template was taken from the section on [writing middleware](xref:fundamentals/middleware#writing-middleware).
 
 The *MyMiddlewareExtensions* helper class makes it easier to configure your middleware in your `Startup` class. The `UseMyMiddleware` method adds your middleware class to the request pipeline. Services required by the middleware get injected in the middleware's constructor.
 

--- a/aspnetcore/security/authentication/cookie.md
+++ b/aspnetcore/security/authentication/cookie.md
@@ -16,7 +16,7 @@ uid: security/authentication/cookie
 
 <a name=security-authentication-cookie-middleware></a>
 
-ASP.NET Core provides cookie [middleware](../../fundamentals/middleware.md#fundamentals-middleware) which serializes a user principal into an encrypted cookie and then, on subsequent requests, validates the cookie, recreates the principal and assigns it to the `User` property on `HttpContext`. If you want to provide your own login screens and user databases you can use the cookie middleware as a standalone feature.
+ASP.NET Core provides cookie [middleware](xref:fundamentals/middleware) which serializes a user principal into an encrypted cookie and then, on subsequent requests, validates the cookie, recreates the principal and assigns it to the `User` property on `HttpContext`. If you want to provide your own login screens and user databases you can use the cookie middleware as a standalone feature.
 
 <a name=security-authentication-cookie-middleware-configuring></a>
 


### PR DESCRIPTION
I came in to add the link for the new Response Compression doc to the *Built-in middleware* section, and I also hit the usual bits while I was here:
* header casing
* codeblocks
* non-italic filenames
* description+keywords
* xref links
* I converted anchoring, along with associated docs, over to header anchors.