### PR TITLE
Updating line 78: Correcting French punctuation.

### DIFF
--- a/aspnetcore/fundamentals/localization.md
+++ b/aspnetcore/fundamentals/localization.md
@@ -75,7 +75,7 @@ A French resource file could contain the following:
 
 | Key | Value |
 | ----- | ------ |
-| `<i>Hello</i> <b>{0}!</b>` | `<i>Bonjour</i> <b>{0}!</b>` |
+| `<i>Hello</i> <b>{0}!</b>` | `<i>Bonjour</i> <b>{0} !</b> ` |
 
 The rendered view would contain the HTML markup from the resource file.
 


### PR DESCRIPTION
In French, a space is required both before and after all two- (or more) part punctuation marks and symbols, including the exclamation mark "!". See https://www.thoughtco.com/how-to-use-french-punctuation-4086509 for more information.

*This pull request was suggested by @RickAndMSFT.*
