### PR TITLE
Remove implied ToolsVersion property

### DIFF
--- a/aspnetcore/mvc/views/view-compilation/sample/MvcRazorCompileOnPublish.csproj
+++ b/aspnetcore/mvc/views/view-compilation/sample/MvcRazorCompileOnPublish.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>


### PR DESCRIPTION
The .csproj file's `ToolsVersion` attribute is implied. Removing it to simplify the code sample.

@Rick-Anderson Please review.
