### PR TITLE
Escape literal asterisk

### DIFF
--- a/aspnetcore/fundamentals/hosting.md
+++ b/aspnetcore/fundamentals/hosting.md
@@ -126,7 +126,7 @@ new WebHostBuilder()
 
 **Server URLs** `string`
 
-Key: `urls`. Set to a semicolon (;) separated list of URL prefixes to which the server should respond. For example, `http://localhost:123`. The domain/host name can be replaced with "*" to indicate the server should listen to requests on any IP address or host using the specified port and protocol (for example, `http://*:5000` or `https://*:5001`). The protocol (`http://` or `https://`) must be included with each URL. The prefixes are interpreted by the configured server; supported formats will vary between servers.
+Key: `urls`. Set to a semicolon (;) separated list of URL prefixes to which the server should respond. For example, `http://localhost:123`. The domain/host name can be replaced with "\*" to indicate the server should listen to requests on any IP address or host using the specified port and protocol (for example, `http://*:5000` or `https://*:5001`). The protocol (`http://` or `https://`) must be included with each URL. The prefixes are interpreted by the configured server; supported formats will vary between servers.
 
 ```csharp
 new WebHostBuilder()


### PR DESCRIPTION
As it was treated as formatting, so it made the rest of the paragraph not legible