### PR TITLE
Fix explanation: setting a default selected option

### DIFF
--- a/aspnet/mvc/overview/getting-started/introduction/adding-search.md
+++ b/aspnet/mvc/overview/getting-started/introduction/adding-search.md
@@ -135,11 +135,11 @@ The parameter "movieGenre" provides the key for the `DropDownList` helper to fin
 
 [!code-csharp[Main](adding-search/samples/sample16.cs?highlight=10)]
 
-The parameter "All" provides the item in the list to be preselected. Had we used the following code:
+The parameter "All" provides an option label. If you inspect that choice in your browser, you'll see that its "value" attribute is empty. Since our controller only filters `if` the string is not `null` or empty, submitting an empty value for `movieGenre` shows all genres.
 
-[!code-cshtml[Main](adding-search/samples/sample17.cshtml)]
+You can also set an option to be selected by default. If you wanted "Comedy" as your default option, you would change the code in the Controller like so:
 
-And we had a movie with a "Comedy" genre in our database, "Comedy" would be preselected in the dropdown list. Because we don't have a movie genre "All", there is no "All" in the `SelectList`, so when we post back without making a slection, the `movieGenre` query string value is empty.
+ViewBag.movieGenre = new SelectList(GenreLst, "Comedy");
 
 Run the application and browse to */Movies/Index*. Try a search by genre, by movie name, and by both criteria.
 

--- a/aspnet/mvc/overview/getting-started/introduction/adding-search/samples/sample17.cshtml
+++ b/aspnet/mvc/overview/getting-started/introduction/adding-search/samples/sample17.cshtml
@@ -1,1 +1,1 @@
-@Html.DropDownList("movieGenre", "Comedy")
+ViewBag.movieGenre = new SelectList(GenreLst, "Comedy");


### PR DESCRIPTION
The current doc treats the second parameter of `@Html.DropDownList()` as a way to set the default selected option. It gives an example of choosing "Comedy" by default. In fact, the given example creates a second entry that says "Comedy" but has an empty value. I provided a correct example.

Feedback is welcome! :-)