### PR TITLE
Remove usage of quotations with set command

### DIFF
--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -78,7 +78,7 @@ To set the `ASPNETCORE_ENVIRONMENT` for the current session, if the app is start
 
 **Command line**
 ```
-set ASPNETCORE_ENVIRONMENT="Development"
+set ASPNETCORE_ENVIRONMENT=Development
 ```
 **PowerShell**
 ```


### PR DESCRIPTION
With the change from setx to set, quotation marks are invalid and get set as part of the environment variable, this actually leads to a bad path exception upon dotnet run.

This was introduced actually by last PR #2958 which although did fix that issue, introduced a new one, it's annoying there is such a difference in syntax between setx and set, but that's the way it goes.

A minor change again but the exception if following along would be confusing.
