### PR TITLE
Fixed broken link syntax

### DIFF
--- a/aspnetcore/includes/webApi/next.md
+++ b/aspnetcore/includes/webApi/next.md
@@ -1,6 +1,6 @@
 ## Next steps
 
-* [ASP.NET Web API Help Pages using Swagger}(xref:tutorials/web-api-help-pages-using-swagger)
+* [ASP.NET Web API Help Pages using Swagger](xref:tutorials/web-api-help-pages-using-swagger)
 * [Routing to Controller Actions](xref:mvc/controllers/routing)
 * For information about deploying your API, see [Publishing and Deployment](xref:publishing/index).
 * [View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/tutorials/first-web-api/sample). See [how to download](xref:tutorials/index#how-to-download-a-sample).


### PR DESCRIPTION
Fixed the Swagger link syntax in the Next Steps section of the ASP.net Core Web API tutorial.