### PR TITLE
Added parameter in the call to the base function

### DIFF
--- a/aspnet/signalr/overview/guide-to-the-api/handling-connection-lifetime-events/samples/sample7.cs
+++ b/aspnet/signalr/overview/guide-to-the-api/handling-connection-lifetime-events/samples/sample7.cs
@@ -9,5 +9,5 @@ public override System.Threading.Tasks.Task OnDisconnected(bool stopCalled)
         Console.WriteLine(String.Format("Client {0} timed out .", Context.ConnectionId));
     }
             
-    return base.OnDisconnected();
+    return base.OnDisconnected(stopCalled);
 }


### PR DESCRIPTION
# Title

The PR contains an update to an example on the server-side.

## Summary

The base object does not have a method with no parameters in SignalR version 2.2.1. The change in the code changed the call to the base class to include a mandatory parameter.

