### PR TITLE
document registering View Component Tag Helpers

### DIFF
--- a/aspnetcore/mvc/views/view-components.md
+++ b/aspnetcore/mvc/views/view-components.md
@@ -107,7 +107,7 @@ Pascal-cased class and method parameters for Tag Helpers are translated into the
 </vc:[view-component-name]>
 ```
 
-Note that in order to use a View Component as a Tag Helper, you must register the assembly containing the View Component using the `@addTagHelper` directive. For example, if your View Component is in an assembly called "MyWebApp" you will need the following directive in your `_ViewImports.cshtml` file to register the View Components:
+Note that in order to use a View Component as a Tag Helper, you must register the assembly containing the View Component using the `@addTagHelper` directive. For example, if your View Component is in an assembly called "MyWebApp" you will need the following directive in your `_ViewImports.cshtml` file (or to any file that references the View Component, see [Managing Tag Helper Scope](../../mvc/views/tag-helpers/intro.md#managing-tag-helper-scope) for more info) to register the View Components:
 
 ```csharp
 @addTagHelper "*, MyWebApp"

--- a/aspnetcore/mvc/views/view-components.md
+++ b/aspnetcore/mvc/views/view-components.md
@@ -107,6 +107,12 @@ Pascal-cased class and method parameters for Tag Helpers are translated into the
 </vc:[view-component-name]>
 ```
 
+Note that in order to use a View Component as a Tag Helper, you must register the assembly containing the View Component using the `@addTagHelper` directive. For example, if your View Component is in an assembly called "MyWebApp" you will need the following directive in your `_ViewImports.cshtml` file to register the View Components:
+
+```csharp
+@addTagHelper "*, MyWebApp"
+```
+
 The `InvokeAsync` method used in this tutorial:
 
 [!code-html[Main](view-components/sample/ViewCompFinal/Views/Todo/IndexFinal.cshtml?range=35)]

--- a/aspnetcore/mvc/views/view-components.md
+++ b/aspnetcore/mvc/views/view-components.md
@@ -113,7 +113,7 @@ Note: In order to use a View Component as a Tag Helper, you must register the as
 @addTagHelper "*, MyWebApp"
 ```
 
-You can register a View Component as a Tag Helper to any file that references the View Component. See [Managing Tag Helper Scope](xref:mvc/views/tag-helpers/intro#managing-tag-helper-scope) for more information on how to register View Components.
+You can register a View Component as a Tag Helper to any file that references the View Component. See [Managing Tag Helper Scope](xref:mvc/views/tag-helpers/intro#managing-tag-helper-scope) for more information on how to register Tag Helpers.
 
 The `InvokeAsync` method used in this tutorial:
 

--- a/aspnetcore/mvc/views/view-components.md
+++ b/aspnetcore/mvc/views/view-components.md
@@ -113,7 +113,7 @@ Note: In order to use a View Component as a Tag Helper, you must register the as
 @addTagHelper "*, MyWebApp"
 ```
 
-You can register a View Component as a Tag Helper to any file that references the View Component. See [Managing Tag Helper Scope]xref:mvc/views/tag-helpers/intro#managing-tag-helper-scope for more information on how to register View Components.
+You can register a View Component as a Tag Helper to any file that references the View Component. See [Managing Tag Helper Scope](xref:mvc/views/tag-helpers/intro#managing-tag-helper-scope) for more information on how to register View Components.
 
 The `InvokeAsync` method used in this tutorial:
 

--- a/aspnetcore/mvc/views/view-components.md
+++ b/aspnetcore/mvc/views/view-components.md
@@ -107,11 +107,13 @@ Pascal-cased class and method parameters for Tag Helpers are translated into the
 </vc:[view-component-name]>
 ```
 
-Note that in order to use a View Component as a Tag Helper, you must register the assembly containing the View Component using the `@addTagHelper` directive. For example, if your View Component is in an assembly called "MyWebApp" you will need the following directive in your `_ViewImports.cshtml` file (or to any file that references the View Component, see [Managing Tag Helper Scope](../../mvc/views/tag-helpers/intro.md#managing-tag-helper-scope) for more info) to register the View Components:
+Note: In order to use a View Component as a Tag Helper, you must register the assembly containing the View Component using the `@addTagHelper` directive. For example, if your View Component is in an assembly called "MyWebApp", add the following directive to the `_ViewImports.cshtml` file:
 
 ```csharp
 @addTagHelper "*, MyWebApp"
 ```
+
+You can register a View Component as a Tag Helper to any file that references the View Component. See [Managing Tag Helper Scope]xref:mvc/views/tag-helpers/intro#managing-tag-helper-scope for more information on how to register View Components.
 
 The `InvokeAsync` method used in this tutorial:
 


### PR DESCRIPTION
This adds some docs to clarify that in order to use a View Component as a Tag Helper, you need to register the assembly containing the View Component using `@addTagHelper`

fixes #3435