### PR TITLE
modified mvc example to use c#7

### DIFF
--- a/aspnetcore/security/authorization/policies.md
+++ b/aspnetcore/security/authorization/policies.md
@@ -231,9 +231,7 @@ The use of the `Resource` property is framework specific. Using information in t
 <!-- literal_block {"ids": [], "names": [], "highlight_args": {}, "backrefs": [], "dupnames": [], "linenos": false, "classes": [], "xml:space": "preserve", "language": "c#"} -->
 
 ```csharp
-var mvcContext = context.Resource as Microsoft.AspNetCore.Mvc.Filters.AuthorizationFilterContext;
-
-if (mvcContext != null)
+if (context.Resource is Microsoft.AspNetCore.Mvc.Filters.AuthorizationFilterContext mvcContext)
 {
     // Examine MVC specific things like routing data.
 }


### PR DESCRIPTION
As suggested by VS2017 I've substituted the 2 line code by an inline temporary variable in the last code example of the doc page.
