### PR TITLE
With VS2017 and dotnet 1.0 installation aspnet geneator needs to have latest version…

### DIFF
--- a/aspnetcore/client-side/yeoman.md
+++ b/aspnetcore/client-side/yeoman.md
@@ -34,7 +34,7 @@ npm install -g yo bower
 From a command prompt, install the ASP.NET generator:
 
 ```console
-npm install -g generator-aspnet@0.2.6
+npm install -g generator-aspnet
 ```
 
 > [!NOTE]


### PR DESCRIPTION
With VS2017 and dotnet 1.0 installation aspnet geneator needs to have latest version…

Because dotnet 1.0.0 it looks for .csproj file..

