### PR TITLE
Correcting creating new web template command.

### DIFF
--- a/aspnetcore/getting-started.md
+++ b/aspnetcore/getting-started.md
@@ -21,7 +21,7 @@ uid: getting-started
     ```console
     mkdir aspnetcoreapp
     cd aspnetcoreapp
-    dotnet new web
+    dotnet new -t web
     ```
     Note: This command requires `.NET Core SDK 1.0.0 - RC4` or later.
 


### PR DESCRIPTION
`dotnet new web` doesn't work. It needs a -t param to make a starter template for the web.