### PR TITLE
Update dockerfile in aspmvc deployment

### DIFF
--- a/aspnet/mvc/overview/deployment/docker-aspnetmvc.md
+++ b/aspnet/mvc/overview/deployment/docker-aspnetmvc.md
@@ -106,7 +106,7 @@ The Dockerfile that creates your image looks like this:
 FROM microsoft/aspnet
 
 # The final instruction copies the site you published earlier into the container.
-COPY ./bin/Release/PublishOutput/ .
+COPY ./bin/Release/PublishOutput/ /inetpub/wwwroot
 ```
 
 There is no `ENTRYPOINT` command in this Dockerfile. You don't need one. When running Windows Server with IIS, the IIS process is the entrypoint, which is configured to start in the aspnet base image.


### PR DESCRIPTION
Fix dockerfile example to work with latest microsoft/aspnet version.

This is the minimal change. There are other ways to get the content in the correct place. The latest aspnet docs use a `site_root` argument when creating the image. See https://github.com/Microsoft/aspnet-docker/blob/master/4.6.2/sample/Dockerfile
