### PR TITLE
Remove double quotes used in addTagHelper directives

### DIFF
--- a/aspnetcore/client-side/angular/sample/AngularJSSample/src/AngularJSSample/Views/_ViewImports.cshtml
+++ b/aspnetcore/client-side/angular/sample/AngularJSSample/src/AngularJSSample/Views/_ViewImports.cshtml
@@ -1,3 +1,3 @@
 ﻿@using AngularSample
 @using AngularSample.Models
-@addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/aspnetcore/mvc/models/validation/sample/Views/_ViewImports.cshtml
+++ b/aspnetcore/mvc/models/validation/sample/Views/_ViewImports.cshtml
@@ -1,2 +1,2 @@
 ﻿@using MVCMovie.Models
-@addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -99,7 +99,7 @@ The *MyApp/Pages/Contact.cshtml* file:
 @page
 @using MyApp
 @using Microsoft.AspNetCore.Mvc.RazorPages
-@addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @inject ApplicationDbContext Db
 
 @functions {
@@ -163,7 +163,7 @@ You could write this form by partitioning the view code and the handler method i
 @using MyApp
 @using MyApp.Pages
 @using Microsoft.AspNetCore.Mvc.RazorPages
-@addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @model ContactModel
 
 <html>
@@ -253,7 +253,7 @@ Add a *_ViewImports.cshtml* file:
 ```c#
 @namespace MyApp.Pages
 @using Microsoft.AspNetCore.Mvc.RazorPages
-@addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 ```
 
 The `@namespace` directive is a new feature that controls the namespace of the generated code.  If the `@namespace` directive is used explicitly on a page, that page's namespace will match specified namespace exactly. If the `@namespace` directive is contained in *_ViewImports.cshtml*, the specified namespace is only the prefix. The suffix is the dot-seperated relative path between the folder containing *_ViewImports.cshtml* and the folder containing the page.

--- a/aspnetcore/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/z1AutoLinkerCopy.cs
+++ b/aspnetcore/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/z1AutoLinkerCopy.cs
@@ -39,7 +39,7 @@ namespace AuthoringTagHelpers.TagHe1pers
 
 /* ViewImports need TagHe1pers
  * 
- @addTagHelper "AuthoringTagHelpers.TagHe1pers.AutoLinkerHttpTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHe1pers.AutoLinkerWwwTagHelper, AuthoringTagHelpers"
+ @addTagHelper AuthoringTagHelpers.TagHe1pers.AutoLinkerHttpTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHe1pers.AutoLinkerWwwTagHelper, AuthoringTagHelpers
 
     */

--- a/aspnetcore/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/z2AutoLinkerCopy.cs
+++ b/aspnetcore/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/TagHelpers/z2AutoLinkerCopy.cs
@@ -44,6 +44,6 @@ namespace AuthoringTagHelpers.TagHelpers
 }
 
 /*
-@addTagHelper "AuthoringTagHelpers.TagHelpers.AutoLinkerHttpTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.AutoLinkerWwwTagHelper, AuthoringTagHelpers"
+@addTagHelper AuthoringTagHelpers.TagHelpers.AutoLinkerHttpTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.AutoLinkerWwwTagHelper, AuthoringTagHelpers
 */

--- a/aspnetcore/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImports.cshtml
+++ b/aspnetcore/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImports.cshtml
@@ -1,13 +1,13 @@
 ﻿@using AuthoringTagHelpers
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper "AuthoringTagHelpers.TagHelpers3.EmailTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.WebsiteInformationTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.ConditionTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.AutoLinkerHttpTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.AutoLinkerWwwTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers3.BoldTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.AutoLinkerHttpTagHelper, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.AutoLinkerWwwTagHelper, AuthoringTagHelpers"
+@addTagHelper AuthoringTagHelpers.TagHelpers3.EmailTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.WebsiteInformationTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.ConditionTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.AutoLinkerHttpTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.AutoLinkerWwwTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers3.BoldTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.AutoLinkerHttpTagHelper, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.AutoLinkerWwwTagHelper, AuthoringTagHelpers
 
 
 
