### PR TITLE
Remove closing brackets

### DIFF
--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -132,7 +132,7 @@ In Solution Explorer, right-click the *Controllers* folder. Select **Add** > **N
 ![Add new Item dialog with controller in search box and web API controller selected](first-web-api/_static/new-project.png)
 
 
-Replace the generated code with the following:
+Replace the generated code with the following (and add closing braces):
 
 [!code-csharp[Main](first-web-api/sample/TodoApi/Controllers/TodoController.cs?name=snippet_todo1)]
 

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -135,7 +135,6 @@ In Solution Explorer, right-click the *Controllers* folder. Select **Add** > **N
 Replace the generated code with the following:
 
 [!code-csharp[Main](first-web-api/sample/TodoApi/Controllers/TodoController.cs?name=snippet_todo1)]
-[!code-csharp[Main](first-web-api/sample/TodoApi/Controllers/TodoController.cs?name=snippet_end)]
 
 This defines an empty controller class. In the next sections, we'll add methods to implement the API.
 


### PR DESCRIPTION
The deleted line is supposed to "make the class complete" by adding the two closing brackets for namespace and class. [The way it is rendered](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-web-api) however does more harm than good in my opinion because it can not be copied at once anyway and looks like bug.

```cs
using System.Collections.Generic;
using Microsoft.AspNetCore.Mvc;
using TodoApi.Models;

namespace TodoApi.Controllers
{
    [Route("api/[controller]")]
    public class TodoController : Controller
    {
        private readonly ITodoRepository _todoRepository;

        public TodoController(ITodoRepository todoRepository)
        {
            _todoRepository = todoRepository;
        }
```

```cs 
    }
}
```

I think users who got far enough to do this tutorial should be able to add the closing brackets without copying the second block.