### PR TITLE
Fix area routes code sample

### DIFF
--- a/aspnetcore/mvc/controllers/areas.md
+++ b/aspnetcore/mvc/controllers/areas.md
@@ -124,7 +124,7 @@ Once you've defined the folder hierarchy, you need to tell MVC that each control
    }
    ```
 
-Set up a route definition that works with your newly created areas. The [🔧 Routing to Controller Actions](routing.md) article goes into detail about how to create route definitions, including using conventional routes versus attribute routes. In this example, we'll use a conventional route. To do so, open the *Startup.cs* file and modify it by adding the highlighted route definition below.
+Set up a route definition that works with your newly created areas. The [🔧 Routing to Controller Actions](routing.md) article goes into detail about how to create route definitions, including using conventional routes versus attribute routes. In this example, we'll use a conventional route. To do so, open the *Startup.cs* file and modify it by adding the `areaRoute` named route definition below.
 
 <!-- literal_block {"ids": [], "linenos": false, "xml:space": "preserve", "language": "csharp", "highlight_args": {"hl_lines": [4, 5, 6]}} -->
 
@@ -137,7 +137,7 @@ Set up a route definition that works with your newly created areas. The [🔧 Ro
 
      routes.MapRoute(
          name: "default",
-         template: "{controller=Home}/{action=Index}");
+         template: "{controller=Home}/{action=Index}/{id?}");
    });
    ```
 


### PR DESCRIPTION
Add the missing _id_ placeholder to the _default_ MVC route. Also, change the verbiage above the code snippet slightly, since there is no highlighting.