### PR TITLE
Move resource naming section up and clarify

### DIFF
--- a/aspnetcore/fundamentals/localization.md
+++ b/aspnetcore/fundamentals/localization.md
@@ -125,6 +125,28 @@ A resource file is a useful mechanism for separating localizable strings from co
 
     ![Solution Explorer showing the Welcome Spanish (es) resource file](localization/_static/se.png)
 
+## Resource file naming
+
+Resources are named for the full type name of their class minus the assembly name. For example, a French resource in a project whose main assembly is `LocalizationWebsite.Web.dll` for the class `LocalizationWebsite.Web.Startup` would be named *Startup.fr.resx*. A resource for the class `LocalizationWebsite.Web.Controllers.HomeController` would be named *Controllers.HomeController.fr.resx*. If your targeted class's namespace is not the same as the assembly name you will need the full type name. For example, in the sample project a resource for the type `ExtraNamespace.Tools` would be named *ExtraNamespace.Tools.fr.resx*.
+
+In the sample project, the `ConfigureServices` method sets the `ResourcesPath` to "Resources", so the project relative path for the home controller's French resource file is *Resources/Controllers.HomeController.fr.resx*. Alternatively, you can use folders to organize resource files. For the home controller, the path would be *Resources/Controllers/HomeController.fr.resx*. If you don't use the `ResourcesPath` option, the *.resx* file would go in the project base directory. The resource file for `HomeController` would be named *Controllers.HomeController.fr.resx*. The choice of using the dot or path naming convention depends on how you want to organize your resource files.
+
+| Resource name | Dot or path naming |
+| ------------   | ------------- |
+| Resources/Controllers.HomeController.fr.resx | Dot  |
+| Resources/Controllers/HomeController.fr.resx  | Path |
+|    |     |
+
+Resource files using `@inject IViewLocalizer` in Razor views follow a similar pattern. The resource file for a view can be named using either dot naming or path naming. Razor view resource files mimic the path of their associated view file. Assuming we set the `ResourcesPath` to "Resources", the French resource file associated with the *Views/Home/About.cshtml* view could be either of the following:
+
+* Resources/Views/Home/About.fr.resx
+
+* Resources/Views.Home.About.fr.resx
+
+If you don't use the `ResourcesPath` option, the *.resx* file for a view would be located in the same folder as the view.
+
+If you remove the ".fr" culture designator AND you have the culture set to French (via cookie or other mechanism), the default resource file is read and strings are localized. The Resource manager designates a default or fallback resource, when nothing meets your requested culture you're served the *.resx file without a culture designator. If you want to just return the key when missing a resource for the requested culture you must not have a default resource file.
+
 ### Generating resource files with Visual Studio
 
 If you create a resource file in Visual Studio without a culture in the file name (for example, *Welcome.resx*), Visual Studio will create a C# class with a property for each string. That's usually not what you want with ASP.NET Core; you typically don't have a default *.resx* resource file (A *.resx* file without the culture name). We suggest you create the *.resx* file with a culture name (for example *Welcome.fr.resx*). When you create a *.resx* file with a culture name, Visual Studio will not generate the class file. We anticipate that many developers will **not** create a default language resource file.
@@ -229,28 +251,6 @@ services.Configure<RequestLocalizationOptions>(options =>
    ```
 
 Use `RequestLocalizationOptions` to add or remove localization providers.
-
-## Resource file naming
-
-Resources are named for the full type name of their class minus the assembly name. For example, a French resource in the `LocalizationWebsite.Web` project for the class `LocalizationWebsite.Web.Startup` would be named *Startup.fr.resx*. A resource for the class `LocalizationWebsite.Web.Controllers.HomeController` would be named *Controllers.HomeController.fr.resx*. If your targeted class's namespace is not the same as the assembly name you will need the full type name. For example, in the sample project a resource for the type `ExtraNamespace.Tools` would be named *ExtraNamespace.Tools.fr.resx*.
-
-In the sample project, the `ConfigureServices` method sets the `ResourcesPath` to "Resources", so the project relative path for the home controller's French resource file is *Resources/Controllers.HomeController.fr.resx*. Alternatively, you can use folders to organize resource files. For the home controller, the path would be *Resources/Controllers/HomeController.fr.resx*. If you don't use the `ResourcesPath` option, the *.resx* file would go in the project base directory. The resource file for `HomeController` would be named *Controllers.HomeController.fr.resx*. The choice of using the dot or path naming convention depends on how you want to organize your resource files.
-
-| Resource name | Dot or path naming |
-| ------------   | ------------- |
-| Resources/Controllers.HomeController.fr.resx | Dot  |
-| Resources/Controllers/HomeController.fr.resx  | Path |
-|    |     |
-
-Resource files using `@inject IViewLocalizer` in Razor views follow a similar pattern. The resource file for a view can be named using either dot naming or path naming. Razor view resource files mimic the path of their associated view file. Assuming we set the `ResourcesPath` to "Resources", the French resource file associated with the *Views/Home/About.cshtml* view could be either of the following:
-
-* Resources/Views/Home/About.fr.resx
-
-* Resources/Views.Home.About.fr.resx
-
-If you don't use the `ResourcesPath` option, the *.resx* file for a view would be located in the same folder as the view.
-
-If you remove the ".fr" culture designator AND you have the culture set to French (via cookie or other mechanism), the default resource file is read and strings are localized. The Resource manager designates a default or fallback resource, when nothing meets your requested culture you're served the *.resx file without a culture designator. If you want to just return the key when missing a resource for the requested culture you must not have a default resource file.
 
 ### Setting the culture programmatically
 


### PR DESCRIPTION
This is an attempt to clarify resource naming (which we get a lot of issues about at aspnet/Localization). Firstly by moving the relevant section higher up in the document where it's more likely to be seen and has relevance to the section about generating resource files. Secondly by emphasizing that what matters in the end is the name of the assembly your project generates.