### PR TITLE
Update dotnet CLI syntax for adding packages

### DIFF
--- a/aspnetcore/security/authentication/social/facebook-logins.md
+++ b/aspnetcore/security/authentication/social/facebook-logins.md
@@ -87,7 +87,7 @@ The following code reads the configuration values stored by the [Secret Manager]
 > [!NOTE]
 > You will need to use NuGet to install the [Microsoft.AspNetCore.Authentication.Facebook](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Facebook) package if it hasn't already been installed. Alternatively, execute the following commands in your project directory:
 >
-> `dotnet install Microsoft.AspNetCore.Authentication.Facebook`
+> `dotnet add package Microsoft.AspNetCore.Authentication.Facebook`
 
 Add the Facebook middleware in the `Configure` method in `Startup.cs`:
 

--- a/aspnetcore/security/authentication/social/google-logins.md
+++ b/aspnetcore/security/authentication/social/google-logins.md
@@ -103,7 +103,7 @@ The following code reads the configuration values stored by the [Secret Manager]
 > [!NOTE]
 > Use NuGet to install the [Microsoft.AspNetCore.Authentication.Google](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Google) package if it hasn't already been installed. Alternatively, execute the following commands in your project directory:
 >
-> `dotnet install Microsoft.AspNetCore.Authentication.Google`
+> `dotnet add package Microsoft.AspNetCore.Authentication.Google`
 
 Add the Google middleware in the `Configure` method in `Startup.cs`:
 

--- a/aspnetcore/security/authentication/social/microsoft-logins.md
+++ b/aspnetcore/security/authentication/social/microsoft-logins.md
@@ -88,7 +88,7 @@ The following code reads the configuration values stored by the [Secret Manager]
 > [!NOTE]
 > Use NuGet to install the [Microsoft.AspNetCore.Authentication.MicrosoftAccount](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.MicrosoftAccount) package if it hasn't already been installed. Alternatively, execute the following commands in your project directory:
 >
-> `dotnet install Microsoft.AspNetCore.Authentication.MicrosoftAccount`
+> `dotnet add package Microsoft.AspNetCore.Authentication.MicrosoftAccount`
 
 Add the Microsoft Account middleware in the `Configure` method in `Startup.cs`:
 

--- a/aspnetcore/security/authentication/social/twitter-logins.md
+++ b/aspnetcore/security/authentication/social/twitter-logins.md
@@ -68,7 +68,7 @@ The following code reads the configuration values stored by the [Secret Manager]
 > [!NOTE]
 > Use NuGet to install the [Microsoft.AspNetCore.Authentication.Twitter](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Twitter) package if it hasn't already been installed. Alternatively, execute the following commands in your project directory:
 >
-> `dotnet install Microsoft.AspNetCore.Authentication.Twitter`
+> `dotnet add package Microsoft.AspNetCore.Authentication.Twitter`
 
 Add the Twitter middleware in the `Configure` method in `Startup.cs`:
 


### PR DESCRIPTION
It looks like the latest dotnet cli syntax for adding packages is "dotnet add package <packagename>" (http://ardalis.com/how-to-add-a-nuget-package-using-dotnet-add).