### PR TITLE
renaming to AngularJS like in page

### DIFF
--- a/aspnetcore/client-side/index.md
+++ b/aspnetcore/client-side/index.md
@@ -18,7 +18,7 @@ ms.prod: asp.net-core
 - [Manage client-side packages with Bower](bower.md)
 - [Building beautiful, responsive sites with Bootstrap](bootstrap.md)
 - [Knockout.js MVVM Framework](knockout.md)
-- [Using Angular for Single Page Applications (SPAs)](angular.md)
+- [Using AngularJS for Single Page Applications (SPAs)](angular.md)
 - [Styling applications with Less, Sass, and Font Awesome](less-sass-fa.md)
 - [Bundling and minification](bundling-and-minification.md)
 - [🔧 Working with a Content Delivery Network (CDN)](cdn.md)


### PR DESCRIPTION
@Rick-Anderson Renaming link to AngularJS like in the article.

Greetings Damien