### PR TITLE
Add KeyDelimiter replacement to GetKey function.

### DIFF
--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -56,7 +56,9 @@ public class EnvironmentSecretManager : IKeyVaultSecretManager
 
     public string GetKey(SecretBundle secret)
     {
-        return secret.SecretIdentifier.Name.Substring(_appNamePrefix.Length);
+        return secret.SecretIdentifier.Name
+                     .Substring(_appNamePrefix.Length)
+                     .Replace("--", ConfigurationPath.KeyDelimiter);
     }
 }
 ```


### PR DESCRIPTION
Without the handling of "--" the keys never get turned into sections seperated by the ConfigurationPath delimiter.