### PR TITLE
enable local builds in aspnet folder

### DIFF
--- a/aspnet/.gitignore
+++ b/aspnet/.gitignore
@@ -1,0 +1,2 @@
+_build/
+_site/

--- a/aspnet/docfx.json
+++ b/aspnet/docfx.json
@@ -35,7 +35,13 @@
     ],
     "overwrite": [],
     "externalReference": [],
-    "globalMetadata": { "breadcrumb_path": "/aspnet/breadcrumb/toc.json" },
+    "globalMetadata": {
+      "breadcrumb_path": "/aspnet/breadcrumb/toc.json",
+      /* Setting navPath and navRel eliminates screen-filling TOC when running local builds using "docfx -t default --serve" */
+      "_navPath": "/foo",
+      "_navRel": "/foo",
+      "searchScope": ["ASP.NET"]
+    },
     "fileMetadata": {},
     "template": [],
     "dest": "_site"

--- a/aspnet/docfx.json
+++ b/aspnet/docfx.json
@@ -37,7 +37,6 @@
     "externalReference": [],
     "globalMetadata": {
       "breadcrumb_path": "/aspnet/breadcrumb/toc.json",
-      /* Setting navPath and navRel eliminates screen-filling TOC when running local builds using "docfx -t default --serve" */
       "_navPath": "/foo",
       "_navRel": "/foo",
       "searchScope": ["ASP.NET"]

--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -34,7 +34,6 @@
     "externalReference": [],
     "globalMetadata": {
       "breadcrumb_path": "/aspnet/breadcrumb/toc.json",
-      /* Setting navPath and navRel eliminates screen-filling TOC when running local builds using "docfx -t default --serve" */
       "_navPath": "/foo",
       "_navRel": "/foo",
       "searchScope": ["ASP.NET Core"]

--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -11,7 +11,8 @@
           "**/samples/**",
           "aspnet/**",
           "**/includes/**",
-          "**/aspnet-core-conceptual/**"
+          "**/aspnet-core-conceptual/**",
+          "_site/**"
         ]
       }
     ],
@@ -33,6 +34,7 @@
     "externalReference": [],
     "globalMetadata": {
       "breadcrumb_path": "/aspnet/breadcrumb/toc.json",
+      /* Setting navPath and navRel eliminates screen-filling TOC when running local builds using "docfx -t default --serve" */
       "_navPath": "/foo",
       "_navRel": "/foo",
       "searchScope": ["ASP.NET Core"]


### PR DESCRIPTION
@Rick-Anderson please review and merge

I also added _site and _build to the empty aspnet folder .gitignore.  However, when we have an opportunity we should delete this file and find out what it is in the main .gitignore that was causing problems and fix it there.