### PR TITLE
Add in-text note for offline VC++ redist install to Publishing to IIS

### DIFF
--- a/aspnetcore/publishing/iis.md
+++ b/aspnetcore/publishing/iis.md
@@ -50,7 +50,7 @@ Proceed through the **Confirmation** step to install the web server role and ser
 
 ## Install the .NET Core Windows Server Hosting bundle
 
-1. Install the [.NET Core Windows Server Hosting](https://go.microsoft.com/fwlink/?linkid=837808) bundle on the server. The bundle will install the .NET Core Runtime, .NET Core Library, and the [ASP.NET Core Module](../fundamentals/servers/aspnet-core-module.md). The module creates the reverse-proxy between IIS and the Kestrel server.
+1. Install the [.NET Core Windows Server Hosting](https://go.microsoft.com/fwlink/?linkid=837808) bundle on the server. The bundle will install the .NET Core Runtime, .NET Core Library, and the [ASP.NET Core Module](../fundamentals/servers/aspnet-core-module.md). The module creates the reverse-proxy between IIS and the Kestrel server. Note: If the server doesn't have an Internet connection, obtain and install the *[Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=53840)* before installing the .NET Core Windows Server Hosting bundle.
 
 2. Restart the server or execute **net stop was /y** followed by **net start w3svc** from a command prompt to pick up a change to the system PATH.
 
@@ -255,7 +255,7 @@ The following is not a complete list of errors. Should you encounter an error no
 
 Troubleshooting:
 
-* If the server does not have Internet access while installing the server hosting bundle, this exception will occur when the installer is prevented from obtaining the *Microsoft Visual C++ 2015 Redistributable (x64)*. You may obtain an installer from the [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=53840). If the installer fails, you may not receive the .NET Core runtime required to host framework-dependent deployments. If you plan to host framework-dependent deployments, confirm that the runtime is installed in Programs &amp; Features. You may obtain a runtime installer from [.NET Downloads](https://www.microsoft.com/net/download/core). After installing the runtime, restart the server or restart IIS by executing **net stop was /y** followed by **net start w3svc** from a command prompt.
+* If the server does not have Internet access while installing the server hosting bundle, this exception will occur when the installer is prevented from obtaining the *Microsoft Visual C++ 2015 Redistributable*. You may obtain an installer from the [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=53840). If the installer fails, you may not receive the .NET Core runtime required to host framework-dependent deployments. If you plan to host framework-dependent deployments, confirm that the runtime is installed in Programs &amp; Features. You may obtain a runtime installer from [.NET Downloads](https://www.microsoft.com/net/download/core). After installing the runtime, restart the server or restart IIS by executing **net stop was /y** followed by **net start w3svc** from a command prompt.
 
 ### OS upgrade removed the 32-bit ASP.NET Core Module
 


### PR DESCRIPTION
Addresses: https://github.com/aspnet/IISIntegration/issues/325

We have the Common Error for this problem, but that's too late in the doc to catch an offline install of the hosting bundle and the :boom: that results. Adding one line should save a few broken hearts 💔 .

Thanks to @salmankhann for pointing this out.

This also makes a minor change and removes the "(x64)" from the name of the redist installer package. Following the language in ANCM issues where the x86 and x64 of the ANCM are discussed, we probably shouldn't guess and instruct which bitness of the redist to install. cc/ @shirhatti - Let me know if we **should** state to **install the x64 version of the VC++ redist explicitly** and I'll make a modification to this PR to point that out.