### PR TITLE
Change environments.md to use set as opposed to setx

### DIFF
--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -78,7 +78,7 @@ To set the `ASPNETCORE_ENVIRONMENT` for the current session, if the app is start
 
 **Command line**
 ```
-setx ASPNETCORE_ENVIRONMENT "Development"
+set ASPNETCORE_ENVIRONMENT="Development"
 ```
 **PowerShell**
 ```


### PR DESCRIPTION
A minor amendment but could be confusing for people unfamiliar with the cmd line.
The text describes setting it for the current current command window, however setx actually only explicitly changes the environment variable, it doesn't change the current window either, so a user would have potentially noticed no change.