### PR TITLE
WIP: What's new in ASP.NET Core 1.1

### DIFF
--- a/aspnetcore/aspnetcore-1.1.md
+++ b/aspnetcore/aspnetcore-1.1.md
@@ -25,11 +25,11 @@ ASP.NET Core 1.1 includes the following new features:
 - [Azure App Service logging provider](xref:fundamentals/logging#appservice)
 - [Azure Key Vault configuration provider](xref:security/key-vault-configuration)
 - [Azure and Redis Storage Data Protection Key Repositories](xref:security/data-protection/implementation/key-storage-providers#azure-and-redis)
-- WebListener Server for Windows
+- WebListener Server for Windows - @tdykstra to complete
 
 
 ## Choosing between versions 1.0 and 1.1 of ASP.NET Core
-
+TODO: Dan Roth to complete this section.
 ASP.NET Core follows the [.NET Core Support Lifecycle](https://www.microsoft.com/net/core/support), therefore ASP.NET Core 1.1 follows the .NET Core 1.1 Current support level. 
 
 ## WebListener Server for Windows

--- a/aspnetcore/aspnetcore-1.1.md
+++ b/aspnetcore/aspnetcore-1.1.md
@@ -25,15 +25,11 @@ ASP.NET Core 1.1 includes the following new features:
 - [Azure App Service logging provider](xref:fundamentals/logging#appservice)
 - [Azure Key Vault configuration provider](xref:security/key-vault-configuration)
 - [Azure and Redis Storage Data Protection Key Repositories](xref:security/data-protection/implementation/key-storage-providers#azure-and-redis)
-- WebListener Server for Windows - @tdykstra to complete
-
+- [WebListener Server for Windows](xref:fundamentals/servers/weblistener)
 
 ## Choosing between versions 1.0 and 1.1 of ASP.NET Core
 TODO: Dan Roth to complete this section.
 ASP.NET Core follows the [.NET Core Support Lifecycle](https://www.microsoft.com/net/core/support), therefore ASP.NET Core 1.1 follows the .NET Core 1.1 Current support level. 
-
-## WebListener Server for Windows
-
 
 ## Additional Information
 

--- a/aspnetcore/aspnetcore-1.1.md
+++ b/aspnetcore/aspnetcore-1.1.md
@@ -1,0 +1,40 @@
+---
+title: What's new in ASP.NET Core 1.1 | Microsoft Docs
+author: rick-anderson
+description: What's new in ASP.NET Core 1.1
+keywords: ASP.NET Core, bower
+ms.author: riande
+manager: wpickett
+ms.date: 02/14/2017
+ms.topic: article
+ms.assetid: 062f8353-d1bc-4e99-a821-c1d1bb162c47
+ms.technology: aspnet
+ms.prod: aspnet-core
+uid: aspnetcore-1.1
+---
+
+# What's new in ASP.NET Core 1.1
+
+ASP.NET Core 1.1 includes the following new features:
+
+- [URL Rewriting Middleware](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/url-rewriting)
+- [Response Caching Middleware](https://docs.microsoft.com/en-us/aspnet/core/performance/caching/middleware)
+- [View Components as Tag Helpers](xref:mvc/views/view-components#invoking-a-view-component-as-a-tag-helper)
+- [Middleware as MVC filters](xref:mvc/controllers/filters#using-middleware-in-the-filter-pipeline)
+- [Cookie-based TempData provider](xref:fundamentals/app-state#cookie-based-tempData-provider )
+- [Azure App Service logging provider](xref:fundamentals/logging#appservice)
+- [Azure Key Vault configuration provider](xref:security/key-vault-configuration)
+- [Azure and Redis Storage Data Protection Key Repositories](xref:security/data-protection/implementation/key-storage-providers#azure-and-redis)
+- WebListener Server for Windows
+
+
+## Choosing between versions 1.0 and 1.1 of ASP.NET Core
+
+ASP.NET Core follows the [.NET Core Support Lifecycle](https://www.microsoft.com/net/core/support), therefore ASP.NET Core 1.1 follows the .NET Core 1.1 Current support level. 
+
+## WebListener Server for Windows
+
+
+## Additional Information
+
+- [ASP.NET Core 1.1.0 Release Notes](https://github.com/aspnet/Home/releases/tag/1.1.0)

--- a/aspnetcore/aspnetcore-1.1.md
+++ b/aspnetcore/aspnetcore-1.1.md
@@ -26,10 +26,38 @@ ASP.NET Core 1.1 includes the following new features:
 - [Azure Key Vault configuration provider](xref:security/key-vault-configuration)
 - [Azure and Redis Storage Data Protection Key Repositories](xref:security/data-protection/implementation/key-storage-providers#azure-and-redis)
 - [WebListener Server for Windows](xref:fundamentals/servers/weblistener)
+- [WebSockets support](#websockets-support)
 
 ## Choosing between versions 1.0 and 1.1 of ASP.NET Core
 TODO: Dan Roth to complete this section.
 ASP.NET Core follows the [.NET Core Support Lifecycle](https://www.microsoft.com/net/core/support), therefore ASP.NET Core 1.1 follows the .NET Core 1.1 Current support level. 
+
+## WebSockets support
+
+A new middleware component provides WebSockets support in ASP.NET Core 1.1. Install the [Microsoft.AspNetCore.WebSockets](https://www.nuget.org/packages/Microsoft.AspNetCore.WebSockets/) package, and add code to the `Configure` method of the `Startup` class:
+
+```
+app.UseWebSockets();
+```
+
+Your project will then have access to a `WebSockets` property on the `HttpContext` object.  You can write your own middleware for the pipeline to interpret and interact with the requests handed to your application by a websocket.  You could add this middleware to your configured pipeline with code like the following:
+
+```
+app.Use(async (context, next) =>
+{
+  if (context.WebSockets.IsWebSocketRequest)
+  {
+    var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+    await DoSomethingCool(context, webSocket);
+  }
+  else
+  {
+    await next();
+  }
+});
+```
+
+The websocket object has `SendAsync` and `ReceiveAsync` methods.  For samples, see the  [WebSockets repository](https://github.com/aspnet/WebSockets/tree/dev/samples).
 
 ## Additional Information
 

--- a/aspnetcore/aspnetcore-1.1.md
+++ b/aspnetcore/aspnetcore-1.1.md
@@ -29,8 +29,8 @@ ASP.NET Core 1.1 includes the following new features:
 - [WebSockets support](#websockets-support)
 
 ## Choosing between versions 1.0 and 1.1 of ASP.NET Core
-TODO: Dan Roth to complete this section.
-ASP.NET Core follows the [.NET Core Support Lifecycle](https://www.microsoft.com/net/core/support), therefore ASP.NET Core 1.1 follows the .NET Core 1.1 Current support level. 
+
+ASP.NET Core 1.1 has more features than 1.0. In general, we recommend you use the latest version.
 
 ## WebSockets support
 

--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -127,6 +127,7 @@
 
 # [API Reference](/aspnet/core/api/)
 
-# [Release notes](https://github.com/aspnet/home/releases)
+# [What's new](aspnetcore-1.1.md)
+## [All release notes](https://github.com/aspnet/home/releases)
 
 # [Contribute](https://github.com/aspnet/Docs/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
New direction as of 28 Feb:
From the Release Notes TOC, link to a page similar to [Release Notes History](http://docs.servicestack.net/release-notes-history) 
I think we'll want to add a link to [ASP.NET Core 1.1 RTM blog](https://blogs.msdn.microsoft.com/webdev/2016/11/16/announcing-asp-net-core-1-1/)



[Internal review ULR](https://review.docs.microsoft.com/en-us/aspnet/core/aspnetcore-1.1?branch=ra%2Fwhats-new-in-1.1) **Note**: some of the in page anchors don't work in this branch such as Cookie-based TempData provider and VC's as TH
- [x] Choosing between versions 1.0 and 1.1 of ASP.NET Core - @danroth27 
- [x]  Hook this up to TOC - @tdykstra 
- [x]  Complete Websockets - @tdykstra 