### PR TITLE
Update service file to set WorkingDirectory

### DIFF
--- a/aspnetcore/publishing/linuxproduction.md
+++ b/aspnetcore/publishing/linuxproduction.md
@@ -122,6 +122,7 @@ An example service file for our application.
     Description=Example .NET Web API Application running on Ubuntu
 
     [Service]
+    WorkingDirectory=/var/aspnetcore/hellomvc
     ExecStart=/usr/bin/dotnet /var/aspnetcore/hellomvc/hellomvc.dll
     Restart=always
     RestartSec=10                                          # Restart service after 10 seconds if dotnet service crashes


### PR DESCRIPTION
Since the ASP.NET Core application is run from /etc/systemd/system directory, the working directory is no longer /var/aspnetcore/hellomvc. Update the service file to set WorkingDirectory=/var/aspnetcore/hellomvc so that the program will run. Otherwise, users will get System.IO.FileNotFoundException when using systemd to monitor and run ASP.NET Core application.