### PR TITLE
Make InvokeAsync styling consistent with other occurrences

### DIFF
--- a/aspnetcore/mvc/views/view-components.md
+++ b/aspnetcore/mvc/views/view-components.md
@@ -63,7 +63,7 @@ A view component class:
 
 A view component defines its logic in an `InvokeAsync` method that returns an `IViewComponentResult`. Parameters come directly from invocation of the view component, not from model binding. A view component never directly handles a request. Typically, a view component initializes a model and passes it to a view by calling the `View` method. In summary, view component methods:
 
-* Define an *`InvokeAsync`* method that returns an `IViewComponentResult`
+* Define an `InvokeAsync` method that returns an `IViewComponentResult`
 * Typically initializes a model and passes it to a view by calling the `ViewComponent` `View` method
 * Parameters come from the calling method, not HTTP, there is no model binding
 * Are not reachable directly as an HTTP endpoint, they are invoked from your code (usually in a view). A view component never handles a request


### PR DESCRIPTION
There was a reference to the `InvokeAsync` method in the [View Components](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/view-components) doc which was unnecessarily italicized. This PR removes the italics to make it consistent with all other occurrences in the doc.