### PR TITLE
Update getting-started.md

### DIFF
--- a/aspnetcore/getting-started.md
+++ b/aspnetcore/getting-started.md
@@ -23,7 +23,6 @@ uid: getting-started
     cd aspnetcoreapp
     dotnet new web
     ```
-    Note: This command requires `.NET Core SDK 1.0.0 - RC4` or later.
 
 3.  Restore the packages:
 


### PR DESCRIPTION
.NET Core 1.0.0 has shipped, so I think we can stop referring to preview builds.