### PR TITLE
Fixed typo in copy: Missing closing ')'

### DIFF
--- a/aspnetcore/fundamentals/routing.md
+++ b/aspnetcore/fundamentals/routing.md
@@ -25,7 +25,7 @@ Routing functionality is responsible for mapping an incoming request to a route 
 
 ## Routing basics
 
-Routing uses *routes* (implementations of [IRouter](https://docs.microsoft.com/en-us/aspnet/core/api/microsoft.aspnetcore.routing.irouter) to:
+Routing uses *routes* (implementations of [IRouter](https://docs.microsoft.com/en-us/aspnet/core/api/microsoft.aspnetcore.routing.irouter)) to:
 
 * map incoming requests to *route handlers*
 


### PR DESCRIPTION
Just under "Routing basics" there was text that had an opening '(' but no closing ')' (probably occurred when the link to IRouter was created). @ardalis