### PR TITLE
Fix parameter type typo

### DIFF
--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -180,7 +180,7 @@ In the `GetById` method:
 
 ```csharp
 [HttpGet("{id}", Name = "GetTodo")]
-public IActionResult GetById(string id)
+public IActionResult GetById(long id)
 ```
 
 `"{id}"` is a placeholder variable for the ID of the `todo` item. When `GetById` is invoked, it assigns the value of "{id}" in the URL to the method's `id` parameter.


### PR DESCRIPTION
To match the earlier code snippet ```string``` should be ```long```