### PR TITLE
Remove unnecessary quotations from localization cookie format

### DIFF
--- a/aspnetcore/fundamentals/localization.md
+++ b/aspnetcore/fundamentals/localization.md
@@ -201,7 +201,7 @@ The `CookieRequestCultureProvider` `DefaultCookieName`  returns the default cook
 
 The cookie format is `c=%LANGCODE%|uic=%LANGCODE%`, where `c` is `Culture` and `uic` is `UICulture`, for example:
 
-    c='en-UK'|uic='en-US'
+    c=en-UK|uic=en-US
 
 If you only specify one of culture info and UI culture, the specified culture will be used for both culture info and UI culture.
 


### PR DESCRIPTION
I made this PR according to the issue that created in the localization repo https://github.com/aspnet/Localization/issues/370, according localization cookie format

It seems someone confused with this line of code https://github.com/aspnet/Localization/blob/dev/samples/LocalizationSample/Startup.cs#L81, because there's no quotation at all in the actual cookie format

/cc @RickAndMSFT 