### PR TITLE
Markdown mismatch

### DIFF
--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -221,15 +221,17 @@ The `CreatedAtRoute` method returns a 201 response, which is the standard respon
 * Select the **raw** radio button
 * Set the type to JSON
 * In the key-value editor, enter a Todo item such as 
-```JSON
+
+```json
 {
 	"name":"walk dog",
 	"isComplete":true
-}```
+}
+```
 
 * Select **Send**
 
-Select the Headers tab in the lower pane and copy the **Location** header:
+* Select the Headers tab in the lower pane and copy the **Location** header:
 
 ![Headers tab of the Postman console](first-web-api/_static/pmget.png)
 


### PR DESCRIPTION
'Use Postman to send a Create request' section has a markdown mismatch. Below the 'In the key-value editor, enter a Todo item such as', the text formatting is broken.