### PR TITLE
Add troubleshooting tip for `System.TypeLoadException`

### DIFF
--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -140,8 +140,8 @@ When the application fails to load configuration using the provider, an error me
 * The Azure AD Key (`ClientSecret`) is expired.
 * The configuration key (name) is incorrect in the app for the value you're trying to load.
 
-There is an exception of type `System.TypeLoadException` thrown during startup while running on top of `.NET 4.6.2`:
-* Add a NuGet reference to the package for `System.Net.Http` version >= 4.3.1
+`System.TypeLoadException` exception during startup using `.NET 4.6.x`:
+* Add a NuGet reference to the package for `System.Net.Http` version 4.3.1 or later.
 
 ## Additional resources
 * <xref:fundamentals/configuration>

--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -140,6 +140,9 @@ When the application fails to load configuration using the provider, an error me
 * The Azure AD Key (`ClientSecret`) is expired.
 * The configuration key (name) is incorrect in the app for the value you're trying to load.
 
+There is an exception of type `System.TypeLoadException` thrown during startup while running on top of `.NET 4.6.2`:
+* Add a NuGet reference to the package for `System.Net.Http` version >= 4.3.1
+
 ## Additional resources
 * <xref:fundamentals/configuration>
 * [Microsoft Azure: Key Vault](https://azure.microsoft.com/services/key-vault/)


### PR DESCRIPTION
When running AspNet Core 1.1 on top of .NET 4.6.2 and trying to use the Azure Key Vault configuration extensions, I was encountering an exception that was being thrown for `System.TypeLoadException`. I discovered this originated from the use of the Azure Key Vault API and how it interacted with an older (built-in) version of `System.Net.HTTP`. I ended up installing the updated NuGet package for `System.Net.Http` and that fixed the issue. Hopefully this proposed tip will help someone in the future. Or at least until the packages get more aligned.

When creating a new PR, please do the following and delete this template text:

Addresses #2968
