### PR TITLE
Changed the "LogOff" action name into "LogOut"

### DIFF
--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -77,7 +77,7 @@ In this topic, you'll learn how to use ASP.NET Core Identity to add functionalit
  
 4.  Log off.
  
-    Clicking the **Log off** link calls the `LogOff` action in the account controller.
+    Clicking the **Log off** link calls the `LogOut` action in the account controller.
  
     [!code-csharp[Main](identity/sample/src/ASPNET-IdentityDemo/Controllers/AccountController.cs?highlight=5&range=131-138)]
  


### PR DESCRIPTION
Changed the "LogOff" action name into "LogOut".Changed the "LogOff" action name into "LogOut".By default ASP Net core provides Logoff action in "LogOut" ActionResult Only.Also raised PR for changed the action name in account controller .
