### PR TITLE
Updated Coding Style in Examples

### DIFF
--- a/aspnet/web-api/overview/advanced/http-cookies/samples/sample11.cs
+++ b/aspnet/web-api/overview/advanced/http-cookies/samples/sample11.cs
@@ -9,7 +9,7 @@ using System.Web.Http;
 
 public class SessionIdHandler : DelegatingHandler
 {
-    static public string SessionIdToken = "session-id";
+    public static string SessionIdToken = "session-id";
 
     async protected override Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request, CancellationToken cancellationToken)

--- a/aspnetcore/fundamentals/configuration/sample/ConfigInMemory/Program.cs
+++ b/aspnetcore/fundamentals/configuration/sample/ConfigInMemory/Program.cs
@@ -24,7 +24,7 @@ public class Program
           ["AppConfiguration:MainWindow:Top"] = "5",
           ["AppConfiguration:MainWindow:Left"] = "11",
       };
-    static public IConfiguration Configuration { get; set; }
+    public static IConfiguration Configuration { get; set; }
     public static void Main(string[] args = null)
     {
         var builder = new ConfigurationBuilder();

--- a/aspnetcore/fundamentals/configuration/sample/src/CommandLine/Program.cs
+++ b/aspnetcore/fundamentals/configuration/sample/src/CommandLine/Program.cs
@@ -7,9 +7,9 @@ using System.Linq;
 // Add NuGet  <package id="Microsoft.Extensions.Configuration.CommandLine"
 public class Program
 {
-    static public IConfigurationRoot Configuration { get; set; }
+    public static IConfigurationRoot Configuration { get; set; }
 
-    static public Dictionary<string, string> GetSwitchMappings(
+    public static Dictionary<string, string> GetSwitchMappings(
     IReadOnlyDictionary<string, string> configurationStrings)
     {
         return configurationStrings.Select(item =>

--- a/aspnetcore/fundamentals/configuration/sample/src/ConfigJson/Program.cs
+++ b/aspnetcore/fundamentals/configuration/sample/src/ConfigJson/Program.cs
@@ -9,7 +9,7 @@ using System.IO;
 
 public class Program
 {
-    static public IConfigurationRoot Configuration { get; set; }
+    public static IConfigurationRoot Configuration { get; set; }
     public static void Main(string[] args = null)
     {
         var builder = new ConfigurationBuilder()

--- a/aspnetcore/fundamentals/configuration/sample/src/InMemory/Program.cs
+++ b/aspnetcore/fundamentals/configuration/sample/src/InMemory/Program.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 // Add NuGet  <package id="Microsoft.Extensions.Configuration.Binder"
 public class Program
 {   
-    static public IConfigurationRoot Configuration { get; set; }
+    public static IConfigurationRoot Configuration { get; set; }
     public static void Main(string[] args = null)
     {
         var dict = new Dictionary<string, string>

--- a/aspnetcore/fundamentals/configuration/sample/src/InMemoryGetValue/Program.cs
+++ b/aspnetcore/fundamentals/configuration/sample/src/InMemoryGetValue/Program.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 // Add NuGet  <package id="Microsoft.Extensions.Configuration.Binder"
 public class Program
 {   
-    static public IConfigurationRoot Configuration { get; set; }
+    public static IConfigurationRoot Configuration { get; set; }
     public static void Main(string[] args = null)
     {
         var dict = new Dictionary<string, string>


### PR DESCRIPTION
# Updated Coding Style in Examples

Replaced several uses of `static public` with the more appropriate `public static` to fall in line with the [coding guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md), which state that the visibility modifier should always be the first modifier present.