@@ -16,5 +16,5 @@
     _ViewImportsCopy is used to mock _ViewImports in the .rst file
 
     When you get to the fully functional email tag, use
-    @addTagHelper "AuthoringTagHelpers.TagHelpers2.EmailTagHelper, AuthoringTagHelpers"
+    @addTagHelper AuthoringTagHelpers.TagHelpers2.EmailTagHelper, AuthoringTagHelpers
 *@

--- a/aspnetcore/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImportsCopy.cshtml
+++ b/aspnetcore/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImportsCopy.cshtml
@@ -1,3 +1,3 @@
 ﻿@using AuthoringTagHelpers
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper "*, AuthoringTagHelpers"
+@addTagHelper *, AuthoringTagHelpers

--- a/aspnetcore/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImportsCopyEmail.cshtml
+++ b/aspnetcore/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImportsCopyEmail.cshtml
@@ -1,3 +1,3 @@
 ﻿@using AuthoringTagHelpers
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper "*, AuthoringTagHelpers"
+@addTagHelper *, AuthoringTagHelpers

--- a/aspnetcore/mvc/views/tag-helpers/intro.md
+++ b/aspnetcore/mvc/views/tag-helpers/intro.md
@@ -73,14 +73,14 @@ If your project contains an `EmailTagHelper` with the default namespace (`Author
 ```html
 @using AuthoringTagHelpers
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper "AuthoringTagHelpers.TagHelpers.EmailTagHelper, AuthoringTagHelpers"
+@addTagHelper AuthoringTagHelpers.TagHelpers.EmailTagHelper, AuthoringTagHelpers
 ```
 
 To add a Tag Helper to a view using an FQN, you first add the FQN (`AuthoringTagHelpers.TagHelpers.EmailTagHelper`), and then the assembly name (*AuthoringTagHelpers*). Most developers prefer to use the  "\*" wildcard syntax. The wildcard syntax allows you to insert the wildcard character "\*" as the suffix in an FQN. For example, any of the following directives will bring in the `EmailTagHelper`:
 
 ```csharp
-@addTagHelper "AuthoringTagHelpers.TagHelpers.E*, AuthoringTagHelpers"
-@addTagHelper "AuthoringTagHelpers.TagHelpers.Email*, AuthoringTagHelpers"
+@addTagHelper AuthoringTagHelpers.TagHelpers.E*, AuthoringTagHelpers
+@addTagHelper AuthoringTagHelpers.TagHelpers.Email*, AuthoringTagHelpers
 ```
 
 As mentioned previously, adding the `@addTagHelper` directive to the *Views/_ViewImports.cshtml* file makes the Tag Helper available to all view files in the *Views* directory and sub-directories. You can use the `@addTagHelper` directive in specific view files if you want to opt-in to exposing the Tag Helper to only those views.

--- a/aspnetcore/mvc/views/view-components.md
+++ b/aspnetcore/mvc/views/view-components.md
@@ -110,7 +110,7 @@ Pascal-cased class and method parameters for Tag Helpers are translated into the
 Note: In order to use a View Component as a Tag Helper, you must register the assembly containing the View Component using the `@addTagHelper` directive. For example, if your View Component is in an assembly called "MyWebApp", add the following directive to the `_ViewImports.cshtml` file:
 
 ```csharp
-@addTagHelper "*, MyWebApp"
+@addTagHelper *, MyWebApp
 ```
 
 You can register a View Component as a Tag Helper to any file that references the View Component. See [Managing Tag Helper Scope](xref:mvc/views/tag-helpers/intro#managing-tag-helper-scope) for more information on how to register Tag Helpers.


### PR DESCRIPTION
Remove the optional double quotes used in the `@addTagHelper` directives. This aligns with what's used in the VS project templates.