### PR TITLE
Fixes typo

### DIFF
--- a/aspnetcore/getting-started.md
+++ b/aspnetcore/getting-started.md
@@ -25,7 +25,7 @@ uid: getting-started
     ```
     
     Notes: 
-    - On macOC and Linux, open a terminal window. On Windows, open a command prompt.
+    - On macOS and Linux, open a terminal window. On Windows, open a command prompt.
     - Previous versions of .NET Core required a `t` parameter, that is   `dotnet new -t web`. If you get an error running `dotnet new web`, install the latest [.NET Core](https://microsoft.com/net/core).  `dotnet` (with no parameters)  will display the .NET Core version.
 
 3.  Restore the packages:


### PR DESCRIPTION
`macOC` -> `macOS`
Well, the change is next to nothing but still...  