### PR TITLE
Mitigate possible race condition in MessageHandler1

### DIFF
--- a/aspnet/web-api/overview/advanced/httpclient-message-handlers/samples/sample2.cs
+++ b/aspnet/web-api/overview/advanced/httpclient-message-handlers/samples/sample2.cs
@@ -5,7 +5,7 @@ class MessageHandler1 : DelegatingHandler
     protected override Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
     {
-        _count++;
+        System.Threading.Interlocked.Increment(ref _count);
         request.Headers.Add("X-Custom-Header", _count.ToString());
         return base.SendAsync(request, cancellationToken);
     }


### PR DESCRIPTION
MSDN description of DelegatingHandler Class says:
"Any instance members are not guaranteed to be thread safe"
https://msdn.microsoft.com/en-us/library/system.net.http.delegatinghandler(v=vs.118).aspx