### PR TITLE
Remove extraneous backtick from Bower doc

### DIFF
--- a/aspnetcore/client-side/bower.md
+++ b/aspnetcore/client-side/bower.md
@@ -58,7 +58,7 @@ Open the *.bowerrc* file under *bower.json*. The `directory` property is set to 
 
 You can use the search box in Solution Explorer to find and display the font-awesome package.
 
-Open the *Views\Shared\_Layout.cshtml* file and add the font-awesome CSS file to the environment [Tag Helper](xref:mvc/views/tag-helpers/intro) for `Development``. From Solution Explorer, drag and drop *font-awesome.css* inside the `<environment names="Development">` element.
+Open the *Views\Shared\_Layout.cshtml* file and add the font-awesome CSS file to the environment [Tag Helper](xref:mvc/views/tag-helpers/intro) for `Development`. From Solution Explorer, drag and drop *font-awesome.css* inside the `<environment names="Development">` element.
 
 [!code-html[Main](bower\sample\_Layout.cshtml?highlight=4&range=9-13)]
 


### PR DESCRIPTION
Fix a backtick usage issue in the **Manual installation in bower.json** section of the Bower doc.