### PR TITLE
Update getting-started.md for a .NET tooling change

### DIFF
--- a/aspnetcore/getting-started.md
+++ b/aspnetcore/getting-started.md
@@ -21,7 +21,7 @@ uid: getting-started
     ```console
     mkdir aspnetcoreapp
     cd aspnetcoreapp
-    dotnet new -t web
+    dotnet new web
     ```
 
 3.  Restore the packages:


### PR DESCRIPTION
dotnet new -t web is no longer valid, using dotnet new web instead.