### PR TITLE
Rename _optionsAccessor field to represent value

### DIFF
--- a/aspnetcore/fundamentals/configuration/sample/src/UsingOptions/Controllers/HomeController.cs
+++ b/aspnetcore/fundamentals/configuration/sample/src/UsingOptions/Controllers/HomeController.cs
@@ -8,17 +8,17 @@ namespace UsingOptions.Controllers
     #region snippet1
     public class HomeController : Controller
     {
-        private readonly MyOptions _optionsAccessor;
+        private readonly MyOptions _options;
 
         public HomeController(IOptions<MyOptions> optionsAccessor)
         {
-            _optionsAccessor = optionsAccessor.Value;
+            _options = optionsAccessor.Value;
         }
 
         public IActionResult Index()
         {
-            var option1 = _optionsAccessor.Option1;
-            var option2 = _optionsAccessor.Option2;
+            var option1 = _options.Option1;
+            var option2 = _options.Option2;
             return Content($"option1 = {option1}, option2 = {option2}");
         }
     }


### PR DESCRIPTION
The constructor receives an optionsAccessor, but by the time it is stored in the field, its value has been accessed, so the field name should not be suffixed with Accessor.