### PR TITLE
Fix markdown formatting around code snippet

### DIFF
--- a/aspnetcore/security/authentication/cookie.md
+++ b/aspnetcore/security/authentication/cookie.md
@@ -58,7 +58,7 @@ To create a cookie holding your user information you must construct a [ClaimsPri
 
    ```csharp
    await HttpContext.Authentication.SignInAsync("MyCookieMiddlewareInstance", principal);
-      ```
+   ```
 
 This will create an encrypted cookie and add it to the current response. The `AuthenticationScheme` specified during [configuration](xref:security/authentication/cookie#security-authentication-cookie-middleware-configuring) must also be used when calling `SignInAsync`.
 


### PR DESCRIPTION
Just a very simple little change to some markdown formatting. The triple backtick being indented meant the next few paragraphs were being included in the code snippet.