### PR TITLE
Update middleware.md

### DIFF
--- a/aspnetcore/fundamentals/middleware.md
+++ b/aspnetcore/fundamentals/middleware.md
@@ -53,11 +53,6 @@ You can chain multiple request delegates together with [app.Use](https://docs.mi
 >
 > [HttpResponse.HasStarted](https://docs.microsoft.com/aspnet/core/api/microsoft.aspnetcore.http.features.httpresponsefeature#Microsoft_AspNetCore_Http_Features_HttpResponseFeature_HasStarted) is a useful hint to indicate if headers have been sent and/or the body has been written to.
 
-
-
->- Calling `next` may send the response to the client. Changes made to the `HttpResponse` after calling `next` will be lost if the response has been sent. Use [HttpResponse.HasStarted](https://docs.microsoft.com/aspnet/core/api/microsoft.aspnetcore.http.features.httpresponsefeature#Microsoft_AspNetCore_Http_Features_HttpResponseFeature_HasStarted) to check whether the headers have been sent.
->- Do **not** call `next.Invoke` after calling a `Write` method. A middleware component either produces a response or calls `next.Invoke`, but not both.
-
 ## Ordering
 
 The order that middleware components are added in the `Configure` method defines the order in which they are invoked on requests, and the reverse order for the response. This ordering is critical for security, performance, and functionality.

--- a/aspnetcore/fundamentals/middleware.md
+++ b/aspnetcore/fundamentals/middleware.md
@@ -47,7 +47,7 @@ You can chain multiple request delegates together with [app.Use](https://docs.mi
 [!code-csharp[Main](middleware/sample/Chain/Startup.cs?name=snippet1)]
 
 >[!WARNING]
-> Do not call `next` after the response has been sent to the client. Changes to `HttpResponse` after the response has started will throw an exception. For example, changes such as setting headers, status code, etc,  will throw an exception. Writing to the response body after calling `next`:
+> Do not call `next.Invoke` after the response has been sent to the client. Changes to `HttpResponse` after the response has started will throw an exception. For example, changes such as setting headers, status code, etc,  will throw an exception. Writing to the response body after calling `next`:
 > - May cause a protocol violation. For example, writing more than the stated `content-length`) 
 > - May corrupt the body format. For example, writing an HTML footer to a CSS file.
 >

--- a/aspnetcore/fundamentals/middleware.md
+++ b/aspnetcore/fundamentals/middleware.md
@@ -48,7 +48,7 @@ You can chain multiple request delegates together with [app.Use](https://docs.mi
 
 >[!WARNING]
 > Do not call `next.Invoke` after the response has been sent to the client. Changes to `HttpResponse` after the response has started will throw an exception. For example, changes such as setting headers, status code, etc,  will throw an exception. Writing to the response body after calling `next`:
-> - May cause a protocol violation. For example, writing more than the stated `content-length`) 
+> - May cause a protocol violation. For example, writing more than the stated `content-length`.
 > - May corrupt the body format. For example, writing an HTML footer to a CSS file.
 >
 > [HttpResponse.HasStarted](https://docs.microsoft.com/aspnet/core/api/microsoft.aspnetcore.http.features.httpresponsefeature#Microsoft_AspNetCore_Http_Features_HttpResponseFeature_HasStarted) is a useful hint to indicate if headers have been sent and/or the body has been written to.

--- a/aspnetcore/fundamentals/middleware.md
+++ b/aspnetcore/fundamentals/middleware.md
@@ -47,6 +47,14 @@ You can chain multiple request delegates together with [app.Use](https://docs.mi
 [!code-csharp[Main](middleware/sample/Chain/Startup.cs?name=snippet1)]
 
 >[!WARNING]
+> Do not call `next` after the response has been sent to the client. Changes to `HttpResponse` after the response has started will throw an exception. For example, changes such as setting headers, status code, etc,  will throw an exception. Writing to the response body after calling `next`:
+> - May cause a protocol violation. For example, writing more than the stated `content-length`) 
+> - May corrupt the body format. For example, writing an HTML footer to a CSS file.
+>
+> [HttpResponse.HasStarted](https://docs.microsoft.com/aspnet/core/api/microsoft.aspnetcore.http.features.httpresponsefeature#Microsoft_AspNetCore_Http_Features_HttpResponseFeature_HasStarted) is a useful hint to indicate if headers have been sent and/or the body has been written to.
+
+
+
 >- Calling `next` may send the response to the client. Changes made to the `HttpResponse` after calling `next` will be lost if the response has been sent. Use [HttpResponse.HasStarted](https://docs.microsoft.com/aspnet/core/api/microsoft.aspnetcore.http.features.httpresponsefeature#Microsoft_AspNetCore_Http_Features_HttpResponseFeature_HasStarted) to check whether the headers have been sent.
 >- Do **not** call `next.Invoke` after calling a `write` method. A middleware component either produces a response or calls `next.Invoke`, but not both.
 

--- a/aspnetcore/fundamentals/middleware.md
+++ b/aspnetcore/fundamentals/middleware.md
@@ -56,7 +56,7 @@ You can chain multiple request delegates together with [app.Use](https://docs.mi
 
 
 >- Calling `next` may send the response to the client. Changes made to the `HttpResponse` after calling `next` will be lost if the response has been sent. Use [HttpResponse.HasStarted](https://docs.microsoft.com/aspnet/core/api/microsoft.aspnetcore.http.features.httpresponsefeature#Microsoft_AspNetCore_Http_Features_HttpResponseFeature_HasStarted) to check whether the headers have been sent.
->- Do **not** call `next.Invoke` after calling a `write` method. A middleware component either produces a response or calls `next.Invoke`, but not both.
+>- Do **not** call `next.Invoke` after calling a `Write` method. A middleware component either produces a response or calls `next.Invoke`, but not both.
 
 ## Ordering
 

--- a/aspnetcore/fundamentals/middleware.md
+++ b/aspnetcore/fundamentals/middleware.md
@@ -47,10 +47,8 @@ You can chain multiple request delegates together with [app.Use](https://docs.mi
 [!code-csharp[Main](middleware/sample/Chain/Startup.cs?name=snippet1)]
 
 >[!WARNING]
->Be careful modifying the `HttpResponse` after invoking `next`, because the response may have already been sent to the client. You can use [HttpResponse.HasStarted](https://docs.microsoft.com/en-us/aspnet/core/api/microsoft.aspnetcore.http.features.httpresponsefeature#Microsoft_AspNetCore_Http_Features_HttpResponseFeature_HasStarted) to check whether the headers have been sent.
-
->[!WARNING]
-> Do **not** call `next.Invoke` after calling a `write` method. A middleware component either produces a response or calls `next.Invoke`, but not both.
+>- Calling `next` may send the response to the client. Changes made to the `HttpResponse` after calling `next` will be lost if the response has been sent. Use [HttpResponse.HasStarted](https://docs.microsoft.com/aspnet/core/api/microsoft.aspnetcore.http.features.httpresponsefeature#Microsoft_AspNetCore_Http_Features_HttpResponseFeature_HasStarted) to check whether the headers have been sent.
+>- Do **not** call `next.Invoke` after calling a `write` method. A middleware component either produces a response or calls `next.Invoke`, but not both.
 
 ## Ordering
 


### PR DESCRIPTION
[Review URL](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware?branch=pr-en-us-3268)
@Tratcher 
The warning implies it's ok to modify the response    if  `(HttpResponse.HasStarted == false)` - but what happens if the response if sent to the client before you modify the the `HttpResponse`? Are you guaranteed that won't happen?

```
app.Use(async (context, next) =>
        {
            // Do work that doesn't write to the Response.
            await next.Invoke();
            if (HttpResponse.HasStarted == false)
              await context.Response.WriteAsync("Hello ");
        });