### PR TITLE
Unused id parameter in Create action

### DIFF
--- a/aspnetcore/mobile/native-mobile-backend/sample/ToDoApi/src/ToDoApi/Controllers/TodoItemsController.cs
+++ b/aspnetcore/mobile/native-mobile-backend/sample/ToDoApi/src/ToDoApi/Controllers/TodoItemsController.cs
@@ -31,7 +31,7 @@ namespace ToDoApi.Controllers
                 {
                     return BadRequest(ErrorCode.TodoItemNameAndNotesRequired.ToString());
                 }
-                bool itemExists = _toDoRepository.DoesItemExist(item.ID);
+                bool itemExists = _toDoRepository.DoesItemExist(id);
                 if (itemExists)
                 {
                     return StatusCode(StatusCodes.Status409Conflict, ErrorCode.TodoItemIDInUse.ToString());


### PR DESCRIPTION
The unused id parameter in the Create action is now used to check if the item exists. This seems more consistent with the Edit action, since it uses its id parameter for a lookup.