### PR TITLE
Update ForgotPassword.cshtml file

### DIFF
--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -122,7 +122,7 @@ Note: We're also preventing a newly registered user from being automatically log
 
 [!code-csharp[Main](accconfirm/sample/WebApp1/Controllers/AccountController.cs?highlight=17-23&name=snippet_ForgotPassword)]
 
-Uncomment the form element in *Views/Account/ForgotPassword.cshtml*. You might want remove the `<p> For more information on how to enable reset password ... </p> element which contains a link to this article.
+Uncomment the form element in *Views/Account/ForgotPassword.cshtml*. You might want to remove the `<p> For more information on how to enable reset password ... </p>` element which contains a link to this article.
 
 [!code-html[Main](accconfirm/sample/WebApp1/Views/Account/ForgotPassword.cshtml?highlight=7-9,11,27)]
 

--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -124,7 +124,7 @@ Note: We're also preventing a newly registered user from being automatically log
 
 Uncomment the form element in *Views/Account/ForgotPassword.cshtml*. You might want to remove the `<p> For more information on how to enable reset password ... </p>` element which contains a link to this article.
 
-[!code-html[Main](accconfirm/sample/WebApp1/Views/Account/ForgotPassword.cshtml?highlight=7-9,11,27)]
+[!code-html[Main](accconfirm/sample/WebApp1/Views/Account/ForgotPassword.cshtml?highlight=7-10,12,28)]
 
 ## Register, confirm email, and reset password
 

--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -122,9 +122,9 @@ Note: We're also preventing a newly registered user from being automatically log
 
 [!code-csharp[Main](accconfirm/sample/WebApp1/Controllers/AccountController.cs?highlight=17-23&name=snippet_ForgotPassword)]
 
-Uncomment the markup in *Views/Account/ForgotPassword.cshtml* and comment out or remove the paragraph with the link to this article:
+Uncomment the form element in *Views/Account/ForgotPassword.cshtml* razor file. You might want remove the `<p> For more information on how to enable reset password ... </p> element which contains a link to this article.
 
-[!code-html[Main](accconfirm/sample/WebApp1/Views/Account/ForgotPassword.cshtml)]
+[!code-html[Main](accconfirm/sample/WebApp1/Views/Account/ForgotPassword.cshtml?highlight=7-9,11,27)]
 
 ## Register, confirm email, and reset password
 

--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -122,7 +122,7 @@ Note: We're also preventing a newly registered user from being automatically log
 
 [!code-csharp[Main](accconfirm/sample/WebApp1/Controllers/AccountController.cs?highlight=17-23&name=snippet_ForgotPassword)]
 
-Uncomment the form element in *Views/Account/ForgotPassword.cshtml* razor file. You might want remove the `<p> For more information on how to enable reset password ... </p> element which contains a link to this article.
+Uncomment the form element in *Views/Account/ForgotPassword.cshtml*. You might want remove the `<p> For more information on how to enable reset password ... </p> element which contains a link to this article.
 
 [!code-html[Main](accconfirm/sample/WebApp1/Views/Account/ForgotPassword.cshtml?highlight=7-9,11,27)]
 

--- a/aspnetcore/security/authentication/accconfirm/sample/WebApp1/Views/Account/ForgotPassword.cshtml
+++ b/aspnetcore/security/authentication/accconfirm/sample/WebApp1/Views/Account/ForgotPassword.cshtml
@@ -1,13 +1,13 @@
-﻿@model ForgotPasswordViewModel
+@model ForgotPasswordViewModel
 @{
     ViewData["Title"] = "Forgot your password?";
 }
 
 <h2>@ViewData["Title"]</h2>
-<p>
+@*<p>
     For more information on how to enable reset password please see this
     <a href="https://go.microsoft.com/fwlink/?LinkID=532713">article</a>.
-</p>
+</p>*@
 
 <form asp-controller="Account" asp-action="ForgotPassword" method="post" class="form-horizontal">
     <h4>Enter your email.</h4>


### PR DESCRIPTION
The text in the ForgotPassword.cshtml file is incorrect as it leaves the paragraph linking back to the article https://go.microsoft.com/fwlink/?LinkID=532713 intact. 