### PR TITLE
Updated PrepareForPublish snippet range

### DIFF
--- a/aspnetcore/migration/mvc.md
+++ b/aspnetcore/migration/mvc.md
@@ -49,7 +49,7 @@ Create a new *empty* ASP.NET Core web app with the same name as the previous pro
 
 * Open the *.csproj* file (right-click the project in **Solution Explorer** and select **Edit WebApp1.csproj**) and add a `PrepareForPublish` target:
 
-  [!code-json[Main](mvc/sample/WebApp1.csproj?range=21-23)]
+  [!code-xml[Main](mvc/sample/WebApp1.csproj?range=21-23)]
 
   The `PrepareForPublish` target is needed for acquiring client-side libraries via Bower. We'll talk about that later.
 

--- a/aspnetcore/migration/mvc.md
+++ b/aspnetcore/migration/mvc.md
@@ -49,7 +49,7 @@ Create a new *empty* ASP.NET Core web app with the same name as the previous pro
 
 * Open the *.csproj* file (right-click the project in **Solution Explorer** and select **Edit WebApp1.csproj**) and add a `PrepareForPublish` target:
 
-  [!code-json[Main](mvc/sample/WebApp1.csproj?range=22-24)]
+  [!code-json[Main](mvc/sample/WebApp1.csproj?range=21-23)]
 
   The `PrepareForPublish` target is needed for acquiring client-side libraries via Bower. We'll talk about that later.
 


### PR DESCRIPTION
The snippet range for `PrepareForPublish` is incorrect.
It currently shows:
![image](https://cloud.githubusercontent.com/assets/122651/24767470/64e1ab4a-1b42-11e7-9952-c630abae70df.png)

and it should show:
```xml
<Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
    <Exec Command="bower install" />
 </Target>
```