### PR TITLE
Properly escape special characters in MVC Areas doc

### DIFF
--- a/aspnetcore/mvc/controllers/areas.md
+++ b/aspnetcore/mvc/controllers/areas.md
@@ -141,7 +141,7 @@ Set up a route definition that works with your newly created areas. The [🔧 Ro
    });
    ```
 
-Browsing to *http://<yourApp>/products*, the `Index` action method of the `HomeController` in the `Products` area will be invoked.
+Browsing to `http://<yourApp>/products`, the `Index` action method of the `HomeController` in the `Products` area will be invoked.
 
 ## Link Generation
 


### PR DESCRIPTION
The MVC Areas doc is displaying _http:///products_ instead of _http://\<yourApp\>/products_. This PR addresses the problem by escaping the less than and greater than characters.