### PR TITLE
Fix typo and filename

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/details.md
+++ b/aspnetcore/tutorials/first-mvc-app/details.md
@@ -20,7 +20,7 @@ Open the Movie controller and examine the `Details` method:
 
 [!code-csharp[Main](start-mvc/sample/MvcMovie/Controllers/MoviesController.cs?name=snippet_details)]
 
-The MVC scaffolding engine that created this action method adds a comment showing a HTTP request that invokes the method. In this case it's a GET request with three URL segments, the `Movies` controller, the `Details` method and a `id` value. Recall these segments are defined in Startup.
+The MVC scaffolding engine that created this action method adds a comment showing an HTTP request that invokes the method. In this case it's a GET request with three URL segments, the `Movies` controller, the `Details` method and an `id` value. Recall these segments are defined in *Startup.cs*.
 
 [!code-csharp[Main](start-mvc/sample/MvcMovie/Startup.cs?highlight=5&name=snippet_1)]
 


### PR DESCRIPTION
Simply changed from "a" to "an" in two places for fluidity and consistency. I also added the filename extension for `Startup` and made it italic.