### PR TITLE
{authorId:int} instead of {authorId}

### DIFF
--- a/aspnet/web-api/overview/web-api-routing-and-actions/create-a-rest-api-with-attribute-routing/samples/sample17.cs
+++ b/aspnet/web-api/overview/web-api-routing-and-actions/create-a-rest-api-with-attribute-routing/samples/sample17.cs
@@ -1,4 +1,4 @@
-[Route("~api/authors/{authorId}/books")]
+[Route("~/api/authors/{authorId:int}/books")]
 public IQueryable<BookDto> GetBooksByAuthor(int authorId)
 {
     return db.Books.Include(b => b.Author)


### PR DESCRIPTION
// its better to use {authorId:int} instead of just {authorId}
// wrong {authorId} will produce a 400 error with error message
// wrong {authorId:int} will produce a 404 error

Since the publish date route is limited to a couple of formats, I assume you're of the type to prefer to control what type of error is shown to the resource user.