### PR TITLE
Remove too-early reference to authentication

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc.md
@@ -48,7 +48,6 @@ Complete the **New Project** dialog:
 
 * In the left pane, tap **.NET Core**
 * In the center pane, tap **ASP.NET Core Web Application (.NET Core)**
-* Verify **Authentication** is set to **No Authentication**
 * Name the project "MvcMovie" (It's important to name the project "MvcMovie" so when you copy code, the namespace will match.)
 * Tap **OK**
 


### PR DESCRIPTION
Unless there's a version of Visual Studio that has a different dialog, I think Authentication only comes up in the second "create a project" dialog. The screenshots that are already in the article confirm this. Thanks!