### PR TITLE
Update Response Compression Sample

### DIFF
--- a/aspnetcore/performance/response-compression/sample/ResponseCompressionSample.csproj
+++ b/aspnetcore/performance/response-compression/sample/ResponseCompressionSample.csproj
@@ -23,8 +23,4 @@
     <PackageReference Include="Microsoft.NETCore.App" Version="1.1.0" />
   </ItemGroup>
 
-  <Target Name="CreateLogsFolder" AfterTargets="AfterPublish">
-    <MakeDir Directories="$(PublishDir)logs" Condition="!Exists('$(PublishDir)logs')" />
-  </Target>
-
 </Project>


### PR DESCRIPTION
@tdykstra This one can go in now. It merely removes the bit that creates a `Logs` folder in published output. It isn't in the templates, so I shouldn't have had it in there in the first place (except it is awfully handy for when you need to flip on stdout logging).