### PR TITLE
PR template changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,10 @@
-# Title
+When creating a new PR, please do the following and delete this template text:
 
-Brief description of what this Pull Request (PR) does.
+* Reference the issue number if there is one:
 
-## Summary
+  Fixes #Issue_Number
 
-Longer description if needed (if there's an issue for it,
-no need to copy the description from there).
+  > The "Fixes #nnn" syntax in the PR description causes
+  > GitHub to automatically close the issue when this PR is merged.
 
-Fixes #Issue_Number
-
-> The "Fixes #nnn" syntax in the PR description causes
-> GitHub to automatically close the issue when this PR is merged.
-> Remove the "Fixes" line if no issue is associated with the PR.
-
-## Suggested Reviewers
-
-If you know who should review this PR, assign them using the GitHub **Reviewers** UI.
+* Suggest reviewers if you know who should review the PR, using the GitHub **Reviewers** UI.


### PR DESCRIPTION
@Rick-Anderson People tend to leave the template text in the PRs, and the title vs summary guidance seems unnecessary so I'm thinking a lighter-weight template would be better.