### PR TITLE
doc(tutorials): fix typo

### DIFF
--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
@@ -308,7 +308,7 @@ Enable static files middleware.
         app.UseSwagger();
 
         // Enable middleware to serve swagger-ui (HTML, JS, CSS etc.), specifying the Swagger JSON endpoint.
-        app.UseSwaggerUi(c =>
+        app.UseSwaggerUI(c =>
         {
             c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
         });


### PR DESCRIPTION
Fix typo where UseSwaggerUI was written with lowercase 'i' in 'UI'