### PR TITLE
Missing ending parentheses in AddAuthorization example code

### DIFF
--- a/aspnetcore/security/authorization/claims.md
+++ b/aspnetcore/security/authorization/claims.md
@@ -94,7 +94,7 @@ public void ConfigureServices(IServiceCollection services)
     {
         options.AddPolicy("Founders", policy =>
                           policy.RequireClaim("EmployeeNumber", "1", "2", "3", "4", "5"));
-    }
+    });
 }
 ```
 


### PR DESCRIPTION
Fixes missing ending parentheses in AddAuthorization example code.