### PR TITLE
Razor Pages update

### DIFF
--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -35,7 +35,7 @@ If you are using a typical *Startup.cs* like the following code, Razor Pages is 
 
 [!code-cs[main](index/sample/RazorPagesIntro/Startup.cs?name=Startup)]
 
-All the Razor Pages types and features are in the `Microsoft.AspNetCore.Mvc.RazorPages` assembly. The `Microsoft.AspNetCore.Mvc` package includes the Razor Pages assembly. The  `Microsoft.AspNetCore.All` metapackage include all ASP.NET Core 2.x packages.
+All the Razor Pages types and features are in the `Microsoft.AspNetCore.Mvc.RazorPages` assembly. The `Microsoft.AspNetCore.Mvc` package includes the Razor Pages assembly. The `Microsoft.AspNetCore.All` metapackage includes all ASP.NET Core 2.x packages.
 
 Consider a basic page:
 <a name="OnGet"></a>

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -5,59 +5,57 @@ description: Overview of Razor Pages in ASP.NET Core
 keywords: ASP.NET Core, Razor Pages
 ms.author: riande
 manager: wpickett
-ms.date: 06/28/2017
+ms.date: 07/28/2017
 ms.topic: get-started-article
 ms.assetid: 30e4104c-0124-477b-86b3-beb7b34ed3f6
 ms.technology: aspnet
 ms.prod: asp.net-core
 uid: mvc/razor-pages/index
 ---
-## Introduction to Razor Pages in ASP.NET Core
+# Introduction to Razor Pages in ASP.NET Core
 
-By [Ryan Nowak](https://github.com/rynowak) and [Rick Anderson](https://twitter.com/RickAndMSFT)
+By [Rick Anderson](https://twitter.com/RickAndMSFT) and [Ryan Nowak](https://github.com/rynowak) 
 
 Razor Pages is a new feature of ASP.NET Core MVC that makes coding page-focused scenarios easier and more productive.
 
 Razor Pages requires ASP.NET Core 2.0.0 or later. Tooling support for Razor Pages ships in Visual Studio 2017 Update 3 or later.
 
-## Getting started
+[Download or view sample code](https://github.com/Rick-Anderson/razor-page-intro).
 
-Razor Pages is on by default in MVC. If you are using a typical *Startup.cs* like the following code, Razor Pages is enabled:
+<a name="prerequisites"></a>
 
-```c#
-public class Startup
-{
-    public void ConfigureServices(IServiceCollection services)
-    {
-        services.AddMvc(); // Includes support for pages and controllers.
-    }
+## ASP.NET Core 2.0 preview prerequisites
 
-    public void Configure(IApplicationBuilder app)
-    {
-        app.UseMvc();
-    }
-}
-```
+ASP.NET Core 2.0 preview  is included in .NET Core 2.0 preview. [Download .NET Core 2.0 Preview 2](https://www.microsoft.com/net/core/preview) 
 
-All the new Razor Pages types and features are included in the `Microsoft.AspNetCore.Mvc.RazorPages` assembly. If you are referencing the `Microsoft.AspNetCore.Mvc` package, then a reference to the Razor Pages assembly is already included.
+Optional: [Visual Studio 2017 Preview](https://www.visualstudio.com/vs/preview/)
+
+## Razor Pages
+
+If you are using a typical *Startup.cs* like the following code, Razor Pages is enabled:
+
+[!code-cs[main](../../../razor-page-intro/RazorPagesIntro/Startup.cs?name=Startup)]
+
+All the Razor Pages types and features are included in the `Microsoft.AspNetCore.Mvc.RazorPages` assembly. If you are referencing the `Microsoft.AspNetCore.Mvc` package, a reference to the Razor Pages assembly is included.
 
 Consider a basic page:
+<a name="OnGet"></a>
 
-```html
-@page
+[!code-html[main](../../../razor-page-intro/RazorPagesIntro/Pages/Index.cshtml)]
 
-@{
-    var message = "Hello, World!";
-}
+The preceeding code looks a lot like a Razor view file. What makes it different is the new `@page` directive. `@page` makes the file into an MVC action - which means that it can handle requests directly, without going through a controller. `@page` must be the first Razor directive on a page. `@page` affects the behavior of other Razor constructs. The [@functions](xref:mvc/views/razor#functions) directive enables function level content.
 
-<html>
-<body>
-    <p>@message</p>
-</body>
-</html>
-```
+A similar page, with the `PageModel` in a separate file, is shown in the following two files:
 
-The preceeding code looks a lot like a regular Razor view file. What makes it different is the new `@page` directive. Using `@page` makes this file into an MVC action - which means that it can handle requests directly, without going through a controller. `@page` must be the first Razor directive on a page. `@page` affects the behavior of other Razor constructs.
+[!code-html[main](../../../razor-page-intro/RazorPagesIntro/Pages/Index2.cshtml)]
+
+The `PageModel` class *Pages/Index2.cshtml.cs*, a code-behind file for the view code:
+
+[!code-cs[main](../../../razor-page-intro/RazorPagesIntro/Pages/Index2.cshtml.cs)]
+
+By convention, the `PageModel` class file has the same name as the Razor Page file with *.cs* appended. For example, the previous Razor Page is *Pages/Index2.cshtml*. The file containing the `PageModel` class is named *Pages/Index2.cshtml.cs*.
+
+For simple pages, mixing the `PageModel` class with the Razor markup is fine. For more complex code, it's a best practice to keep the page model code seperate.
 
 The associations of URL paths to pages are determined by the page's location in the file system. The following table shows a Razor Pages path and the matching URL:
 
@@ -75,313 +73,181 @@ The new Razor Pages features are designed to make common patterns used with web 
 
 For the examples in this document, the `DbContext` is initialized in the *Startup.cs* file.
 
-The *MyApp/Contact.cs* file:
+[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Startup.cs?highlight=15-16)]
 
-```c#
-using System.ComponentModel.DataAnnotations;
+The data model:
 
-namespace MyApp 
-{
-    public class Contact
-    {
-        [Required]
-        public string Name { get; set; }
+[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Data/Customer.cs)]
 
-        [Required]
-        public string Email { get; set; }
-    }
-}
-```
+The *Pages/Create.cshtml* view file:
 
-The *MyApp/Pages/Contact.cshtml* file:
+[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/Create.cshtml)]
 
-```html
-@page
-@using MyApp
-@using Microsoft.AspNetCore.Mvc.RazorPages
-@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@inject ApplicationDbContext Db
+The `PageModel` class *Pages/Create.cshtml.cs* code-behind file for the view:
 
-@functions {
-    [BindProperty]
-    public Contact Contact { get; set; }
-    
-    public async Task<IActionResult> OnPostAsync()
-    {
-        if (ModelState.IsValid)
-        {
-            Db.Contacts.Add(Contact);
-            await Db.SaveChangesAsync();
-            return RedirectToPage();
-        }
-        
-        return Page();
-    }
-}
+[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Pages/Create.cshtml.cs?name=ALL)]
 
-<html>
-<body>
-    <p>Enter your contact info here and we will email you about 
-         our fine products!</p> 
-    <div asp-validation-summary="All"></div>
-    <form method="POST">
-      <div>Name: <input asp-for="Contact.Name" /></div>
-      <div>Email: <input asp-for="Contact.Email" /></div>
-      <input type="submit" />
-    </form>
-</body>
-</html>
-```
+By convention, the `PageModel` class is called `<PageName>Model` and is in the same namespace as the page. Not much change is needed to convert from a page using `@functions` to define handlers and a page using a `PageModel` class. 
+
+Using a `PageModel` code-behind file supports unit testing, but requires you to write an explicit constructor and class. Pages without `PageModel` code-behind files support runtime compilation, which can be an advantage in development.  <!-- review: advantage because you can make changes and refresh the browser without explicitly compiling the app -->
 
 The page has an `OnPostAsync` *handler method* which runs on `POST` requests (when a user posts the form). You can add handler methods for any HTTP verb. The most common handlers are:
 
-* `OnGet` to initialize state needed for the page.
+* `OnGet` to initialize state needed for the page. [OnGet](#OnGet) sample.
 * `OnPost` to handle form submissions. 
 
-The `Async` naming suffix is optional but is often used by convention. The code that's in `OnPostAsync` in the preceding example looks similar to what you would normally write in a controller. This is typical for pages. Most of the MVC primitives like model binding, validation, and action results are shared.
+The `Async` naming suffix is optional but is often used by convention. The code that's in `OnPostAsync` in the preceding example looks similar to what you would normally write in a controller. This is typical for Razor Pages. Most of the MVC primitives like [model binding](xref:mvc/models/model-binding), [validation](xref:mvc/models/validation), and action results are shared.  <!-- Review: Ryan, can we get a list of what is shared and what isn't? -->
 
-The basic flow of `OnPostAsync` is:
+The previous `OnPostAsync` method:
+
+[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Pages/Create.cshtml.cs?name=OnPostAsync)]
+
+The basic flow of `OnPostAsync`: 
 
 Check for validation errors.
 
 *  If there are no errors, save the data and redirect.
-*  If there are errors, show the page again with the validation message.
+*  If there are errors, show the page again with validation messages. Client side validation is identical to traditonal ASP.NET Core MVC applications. In many cases validation errors would be caught on the client and never submitted to the server.
 
-When the data is entered successfully, the `OnPostAsync` handler method calls the `RedirectToPage` helper method to return an instance of `RedirectToPageResult`. This is a new action result similar to `RedirectToAction` or `RedirectToRoute` but customized for pages. In the preceding sample, it redirects back to the same URL as the current page (`/Contact`). Later, I'll show how to redirect to a different page.
+When the data is entered successfully, the `OnPostAsync` handler method calls the `RedirectToPage` helper method to return an instance of `RedirectToPageResult`. This is a new action result similar to `RedirectToAction` or `RedirectToRoute` but customized for pages. In the preceding sample, it redirects to the Index page (`/Index`). `RedirectToPage` is detailed in the [URL generation for Pages](#url_gen) section.
 
-When the submitted form has validation errors, the`OnPostAsync` handler method calls the `Page` helper method. `Page` returns an instance of `PageResult`. This is similar to how actions in controllers return `View`. `PageResult` is the default for a handler method. A handler method that returns `void` will render the page.
+When the submitted form has validation errors (that are passed to the server), the`OnPostAsync` handler method calls the `Page` helper method. `Page` returns an instance of `PageResult`. This is similar to how actions in controllers return `View`. `PageResult` is the default <!-- Review default what? Return type?? --> for a handler method. A handler method that returns `void` will render the page.
 
-The `Contact` property is using the new `[BindProperty]` attribute to opt-in to model binding. Pages, by default, bind properties only with non-GET verbs. Binding to properties can reduce the amount of code you have to write by using the same property to render form fields (`<input asp-for="Contacts.Name" />`) and accept the input.
+The `Customer` property is using the new `[BindProperty]` attribute to opt-in to model binding. 
 
-Rather than using `@model` here, we're taking advantage of a special new feature for pages. By default, the generated `Page`-derived class *is* the model. This means that features like model binding, tag helpers, and HTML helpers all *just work* with the properties defined in `@functions`. Using a *view model* with Razor views is a best practice. With pages, you get a view model automatically. 
+[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Pages/Create.cshtml.cs?name=PageModel&highlight=10-11)]
 
-Notice that this Page uses `@inject` for dependency injection, which is the same as traditional Razor views. The `@inject` statement generates the `Db` property that is used in `OnPostAsync`. Injected (`@inject`) properties are set before handler methods run.
+Razor Pages, by default, bind properties only with non-GET verbs. Binding to properties can reduce the amount of code you have to write by using the same property to render form fields (`<input asp-for="Customer.Name" />`) and accept the input.
 
-You don't have to write any code for antiforgery validation. Antiforgery token generation and validation is automatic for pages. No additional code or attributes are needed to get this security feature.
+Rather than using `@model`, we're taking advantage of a new feature for Pages. By default, the generated `Page`-derived class *is* the model. This means that features like [model binding](xref:mvc/models/model-binding), [tag helpers](xref:mvc/views/tag-helpers/intro), and HTML helpers all *just work* with the properties defined in `@functions`. Using a *view model* with Razor views is a best practice. With Pages, you get a view model **automatically**. 
 
-## Introducing PageModel
+The following code shows the combined version of the create page:
 
-You could write this form by partitioning the view code and the handler method into separate files. The view code:
+[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/CreateCombined.cshtml)]
 
-*MyApp/Pages/Contact.cshtml*
+The main change is to replace constructor injection with injected (`@inject`) properties. This page uses [@inject](xref:mvc/views/razor#inject) for dependency injection. The `@inject` statement generates and initializes the `Db` property that is used in `OnPostAsync`. Injected (`@inject`) properties are set before handler methods run.
+
+
+The home page (*Index.cshtml*)
+
+[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/Index.cshtml)]
+
+The code behind *Index.cshtml.cs* file:
+
+[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/Index.cshtml.cs)]
+
+The *Index.cshtml* file contains the following markup to create an edit link for each contact:
 
 ```html
-@page
-@using MyApp
-@using MyApp.Pages
-@using Microsoft.AspNetCore.Mvc.RazorPages
-@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@model ContactModel
-
-<html>
-<body>
-    <p>Enter your contact info here and we will email you about 
-         our fine products!</p> 
-    <div asp-validation-summary="All"></div>
-    <form method="POST">
-      <div>Name: <input asp-for="Contact.Name" /></div>
-      <div>Email: <input asp-for="Contact.Email" /></div>
-      <input type="submit" />
-    </form>
-</body>
-</html>
+<a asp-page="./Edit" asp-route-id="@contact.Id">edit</a>
 ```
 
-The `PageModel` class, a 'code-behind' file for the view code:
+The [Anchor Tag Helper](xref:mvc/views/tag-helpers/builtin-th/AnchorTagHelper) 
+used the [asp-route-](xref:mvc/views/tag-helpers/builtin-th/AnchorTagHelper#route) 
+attribute to generate a link to the Edit page. The link contains route data with the contact ID. For example, `http://localhost:5000/Edit/1`.
 
-*MyApp/Pages/Contact.cshtml.cs*
+The *Pages/Edit.cshtml* file:
 
-```c#
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
+[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/Edit.cshtml?highlight=1)]
 
-namespace MyApp.Pages
-{
-    public class ContactModel : PageModel
-    {
-        public ContactModel(ApplicationDbContext db)
-        {
-            Db = db;
-        }
+<!-- REVIEW -->
+The first line contains the `@page "{id:int}"` directive. `"{id:int}"` tells the page to accept requests to the page that contain `int` route data. If a request to the page doesn't contain route data that can be converted to an `int`, the runtime returns an HTTP 404 (not found) error.
 
-        [BindProperty]
-        public Contact Contact { get; set; }
-        
-        private ApplicationDbContext Db { get; }
-    
-        public async Task<IActionResult> OnPostAsync()
-        {
-            if (ModelState.IsValid)
-            {
-                Db.Contacts.Add(Contact);
-                await Db.SaveChangesAsync();
-                return RedirectToPage();
-            }
-            
-            return Page();
-        }
-    }
-}
-```
+The *Pages/Edit.cshtml.cs* file:
 
-By convention, the `PageModel` class is called `<PageName>Model` and is in the same namespace as the page. Not much change is needed to convert from a page using `@functions` to define handlers and a page using a `PageModel` class. The main change is to add constructor injection for all your injected (`@inject`) properties.
+[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/Edit.cshtml.cs)]
 
-Using a `PageModel` supports unit testing, but requires you to write an explicit constructor and class. Pages without `PageModel` files support runtime compilation, which can be an advantage in development.
+<a name="xsrf"></a>
 
-## Using the view engine
+## XSRF/CSRF and Razor Pages
 
-Pages work with all the features of the Razor view engine. Layouts, partials, templates, tag helpers, *_ViewStart.cshtml*, *_ViewImports.cshtml* all work in the same way they do for conventional Razor views. 
+You don't have to write any code for [antiforgery validation](xref:security/anti-request-forgery). Antiforgery token generation and validation is automatically included in Razor Pages.
+
+## Using Layouts, partials, templates, and tag helpers with Razor Pages
+
+Pages work with all the features of the Razor view engine. Layouts, partials, templates, tag helpers, *_ViewStart.cshtml*, *_ViewImports.cshtml* work in the same way they do for conventional Razor views. 
 
 Let's declutter this page by taking advantage of some of those features. 
 
-Add a layout page for the HTML skeleton, and set the `Layout` property from `_ViewStart.cshtml`:
+Add a [layout page](xref:mvc/views/layout) to Pages/_Layout.cshtm:
 
-*MyApp/Pages/_Layout.cshtml*
+                     razor-page-intro/RazorPagesContacts2/Pages/_LayoutSimple.cshtml
 
-```html
-<html>
-    ...
-</html>
-```
+The [Layout](xref:mvc/views/layout#specifying-a-layout) property is set in *Pages/_ViewStart.cshtml*:
 
-*MyApp/Pages/_ViewStart.cshtml*
+[!code-html[main](../../../razor-page-intro/RazorPagesContacts2/Pages/_ViewStart.cshtml)]
 
-```c#
-@{ Layout = "_Layout"; }
-```
+Note: The layout is in the *Pages* folder. Pages look for other views (layouts, templates, partials) hierarchically, starting in the same folder as the current page. This means that a layout in the *Pages* folder can be used from any Razor page under the *Pages* folder.
 
-Note that we placed the layout in the *MyApp/Pages* folder. Pages look for other views (layouts, templates, partials) hierarchically, starting in the same folder as the current page. This means that a layout in the *MyApp/Pages* folder can be used from any Razor page.
+We recommend you **not** put the layout file in the *Views/Shared* folder. *Views/Shared* is an MVC views pattern. Razor Pages are meant to rely on folder hierarchy, not path conventions.
 
-View search from a Razor Page will include the *MyApp/Views/Shared* folder. The layouts, templates, and partials you're using with MVC controllers and conventional Razor views *just work*.
+View search from a Razor Page will include the *Pages* folder. The layouts, templates, and partials you're using with MVC controllers and conventional Razor views *just work*.
 
-Add a *_ViewImports.cshtml* file:
+Add a *Pages/_ViewImports.cshtml* file:
 
-*MyApp/Pages/_ViewImports.cshtml*
+[!code-cs[main](../../../razor-page-intro/RazorPagesContacts2/Pages/_ViewImports.cshtml)]
 
-```c#
-@namespace MyApp.Pages
-@using Microsoft.AspNetCore.Mvc.RazorPages
-@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-```
+I'll explain the `@namespace` later. The `@addTagHelper` directive will bring in the [built-in tag helpers](https://docs.microsoft.com/aspnet/core/mvc/views/tag-helpers/built-in/) to all the pages in the *Pages* folder.
 
-The `@namespace` directive is a new feature that controls the namespace of the generated code. If the `@namespace` directive is used explicitly on a page, that page's namespace will match specified namespace exactly. If the `@namespace` directive is contained in *_ViewImports.cshtml*, the specified namespace is only the prefix. The suffix is the dot-separated relative path between the folder containing *_ViewImports.cshtml* and the folder containing the page.
+<a name="namespace"></a>
 
-Because the *Customer.cshtml* and *_ViewImports.cshtml* files are both in the *MyApp/Pages* folder, there is no suffix, so the page will have the namespace *MyApp.Pages*. If the path was *MyApp/Pages/Store/Customer.cshtml*, the namespace of the generated code would be *MyApp.Pages.Store*. If the `@namespace` directive is also changed to `@namespace NotMyApp`, the namespace of the generated code is *NotMyApp.Store*. The `@namespace` directive was designed so the C# classes you add and pages-generated code *just work* without having to add extra usings.
+When the `@namespace` directive is used explicitly on a page:
 
-Note: `@namespace` works with conventional Razor views.
+[!code-html[main](../../../razor-page-intro/RazorPagesIntro/Pages/Customers/Namespace2.cshtml?highlight=2)]
 
-Here's what the page looks like after simplification:
+The directive sets the namespace for the page. The `@model` directive doesn't need to include the namespace.
 
-*MyApp/Pages/Contact.cshtml*
+When the `@namespace` directive is contained in *_ViewImports.cshtml*, the specified namespace supplies the prefix for the generated namespace in the Page that imports the `@namespace` directive. The rest of the generated namespace (the suffix portion) is the dot-separated relative path between the folder containing *_ViewImports.cshtml* and the folder containing the page.
 
-```html
-@page
-@inject ApplicationDbContext Db
+For example, the code behind file *Pages/Customers/Edit.cshtml.cs* explicitly sets the namespace:
 
-@functions {
+[!code-cs[main](../../../razor-page-intro/RazorPagesContacts2/Pages/Customers/Edit.cshtml.cs?name=namespace)]
 
-    [BindProperty]
-    public Contact Contact { get; set; }
-    
-    public async Task<IActionResult> OnPostAsync()
-    {
-        if (ModelState.IsValid)
-        {
-            Db.Contacts.Add(Contact);
-            await Db.SaveChangesAsync();
-            return RedirectToPage();
-        }
-        
-        return Page();
-    }
-}
+The *Pages/_ViewImports.cshtml* file sets the following namespace:
 
-<div class="row">
-    <div class="col-md-3">
-        <p>Enter your contact info here and we will email you about our fine products!</p> 
-        <div asp-validation-summary="All"></div>
-        <form method="POST">
-            <div>Name: <input asp-for="Contact.Name" /></div>
-            <div>Email: <input asp-for="Contact.Email" /></div>
-            <input type="submit" />
-        </form>
-    </div>
-</div>
-```
+[!code-cs[main](../../../razor-page-intro/RazorPagesContacts2/Pages/_ViewImports.cshtml?highlight=1)]
+
+The generated namespace for the *Pages/Customers/Edit.cshtml* Razor Page is the same as the code behind file. The `@namespace` directive was designed so the C# classes you add and pages-generated code *just work* without having to add an `@using` statement for the code behind file.
+
+Note: `@namespace` also works with conventional Razor views.
+
+<!--
+Add a *Pages/_ValidationScriptsPartial.cshtml* file to enable client side validation.
+
+[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Pages/_ValidationScriptsPartial.cshtml)]
+
+-->
+
+The original *Pages/Create.cshtml* view file:
+
+[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/Create.cshtml)]
+
+The updated page:
+
+The *Pages/Create.cshtml* view file:
+
+[!code-html[main](../../../razor-page-intro/RazorPagesContacts2/Pages/Customers/Create.cshtml)]
+
+<a name="url_gen"></a>
 
 ## URL generation for Pages
 
-Let's suppose we want to do something more useful than showing the same page again when the visitor submits their contact information. We can use `RedirectToPage("/Index")` to redirect to the `Index` page.
+The `Create` page, shown previously, uses `RedirectToPage`:
 
-This example adds a confirmation message and redirects back to the home page:
+[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Pages/Create.cshtml.cs?name=OnPostAsync&highlight=10)]
 
-*MyApp/Pages/Contact.cshtml*
+The app has the following file/folder structure
 
-```html
-@page
-@inject ApplicationDbContext Db
+* */Pages*
 
-@functions {
+  * *Index.cshtml*
+  * */Customer* 
 
-    [BindProperty]
-    public Contact Contact { get; set; }
-    
-    [TempData]
-    public string Message { get; set; }
-    
-    public async Task<IActionResult> OnPostAsync()
-    {
-        if (ModelState.IsValid)
-        {
-            Db.Contacts.Add(Contact);
-            await Db.SaveChangesAsync();
-            
-            Message = "Thanks, we'll be in touch shortly.";
-            return RedirectToPage("/Index");
-        }
-        
-        return Page();
-    }
-}
+    * *Create.cshtml*
+    * *Edit.cshtml*
+    * *Index.cshtml*
 
-
-<div class="row">
-    <div class="col-md-3">
-        <p>Enter your contact info here and we will email you about our fine products!</p> 
-        <div asp-validation-summary="All"></div>
-        <form method="POST">
-            <div>Name: <input asp-for="Contact.Name" /></div>
-            <div>Email: <input asp-for="Contact.Email" /></div>
-            <input type="submit" />
-        </form>
-    </div>
-</div>
-```
-
-*MyApp/Pages/Index.cshtml*
-
-```html
-@page
-
-@functions {
-    [TempData]
-    public string Message { get; set; }
-}
-
-
-<div class="row">
-    <div class="col-md-3">
-        @if (Message != null)
-        {
-            <h3>@Message</h3>
-        }
-
-        <p>Hi, welcome to our website!</p>
-    </div>
-</div>
-```
-
-We've added another page (*MyApp/Pages/Index.cshtml*), and are redirecting to it using `RedirectToPage("/Index")`. The string `/Index` is part of the URI to access the the preceding page. The string `/Index` can be used to generate URIs to this page. For example:
+The *Pages/Customers/Create.cshtml*  and *Pages/Customers/Edit.cshtml* pages redirect to *Pages/Index.cshtml* after success. The string `/Index` is part of the URI to access the the preceding page. The string `/Index` can be used to generate URIs to the *Pages/Index.cshtml* page. For example:
 
 
 * `Url.Page("/Index", ...)`
@@ -389,62 +255,49 @@ We've added another page (*MyApp/Pages/Index.cshtml*), and are redirecting to it
 * `RedirectToPage("/Index")`
 
 
-The page name is the path to the page from the root *MyApp/Pages* folder (including a leading `/`, for example `/Index`). It seems simple, but this is much more feature-rich than just hardcoding a URL. This is URL generation using [routing](xref:mvc/controllers/routing), and can generate and encode parameters according to how the route is defined in the destination path.
+The page name is the path to the page from the root */Pages* folder (including a leading `/`, for example `/Index`). This is much more feature-rich than just hardcoding a URL. This is URL generation using [routing](xref:mvc/controllers/routing), and can generate and encode parameters according to how the route is defined in the destination path.
 
-URL generation for pages supports relative names. From *MyApp/Pages/Contact.cshtml*, you could also redirect to *MyApp/Pages/Index.cshtml* using `RedirectToPage("Index")` or `RedirectToPage("./Index")`. These are both *relative names*. The provided string is *combined* with the page name of the current page to compute the name of the destination page. You can also use the directory traversal `..` operator. 
+URL generation for pages supports relative names. The following table shows which Index page is selected with different `RedirectToPage` parameters from *Pages/Customers/Create.cshtml*:
+
+| `RedirectToPage(x)| Page |
+| ----------------- | ------------ |  
+|  RedirectToPage("/Index") | *Pages/Index* |
+| RedirectToPage("./Index"); | *Pages/Customers/Index* |
+| RedirectToPage("../Index") | *Pages/Index* |
+| RedirectToPage("Index")  | *Pages/Customers/Index* |
+
+`RedirectToPage("Index")`, `RedirectToPage("./Index")`, and `RedirectToPage("../Index")`  are *relative names*. The `RedirectToPage` parameter is *combined* with the path of the current page to compute the name of the destination page.  <!- Review: Original had The provided string is combined with the page name of the current page to compute the name of the destination page. -- page name, not page path -->
 
 Relative name linking is useful when building sites with a complex structure. If you use relative names to link between pages in a folder, you can rename that folder. All the links still work (because they didn't include the folder name).
 
-Since we have another page here, we're also taking advantage of the `[TempData]` attribute to pass data across pages. `[TempData]` is a more convenient way to use the existing MVC temp data features. The `[TempData]` attribute is new in 2.0.0 and is supported on controllers and pages. In 2.0.0, the default storage for temp data is now cookies. A session provider is no longer required by default.
 
-### Using multiple handlers
+## TempData
 
-Let's update this form to support multiple operations. A visitor to the site can either join the mailing list or ask for a free quote.
+The `[TempData]` attribute is new in 2.0.0 and is supported on controllers and pages. In 2.0.0, the default storage for temp data is cookies. A session provider is no longer required by default.
 
-If you want one page to handle multiple logical actions, you can use *named handler methods*. Any text in the name after `On<Verb>` and before `Async` (if present) in the method name is considered a handler name. The handler methods in the following example have the handler names `JoinMailingList` and `RequestQuote`:
+<a name="mhpp"></a>
+##  Multiple handlers per page
 
-*MyApp/Pages/Contact.cshtml*
+The following page generates markup for two page handlers using the `asp-page-handler` tag helper:
 
-```html
-@page
-@inject ApplicationDbContext Db
+[!code-html[main](../../../razor-page-intro/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml?highlight=12-13)]
 
-@functions {
+<!-- Review: Where is the FormActionTagHelper?  How is it used in conjunction? -->
+The form in the preceeding example has two submit buttons, each using the new `FormActionTagHelper` in conjunction to submit to a different URL. The `asp-handler` attribute is a companion to `asp-page` and generates URLs that submit to each of the handler methods defined by the page. We don't need to specify `asp-page` because we're linking to the current page.
 
-    [BindProperty]
-    public Contact Contact { get; set; }
-    
-    public async Task<IActionResult> OnPostJoinMailingListAsync()
-    {
-        ...
-    }
+The code-behind file:
 
-    public async Task<IActionResult> OnPostRequestQuoteAsync()
-    {
-        ...
-    }
-}
-<div class="row">
-    <div class="col-md-3">
-        <p>Enter your contact info here we will email you about our fine products! Or get a free quote!</p>
-        <div asp-validation-summary="All"></div>
-        <form method="POST">
-            <div>Name: <input asp-for="Contact.Name" /></div>
-            <div>Email: <input asp-for="Contact.Email" /></div>
-            <input type="submit" asp-page-handler="JoinMailingList" value="Join our mailing list"/>
-            <input type="submit" asp-page-handler="RequestQuote" value="Get a free quote"/>
-        </form>
-    </div>
-</div>
-```
+[!code-cs[main](../../../razor-page-intro/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml.cs?highlight=20,32)]
 
-The form in this example has two submit buttons, each using the new `FormActionTagHelper` in conjunction to submit to a different URL. The `asp-handler` attribute is a companion to `asp-page` and generates URLs that submit to each of the handler methods defined by the page. We don't need to specify `asp-page` because we're linking to the current page.
+The preceeding code uses *named handler methods*. Named handler methods are created by taking the text in the name after `On<HTTP Verb>` and before `Async` (if present). In the preceeding example, the page methods are OnPost**JoinList**Async and OnPost**JoinListUC**Async. The handler names when **OnPost** and **Async** are removed are `JoinList` and `JoinListUC`.
 
-In this case, the URL path that submits to `OnPostJoinMailingListAsync` is `/Contact?handler=JoinMailingList` and the URL path that submits to `OnPostRequestQuoteAsync` is `/Contact?handler=RequestQuote`.
+[!code-html[main](../../../razor-page-intro/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml?highlight=12-13)]
+
+Using the preceeding code, the URL path that submits to `OnPostJoinListAsync` is `http://localhost:5000/Customers/CreateFATH?handler=JoinList`. The URL path that submits to `OnPostJoinListUCAsync` is `http://localhost:5000/Customers/CreateFATH?handler=JoinListUC`. 
 
 ## Customizing Routing
 
-If you don't like seeing `?handler=RequestQuote` in the URL, you can change the route to put the handler name in the path portion of the URL. You can customize the route by adding a route template enclosed in quotes after the `@page` directive.
+If you don't like `?handler=RequestQuote` in the URL, you can change the route to put the handler name in the path portion of the URL. You can customize the route by adding a route template enclosed in quotes after the `@page` directive.
 
 ```c#
 @page "{handler?}"
@@ -457,7 +310,7 @@ This route will now put the handler name in the URL path instead of the query st
 
 You can use `@page` to add additional segments and parameters to a page's route. Whatever's there is **appended** to the default route of the page. Using an absolute or virtual path to change the page's route (like `"~/Some/Other/Path"`) is not supported.
 
-### Configuration and settings
+## Configuration and settings
 
 Use the extension method `AddRazorPagesOptions` on the MVC builder to configure advanced options such as the following example:
 

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -34,24 +34,24 @@ Optional: [Visual Studio 2017 Preview](https://www.visualstudio.com/vs/preview/)
 
 If you are using a typical *Startup.cs* like the following code, Razor Pages is enabled:
 
-[!code-cs[main](../../../razor-page-intro/RazorPagesIntro/Startup.cs?name=Startup)]
+[!code-cs[main](index/sample/RazorPagesIntro/Startup.cs?name=Startup)]
 
 All the Razor Pages types and features are included in the `Microsoft.AspNetCore.Mvc.RazorPages` assembly. If you are referencing the `Microsoft.AspNetCore.Mvc` package, a reference to the Razor Pages assembly is included.
 
 Consider a basic page:
 <a name="OnGet"></a>
 
-[!code-html[main](../../../razor-page-intro/RazorPagesIntro/Pages/Index.cshtml)]
+[!code-html[main](index/sample/RazorPagesIntro/Pages/Index.cshtml)]
 
 The preceeding code looks a lot like a Razor view file. What makes it different is the new `@page` directive. `@page` makes the file into an MVC action - which means that it can handle requests directly, without going through a controller. `@page` must be the first Razor directive on a page. `@page` affects the behavior of other Razor constructs. The [@functions](xref:mvc/views/razor#functions) directive enables function level content.
 
 A similar page, with the `PageModel` in a separate file, is shown in the following two files:
 
-[!code-html[main](../../../razor-page-intro/RazorPagesIntro/Pages/Index2.cshtml)]
+[!code-html[main](index/sample/RazorPagesIntro/Pages/Index2.cshtml)]
 
 The `PageModel` class *Pages/Index2.cshtml.cs*, a code-behind file for the view code:
 
-[!code-cs[main](../../../razor-page-intro/RazorPagesIntro/Pages/Index2.cshtml.cs)]
+[!code-cs[main](index/sample/RazorPagesIntro/Pages/Index2.cshtml.cs)]
 
 By convention, the `PageModel` class file has the same name as the Razor Page file with *.cs* appended. For example, the previous Razor Page is *Pages/Index2.cshtml*. The file containing the `PageModel` class is named *Pages/Index2.cshtml.cs*.
 
@@ -73,19 +73,19 @@ The new Razor Pages features are designed to make common patterns used with web 
 
 For the examples in this document, the `DbContext` is initialized in the *Startup.cs* file.
 
-[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Startup.cs?highlight=15-16)]
+[!code-cs[main](index/sample/RazorPagesContacts/Startup.cs?highlight=15-16)]
 
 The data model:
 
-[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Data/Customer.cs)]
+[!code-cs[main](index/sample/RazorPagesContacts/Data/Customer.cs)]
 
 The *Pages/Create.cshtml* view file:
 
-[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/Create.cshtml)]
+[!code-html[main](index/sample/RazorPagesContacts/Pages/Create.cshtml)]
 
 The `PageModel` class *Pages/Create.cshtml.cs* code-behind file for the view:
 
-[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Pages/Create.cshtml.cs?name=ALL)]
+[!code-cs[main](index/sample/RazorPagesContacts/Pages/Create.cshtml.cs?name=ALL)]
 
 By convention, the `PageModel` class is called `<PageName>Model` and is in the same namespace as the page. Not much change is needed to convert from a page using `@functions` to define handlers and a page using a `PageModel` class. 
 
@@ -100,7 +100,7 @@ The `Async` naming suffix is optional but is often used by convention. The code 
 
 The previous `OnPostAsync` method:
 
-[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Pages/Create.cshtml.cs?name=OnPostAsync)]
+[!code-cs[main](index/sample/RazorPagesContacts/Pages/Create.cshtml.cs?name=OnPostAsync)]
 
 The basic flow of `OnPostAsync`: 
 
@@ -115,7 +115,7 @@ When the submitted form has validation errors (that are passed to the server), t
 
 The `Customer` property is using the new `[BindProperty]` attribute to opt-in to model binding. 
 
-[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Pages/Create.cshtml.cs?name=PageModel&highlight=10-11)]
+[!code-cs[main](index/sample/RazorPagesContacts/Pages/Create.cshtml.cs?name=PageModel&highlight=10-11)]
 
 Razor Pages, by default, bind properties only with non-GET verbs. Binding to properties can reduce the amount of code you have to write by using the same property to render form fields (`<input asp-for="Customer.Name" />`) and accept the input.
 
@@ -123,18 +123,18 @@ Rather than using `@model`, we're taking advantage of a new feature for Pages. B
 
 The following code shows the combined version of the create page:
 
-[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/CreateCombined.cshtml)]
+[!code-html[main](index/sample/RazorPagesContacts/Pages/CreateCombined.cshtml)]
 
 The main change is to replace constructor injection with injected (`@inject`) properties. This page uses [@inject](xref:mvc/views/razor#inject) for dependency injection. The `@inject` statement generates and initializes the `Db` property that is used in `OnPostAsync`. Injected (`@inject`) properties are set before handler methods run.
 
 
 The home page (*Index.cshtml*)
 
-[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/Index.cshtml)]
+[!code-html[main](index/sample/RazorPagesContacts/Pages/Index.cshtml)]
 
 The code behind *Index.cshtml.cs* file:
 
-[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/Index.cshtml.cs)]
+[!code-html[main](index/sample/RazorPagesContacts/Pages/Index.cshtml.cs)]
 
 The *Index.cshtml* file contains the following markup to create an edit link for each contact:
 
@@ -148,14 +148,14 @@ attribute to generate a link to the Edit page. The link contains route data with
 
 The *Pages/Edit.cshtml* file:
 
-[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/Edit.cshtml?highlight=1)]
+[!code-html[main](index/sample/RazorPagesContacts/Pages/Edit.cshtml?highlight=1)]
 
 <!-- REVIEW -->
 The first line contains the `@page "{id:int}"` directive. `"{id:int}"` tells the page to accept requests to the page that contain `int` route data. If a request to the page doesn't contain route data that can be converted to an `int`, the runtime returns an HTTP 404 (not found) error.
 
 The *Pages/Edit.cshtml.cs* file:
 
-[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/Edit.cshtml.cs)]
+[!code-html[main](index/sample/RazorPagesContacts/Pages/Edit.cshtml.cs)]
 
 <a name="xsrf"></a>
 
@@ -175,7 +175,7 @@ Add a [layout page](xref:mvc/views/layout) to Pages/_Layout.cshtm:
 
 The [Layout](xref:mvc/views/layout#specifying-a-layout) property is set in *Pages/_ViewStart.cshtml*:
 
-[!code-html[main](../../../razor-page-intro/RazorPagesContacts2/Pages/_ViewStart.cshtml)]
+[!code-html[main](index/sample/RazorPagesContacts2/Pages/_ViewStart.cshtml)]
 
 Note: The layout is in the *Pages* folder. Pages look for other views (layouts, templates, partials) hierarchically, starting in the same folder as the current page. This means that a layout in the *Pages* folder can be used from any Razor page under the *Pages* folder.
 
@@ -185,7 +185,7 @@ View search from a Razor Page will include the *Pages* folder. The layouts, temp
 
 Add a *Pages/_ViewImports.cshtml* file:
 
-[!code-cs[main](../../../razor-page-intro/RazorPagesContacts2/Pages/_ViewImports.cshtml)]
+[!code-cs[main](index/sample/RazorPagesContacts2/Pages/_ViewImports.cshtml)]
 
 I'll explain the `@namespace` later. The `@addTagHelper` directive will bring in the [built-in tag helpers](https://docs.microsoft.com/aspnet/core/mvc/views/tag-helpers/built-in/) to all the pages in the *Pages* folder.
 
@@ -193,7 +193,7 @@ I'll explain the `@namespace` later. The `@addTagHelper` directive will bring in
 
 When the `@namespace` directive is used explicitly on a page:
 
-[!code-html[main](../../../razor-page-intro/RazorPagesIntro/Pages/Customers/Namespace2.cshtml?highlight=2)]
+[!code-html[main](index/sample/RazorPagesIntro/Pages/Customers/Namespace2.cshtml?highlight=2)]
 
 The directive sets the namespace for the page. The `@model` directive doesn't need to include the namespace.
 
@@ -201,11 +201,11 @@ When the `@namespace` directive is contained in *_ViewImports.cshtml*, the speci
 
 For example, the code behind file *Pages/Customers/Edit.cshtml.cs* explicitly sets the namespace:
 
-[!code-cs[main](../../../razor-page-intro/RazorPagesContacts2/Pages/Customers/Edit.cshtml.cs?name=namespace)]
+[!code-cs[main](index/sample/RazorPagesContacts2/Pages/Customers/Edit.cshtml.cs?name=namespace)]
 
 The *Pages/_ViewImports.cshtml* file sets the following namespace:
 
-[!code-cs[main](../../../razor-page-intro/RazorPagesContacts2/Pages/_ViewImports.cshtml?highlight=1)]
+[!code-cs[main](index/sample/RazorPagesContacts2/Pages/_ViewImports.cshtml?highlight=1)]
 
 The generated namespace for the *Pages/Customers/Edit.cshtml* Razor Page is the same as the code behind file. The `@namespace` directive was designed so the C# classes you add and pages-generated code *just work* without having to add an `@using` statement for the code behind file.
 
@@ -214,19 +214,19 @@ Note: `@namespace` also works with conventional Razor views.
 <!--
 Add a *Pages/_ValidationScriptsPartial.cshtml* file to enable client side validation.
 
-[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Pages/_ValidationScriptsPartial.cshtml)]
+[!code-cs[main](index/sample/RazorPagesContacts/Pages/_ValidationScriptsPartial.cshtml)]
 
 -->
 
 The original *Pages/Create.cshtml* view file:
 
-[!code-html[main](../../../razor-page-intro/RazorPagesContacts/Pages/Create.cshtml)]
+[!code-html[main](index/sample/RazorPagesContacts/Pages/Create.cshtml)]
 
 The updated page:
 
 The *Pages/Create.cshtml* view file:
 
-[!code-html[main](../../../razor-page-intro/RazorPagesContacts2/Pages/Customers/Create.cshtml)]
+[!code-html[main](index/sample/RazorPagesContacts2/Pages/Customers/Create.cshtml)]
 
 <a name="url_gen"></a>
 
@@ -234,7 +234,7 @@ The *Pages/Create.cshtml* view file:
 
 The `Create` page, shown previously, uses `RedirectToPage`:
 
-[!code-cs[main](../../../razor-page-intro/RazorPagesContacts/Pages/Create.cshtml.cs?name=OnPostAsync&highlight=10)]
+[!code-cs[main](index/sample/RazorPagesContacts/Pages/Create.cshtml.cs?name=OnPostAsync&highlight=10)]
 
 The app has the following file/folder structure
 
@@ -280,18 +280,18 @@ The `[TempData]` attribute is new in 2.0.0 and is supported on controllers and p
 
 The following page generates markup for two page handlers using the `asp-page-handler` tag helper:
 
-[!code-html[main](../../../razor-page-intro/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml?highlight=12-13)]
+[!code-html[main](index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml?highlight=12-13)]
 
 <!-- Review: Where is the FormActionTagHelper?  How is it used in conjunction? -->
 The form in the preceeding example has two submit buttons, each using the new `FormActionTagHelper` in conjunction to submit to a different URL. The `asp-handler` attribute is a companion to `asp-page` and generates URLs that submit to each of the handler methods defined by the page. We don't need to specify `asp-page` because we're linking to the current page.
 
 The code-behind file:
 
-[!code-cs[main](../../../razor-page-intro/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml.cs?highlight=20,32)]
+[!code-cs[main](index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml.cs?highlight=20,32)]
 
 The preceeding code uses *named handler methods*. Named handler methods are created by taking the text in the name after `On<HTTP Verb>` and before `Async` (if present). In the preceeding example, the page methods are OnPost**JoinList**Async and OnPost**JoinListUC**Async. The handler names when **OnPost** and **Async** are removed are `JoinList` and `JoinListUC`.
 
-[!code-html[main](../../../razor-page-intro/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml?highlight=12-13)]
+[!code-html[main](index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml?highlight=12-13)]
 
 Using the preceeding code, the URL path that submits to `OnPostJoinListAsync` is `http://localhost:5000/Customers/CreateFATH?handler=JoinList`. The URL path that submits to `OnPostJoinListUCAsync` is `http://localhost:5000/Customers/CreateFATH?handler=JoinListUC`. 
 

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -7,7 +7,6 @@ ms.author: riande
 manager: wpickett
 ms.date: 07/28/2017
 ms.topic: get-started-article
-ms.assetid: 30e4104c-0124-477b-86b3-beb7b34ed3f6
 ms.technology: aspnet
 ms.prod: asp.net-core
 uid: mvc/razor-pages/index

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -1,3 +1,8 @@
+<!--   TODO
+
+check lang type [!code-
+
+-->
 ---
 title: Introduction to Razor Pages in ASP.NET Core
 author: Rick-Anderson
@@ -220,13 +225,13 @@ Add a *Pages/_ValidationScriptsPartial.cshtml* file to enable client side valida
 
 The original *Pages/Create.cshtml* view file:
 
-[!code-html[main](index/sample/RazorPagesContacts/Pages/Create.cshtml)]
+[!code-html[main](index/sample/RazorPagesContacts/Pages/Create.cshtml?highlight=2)]
 
 The updated page:
 
 The *Pages/Create.cshtml* view file:
 
-[!code-html[main](index/sample/RazorPagesContacts2/Pages/Customers/Create.cshtml)]
+[!code-html[main](index/sample/RazorPagesContacts2/Pages/Customers/Create.cshtml?highlight=2)]
 
 <a name="url_gen"></a>
 
@@ -266,7 +271,7 @@ URL generation for pages supports relative names. The following table shows whic
 | RedirectToPage("../Index") | *Pages/Index* |
 | RedirectToPage("Index")  | *Pages/Customers/Index* |
 
-`RedirectToPage("Index")`, `RedirectToPage("./Index")`, and `RedirectToPage("../Index")`  are *relative names*. The `RedirectToPage` parameter is *combined* with the path of the current page to compute the name of the destination page.  <!- Review: Original had The provided string is combined with the page name of the current page to compute the name of the destination page. -- page name, not page path -->
+`RedirectToPage("Index")`, `RedirectToPage("./Index")`, and `RedirectToPage("../Index")`  are *relative names*. The `RedirectToPage` parameter is *combined* with the path of the current page to compute the name of the destination page.  <!-- Review: Original had The provided string is combined with the page name of the current page to compute the name of the destination page. -- page name, not page path -->
 
 Relative name linking is useful when building sites with a complex structure. If you use relative names to link between pages in a folder, you can rename that folder. All the links still work (because they didn't include the folder name).
 
@@ -274,6 +279,8 @@ Relative name linking is useful when building sites with a complex structure. If
 ## TempData
 
 The `[TempData]` attribute is new in 2.0.0 and is supported on controllers and pages. In 2.0.0, the default storage for temp data is cookies. A session provider is no longer required by default.
+
+TODO provide sample moving temp data bewteen pages.
 
 <a name="mhpp"></a>
 ##  Multiple handlers per page
@@ -289,7 +296,7 @@ The code-behind file:
 
 [!code-cs[main](index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml.cs?highlight=20,32)]
 
-The preceeding code uses *named handler methods*. Named handler methods are created by taking the text in the name after `On<HTTP Verb>` and before `Async` (if present). In the preceeding example, the page methods are OnPost**JoinList**Async and OnPost**JoinListUC**Async. The handler names when **OnPost** and **Async** are removed are `JoinList` and `JoinListUC`.
+The preceeding code uses *named handler methods*. Named handler methods are created by taking the text in the name after `On<HTTP Verb>` and before `Async` (if present). In the preceeding example, the page methods are OnPost**JoinList**Async and OnPost**JoinListUC**Async. The handler names when *OnPost* and *Async* are removed are `JoinList` and `JoinListUC`.
 
 [!code-html[main](index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml?highlight=12-13)]
 
@@ -297,14 +304,10 @@ Using the preceeding code, the URL path that submits to `OnPostJoinListAsync` is
 
 ## Customizing Routing
 
-If you don't like `?handler=RequestQuote` in the URL, you can change the route to put the handler name in the path portion of the URL. You can customize the route by adding a route template enclosed in quotes after the `@page` directive.
+If you don't like the query string`?handler=JoinList` in the URL, you can change the route to put the handler name in the path portion of the URL. You can customize the route by adding a route template enclosed in quotes after the `@page` directive.
 
-```c#
-@page "{handler?}"
-@inject ApplicationDbContext Db
+[!code-html[main](index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml?highlight=1)]
 
-...
-```
 
 This route will now put the handler name in the URL path instead of the query string. The `?` following `handler` means this is an optional route parameter.
 
@@ -313,6 +316,9 @@ You can use `@page` to add additional segments and parameters to a page's route.
 ## Configuration and settings
 
 Use the extension method `AddRazorPagesOptions` on the MVC builder to configure advanced options such as the following example:
+
+<!-- Review - please update the sample code to do this and I'll import the snippet
+-->
 
 ```c#
 public class Startup

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -36,20 +36,20 @@ If you are using a typical *Startup.cs* like the following code, Razor Pages is 
 
 [!code-cs[main](index/sample/RazorPagesIntro/Startup.cs?name=Startup)]
 
-All the Razor Pages types and features are included in the `Microsoft.AspNetCore.Mvc.RazorPages` assembly. If you are referencing the `Microsoft.AspNetCore.Mvc` package, a reference to the Razor Pages assembly is included.
+All the Razor Pages types and features are in the `Microsoft.AspNetCore.Mvc.RazorPages` assembly. The `Microsoft.AspNetCore.Mvc` package includes the Razor Pages assembly. The  `Microsoft.AspNetCore.All` metapackage include all ASP.NET Core 2.x packages.
 
 Consider a basic page:
 <a name="OnGet"></a>
 
 [!code-html[main](index/sample/RazorPagesIntro/Pages/Index.cshtml)]
 
-The preceding code looks a lot like a Razor view file. What makes it different is the new `@page` directive. `@page` makes the file into an MVC action - which means that it can handle requests directly, without going through a controller. `@page` must be the first Razor directive on a page. `@page` affects the behavior of other Razor constructs. The [@functions](xref:mvc/views/razor#functions) directive enables function level content.
+The preceding code looks a lot like a Razor view file. What makes it different is the new `@page` directive. `@page` makes the file into an MVC action - which means that it can handle requests directly, without going through a controller. `@page` must be the first Razor directive on a page. `@page` affects the behavior of other Razor constructs. The [@functions](xref:mvc/views/razor#functions) directive enables function-level content.
 
 A similar page, with the `PageModel` in a separate file, is shown in the following two files. The *Pages/Index2.cshtml* file:
 
 [!code-html[main](index/sample/RazorPagesIntro/Pages/Index2.cshtml)]
 
-The *Pages/Index2.cshtml.cs* `code-behind` file:
+The *Pages/Index2.cshtml.cs* 'code-behind' file:
 
 [!code-cs[main](index/sample/RazorPagesIntro/Pages/Index2.cshtml.cs)]
 
@@ -69,7 +69,7 @@ The runtime looks for Razor Pages files in the *Pages* folder by default.
 
 ## Writing a basic form
 
-The new Razor Pages features are designed to make common patterns used with web browsers easy. Consider a page that implements a basic 'contact us' form for the `Contact` model:
+The new Razor Pages features are designed to make common patterns used with web browsers easy. Consider a page that implements a basic "contact us" form for the `Contact` model:
 
 For the examples in this document, the `DbContext` is initialized in the *Startup.cs* file.
 
@@ -96,7 +96,7 @@ The page has an `OnPostAsync` *handler method* which runs on `POST` requests (wh
 * `OnGet` to initialize state needed for the page. [OnGet](#OnGet) sample.
 * `OnPost` to handle form submissions. 
 
-The `Async` naming suffix is optional but is often used by convention. The code that's in `OnPostAsync` in the preceding example looks similar to what you would normally write in a controller. This is typical for Razor Pages. Most of the MVC primitives like [model binding](xref:mvc/models/model-binding), [validation](xref:mvc/models/validation), and action results are shared.  <!-- Review: Ryan, can we get a list of what is shared and what isn't? -->
+The `Async` naming suffix is optional but is often used by convention. The `OnPostAsync` code in the preceding example looks similar to what you would normally write in a controller. This is typical for Razor Pages. Most of the MVC primitives like [model binding](xref:mvc/models/model-binding), [validation](xref:mvc/models/validation), and action results are shared.  <!-- Review: Ryan, can we get a list of what is shared and what isn't? -->
 
 The previous `OnPostAsync` method:
 
@@ -107,11 +107,11 @@ The basic flow of `OnPostAsync`:
 Check for validation errors.
 
 *  If there are no errors, save the data and redirect.
-*  If there are errors, show the page again with validation messages. Client side validation is identical to traditonal ASP.NET Core MVC applications. In many cases validation errors would be caught on the client and never submitted to the server.
+*  If there are errors, show the page again with validation messages. Client-side validation is identical to traditional ASP.NET Core MVC applications. In many cases, validation errors would be caught on the client and never submitted to the server.
 
-When the data is entered successfully, the `OnPostAsync` handler method calls the `RedirectToPage` helper method to return an instance of `RedirectToPageResult`. This is a new action result similar to `RedirectToAction` or `RedirectToRoute` but customized for pages. In the preceding sample, it redirects to the root Index page (`/Index`). `RedirectToPage` is detailed in the [URL generation for Pages](#url_gen) section.
+When the data is entered successfully, the `OnPostAsync` handler method calls the `RedirectToPage` helper method to return an instance of `RedirectToPageResult`.This is a new action result, similar to `RedirectToAction` or `RedirectToRoute`, but customized for pages. In the preceding sample, it redirects to the root Index page (`/Index`). `RedirectToPage` is detailed in the [URL generation for Pages](#url_gen) section.
 
-When the submitted form has validation errors (that are passed to the server), the`OnPostAsync` handler method calls the `Page` helper method. `Page` returns an instance of `PageResult`. This is similar to how actions in controllers return `View`. `PageResult` is the default <!-- Review default what?  --> for a handler method. A handler method that returns `void` will render the page.
+When the submitted form has validation errors (that are passed to the server), the`OnPostAsync` handler method calls the `Page` helper method. `Page` returns an instance of `PageResult`. This is similar to how actions in controllers return `View`. `PageResult` is the default <!-- Review  --> return type for a handler method. A handler method that returns `void` will render the page.
 
 The `Customer` property is using the new `[BindProperty]` attribute to opt-in to model binding. 
 
@@ -119,7 +119,7 @@ The `Customer` property is using the new `[BindProperty]` attribute to opt-in to
 
 Razor Pages, by default, bind properties only with non-GET verbs. Binding to properties can reduce the amount of code you have to write by using the same property to render form fields (`<input asp-for="Customer.Name" />`) and accept the input.
 
-Rather than using `@model`, we're taking advantage of a new feature for Pages. By default, the generated `Page`-derived class *is* the model. This means that features like [model binding](xref:mvc/models/model-binding), [tag helpers](xref:mvc/views/tag-helpers/intro), and HTML helpers all *just work* with the properties defined in `@functions`. Using a *view model* with Razor views is a best practice. With Pages, you get a view model *automatically*. 
+Rather than using `@model`, we're taking advantage of a new feature for Pages. By default, the generated `Page`-derived class *is* the model. This means that features like [model binding](xref:mvc/models/model-binding), [Tag Helpers](xref:mvc/views/tag-helpers/intro), and HTML helpers all *just work* with the properties defined in `@functions`. Using a *view model* with Razor views is a best practice. With Pages, you get a view model *automatically*. 
 
 The following code shows the combined version of the create page:
 
@@ -128,7 +128,7 @@ The following code shows the combined version of the create page:
 The main change is to replace constructor injection with injected (`@inject`) properties. This page uses [@inject](xref:mvc/views/razor#inject) for dependency injection. The `@inject` statement generates and initializes the `Db` property that is used in `OnPostAsync`. Injected (`@inject`) properties are set before handler methods run.
 
 
-The home page (*Index.cshtml*)
+The home page (*Index.cshtml*):
 
 [!code-html[main](index/sample/RazorPagesContacts/Pages/Index.cshtml)]
 
@@ -163,13 +163,13 @@ The *Pages/Edit.cshtml.cs* file:
 
 You don't have to write any code for [antiforgery validation](xref:security/anti-request-forgery). Antiforgery token generation and validation is automatically included in Razor Pages.
 
-## Using Layouts, partials, templates, and tag helpers with Razor Pages
+## Using Layouts, partials, templates, and Tag Helpers with Razor Pages
 
-Pages work with all the features of the Razor view engine. Layouts, partials, templates, tag helpers, *_ViewStart.cshtml*, *_ViewImports.cshtml* work in the same way they do for conventional Razor views. 
+Pages work with all the features of the Razor view engine. Layouts, partials, templates, Tag Helpers, *_ViewStart.cshtml*, *_ViewImports.cshtml* work in the same way they do for conventional Razor views. 
 
 Let's declutter this page by taking advantage of some of those features. 
 
-Add a [layout page](xref:mvc/views/layout) to Pages/_Layout.cshtm:
+Add a [layout page](xref:mvc/views/layout) to Pages/_Layout.cshtml:
 
 [!code-html[main](index/sample/RazorPagesContacts2/Pages/_LayoutSimple.cshtml)]
 
@@ -187,7 +187,7 @@ Add a *Pages/_ViewImports.cshtml* file:
 
 [!code-html[main](index/sample/RazorPagesContacts2/Pages/_ViewImports.cshtml)]
 
-I'll explain the `@namespace` later. The `@addTagHelper` directive will bring in the [built-in tag helpers](https://docs.microsoft.com/aspnet/core/mvc/views/tag-helpers/built-in/) to all the pages in the *Pages* folder.
+I'll explain the `@namespace` later. The `@addTagHelper` directive will bring in the [built-in Tag Helpers](https://docs.microsoft.com/aspnet/core/mvc/views/tag-helpers/built-in/) to all the pages in the *Pages* folder.
 
 <a name="namespace"></a>
 
@@ -207,12 +207,12 @@ The *Pages/_ViewImports.cshtml* file sets the following namespace:
 
 [!code-html[main](index/sample/RazorPagesContacts2/Pages/_ViewImports.cshtml?highlight=1)]
 
-The generated namespace for the *Pages/Customers/Edit.cshtml* Razor Page is the same as the code behind file. The `@namespace` directive was designed so the C# classes you add and pages-generated code *just work* without having to add an `@using` statement for the code behind file.
+The generated namespace for the *Pages/Customers/Edit.cshtml* Razor Page is the same as the code behind file. The `@namespace` directive was designed so the C# classes you add and pages-generated code *just work* without having to add an `@using` directive for the code behind file.
 
 Note: `@namespace` also works with conventional Razor views.
 
 <!-- rick todo
-Add a *Pages/_ValidationScriptsPartial.cshtml* file to enable client side validation.
+Add a *Pages/_ValidationScriptsPartial.cshtml* file to enable client-side validation.
 
 [!code-html[main](index/sample/RazorPagesContacts/Pages/_ValidationScriptsPartial.cshtml)]
 
@@ -273,7 +273,7 @@ Relative name linking is useful when building sites with a complex structure. If
 
 ## TempData
 
-The `[TempData]` attribute is new in 2.0.0 and is supported on controllers and pages. In 2.0.0, the default storage for temp data is cookies. A session provider is no longer required by default.
+The `[TempData]` attribute is new in ASP.NET Core 2.0 and is supported on controllers and pages. In 2.0.0, the default storage for temp data is cookies. A session provider is no longer required by default.
 
 TODO provide sample moving temp data bewteen pages.
 
@@ -291,7 +291,7 @@ The code-behind file:
 
 [!code-cs[main](index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml.cs?highlight=20,32)]
 
-The preceding code uses *named handler methods*. Named handler methods are created by taking the text in the name after `On<HTTP Verb>` and before `Async` (if present). In the preceding example, the page methods are OnPost**JoinList**Async and OnPost**JoinListUC**Async. The handler names when *OnPost* and *Async* are removed are `JoinList` and `JoinListUC`.
+The preceding code uses *named handler methods*. Named handler methods are created by taking the text in the name after `On<HTTP Verb>` and before `Async` (if present). In the preceding example, the page methods are OnPost**JoinList**Async and OnPost**JoinListUC**Async. With *OnPost* and *Async* removed, the handler names are `JoinList` and `JoinListUC`.
 
 [!code-html[main](index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml?highlight=12-13)]
 
@@ -299,7 +299,7 @@ Using the preceding code, the URL path that submits to `OnPostJoinListAsync` is 
 
 ## Customizing Routing
 
-If you don't like the query string`?handler=JoinList` in the URL, you can change the route to put the handler name in the path portion of the URL. You can customize the route by adding a route template enclosed in quotes after the `@page` directive.
+If you don't like the query string `?handler=JoinList` in the URL, you can change the route to put the handler name in the path portion of the URL. You can customize the route by adding a route template enclosed in double quotes after the `@page` directive.
 
 [!code-html[main](index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml?highlight=1)]
 

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -45,11 +45,11 @@ Consider a basic page:
 
 The preceeding code looks a lot like a Razor view file. What makes it different is the new `@page` directive. `@page` makes the file into an MVC action - which means that it can handle requests directly, without going through a controller. `@page` must be the first Razor directive on a page. `@page` affects the behavior of other Razor constructs. The [@functions](xref:mvc/views/razor#functions) directive enables function level content.
 
-A similar page, with the `PageModel` in a separate file, is shown in the following two files:
+A similar page, with the `PageModel` in a separate file, is shown in the following two files. The *Pages/Index2.cshtml* file:
 
 [!code-html[main](index/sample/RazorPagesIntro/Pages/Index2.cshtml)]
 
-The `PageModel` class *Pages/Index2.cshtml.cs*, a code-behind file for the view code:
+The *Pages/Index2.cshtml.cs* `code-behind` file:
 
 [!code-cs[main](index/sample/RazorPagesIntro/Pages/Index2.cshtml.cs)]
 
@@ -57,7 +57,7 @@ By convention, the `PageModel` class file has the same name as the Razor Page fi
 
 For simple pages, mixing the `PageModel` class with the Razor markup is fine. For more complex code, it's a best practice to keep the page model code seperate.
 
-The associations of URL paths to pages are determined by the page's location in the file system. The following table shows a Razor Pages path and the matching URL:
+The associations of URL paths to pages are determined by the page's location in the file system. The following table shows a Razor Page path and the matching URL:
 
 | File name and path               | matching URL |
 | ----------------- | ------------ | 
@@ -67,7 +67,7 @@ The associations of URL paths to pages are determined by the page's location in 
 
 The runtime looks for Razor Pages files in the *Pages* folder by default.
 
-### Writing a basic form
+## Writing a basic form
 
 The new Razor Pages features are designed to make common patterns used with web browsers easy. Consider a page that implements a basic 'contact us' form for the `Contact` model:
 
@@ -83,7 +83,7 @@ The *Pages/Create.cshtml* view file:
 
 [!code-html[main](index/sample/RazorPagesContacts/Pages/Create.cshtml)]
 
-The `PageModel` class *Pages/Create.cshtml.cs* code-behind file for the view:
+The *Pages/Create.cshtml.cs* code-behind file for the view:
 
 [!code-cs[main](index/sample/RazorPagesContacts/Pages/Create.cshtml.cs?name=ALL)]
 
@@ -109,9 +109,9 @@ Check for validation errors.
 *  If there are no errors, save the data and redirect.
 *  If there are errors, show the page again with validation messages. Client side validation is identical to traditonal ASP.NET Core MVC applications. In many cases validation errors would be caught on the client and never submitted to the server.
 
-When the data is entered successfully, the `OnPostAsync` handler method calls the `RedirectToPage` helper method to return an instance of `RedirectToPageResult`. This is a new action result similar to `RedirectToAction` or `RedirectToRoute` but customized for pages. In the preceding sample, it redirects to the Index page (`/Index`). `RedirectToPage` is detailed in the [URL generation for Pages](#url_gen) section.
+When the data is entered successfully, the `OnPostAsync` handler method calls the `RedirectToPage` helper method to return an instance of `RedirectToPageResult`. This is a new action result similar to `RedirectToAction` or `RedirectToRoute` but customized for pages. In the preceding sample, it redirects to the root Index page (`/Index`). `RedirectToPage` is detailed in the [URL generation for Pages](#url_gen) section.
 
-When the submitted form has validation errors (that are passed to the server), the`OnPostAsync` handler method calls the `Page` helper method. `Page` returns an instance of `PageResult`. This is similar to how actions in controllers return `View`. `PageResult` is the default <!-- Review default what? Return type?? --> for a handler method. A handler method that returns `void` will render the page.
+When the submitted form has validation errors (that are passed to the server), the`OnPostAsync` handler method calls the `Page` helper method. `Page` returns an instance of `PageResult`. This is similar to how actions in controllers return `View`. `PageResult` is the default <!-- Review default what?  --> for a handler method. A handler method that returns `void` will render the page.
 
 The `Customer` property is using the new `[BindProperty]` attribute to opt-in to model binding. 
 
@@ -119,7 +119,7 @@ The `Customer` property is using the new `[BindProperty]` attribute to opt-in to
 
 Razor Pages, by default, bind properties only with non-GET verbs. Binding to properties can reduce the amount of code you have to write by using the same property to render form fields (`<input asp-for="Customer.Name" />`) and accept the input.
 
-Rather than using `@model`, we're taking advantage of a new feature for Pages. By default, the generated `Page`-derived class *is* the model. This means that features like [model binding](xref:mvc/models/model-binding), [tag helpers](xref:mvc/views/tag-helpers/intro), and HTML helpers all *just work* with the properties defined in `@functions`. Using a *view model* with Razor views is a best practice. With Pages, you get a view model **automatically**. 
+Rather than using `@model`, we're taking advantage of a new feature for Pages. By default, the generated `Page`-derived class *is* the model. This means that features like [model binding](xref:mvc/models/model-binding), [tag helpers](xref:mvc/views/tag-helpers/intro), and HTML helpers all *just work* with the properties defined in `@functions`. Using a *view model* with Razor views is a best practice. With Pages, you get a view model *automatically*. 
 
 The following code shows the combined version of the create page:
 
@@ -143,7 +143,7 @@ The *Index.cshtml* file contains the following markup to create an edit link for
 ```
 
 The [Anchor Tag Helper](xref:mvc/views/tag-helpers/builtin-th/AnchorTagHelper) 
-used the [asp-route-](xref:mvc/views/tag-helpers/builtin-th/AnchorTagHelper#route) 
+used the [asp-route-{value}](xref:mvc/views/tag-helpers/builtin-th/AnchorTagHelper#route) 
 attribute to generate a link to the Edit page. The link contains route data with the contact ID. For example, `http://localhost:5000/Edit/1`.
 
 The *Pages/Edit.cshtml* file:
@@ -155,7 +155,7 @@ The first line contains the `@page "{id:int}"` directive. `"{id:int}"` tells the
 
 The *Pages/Edit.cshtml.cs* file:
 
-[!code-html[main](index/sample/RazorPagesContacts/Pages/Edit.cshtml.cs)]
+[!code-cs[main](index/sample/RazorPagesContacts/Pages/Edit.cshtml.cs)]
 
 <a name="xsrf"></a>
 
@@ -171,7 +171,7 @@ Let's declutter this page by taking advantage of some of those features.
 
 Add a [layout page](xref:mvc/views/layout) to Pages/_Layout.cshtm:
 
-                     razor-page-intro/RazorPagesContacts2/Pages/_LayoutSimple.cshtml
+[!code-cs[main](index/sample/RazorPagesContacts2/Pages/_LayoutSimple.cshtml)]
 
 The [Layout](xref:mvc/views/layout#specifying-a-layout) property is set in *Pages/_ViewStart.cshtml*:
 

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -48,7 +48,7 @@ Consider a basic page:
 
 [!code-html[main](index/sample/RazorPagesIntro/Pages/Index.cshtml)]
 
-The preceeding code looks a lot like a Razor view file. What makes it different is the new `@page` directive. `@page` makes the file into an MVC action - which means that it can handle requests directly, without going through a controller. `@page` must be the first Razor directive on a page. `@page` affects the behavior of other Razor constructs. The [@functions](xref:mvc/views/razor#functions) directive enables function level content.
+The preceding code looks a lot like a Razor view file. What makes it different is the new `@page` directive. `@page` makes the file into an MVC action - which means that it can handle requests directly, without going through a controller. `@page` must be the first Razor directive on a page. `@page` affects the behavior of other Razor constructs. The [@functions](xref:mvc/views/razor#functions) directive enables function level content.
 
 A similar page, with the `PageModel` in a separate file, is shown in the following two files. The *Pages/Index2.cshtml* file:
 
@@ -60,7 +60,7 @@ The *Pages/Index2.cshtml.cs* `code-behind` file:
 
 By convention, the `PageModel` class file has the same name as the Razor Page file with *.cs* appended. For example, the previous Razor Page is *Pages/Index2.cshtml*. The file containing the `PageModel` class is named *Pages/Index2.cshtml.cs*.
 
-For simple pages, mixing the `PageModel` class with the Razor markup is fine. For more complex code, it's a best practice to keep the page model code seperate.
+For simple pages, mixing the `PageModel` class with the Razor markup is fine. For more complex code, it's a best practice to keep the page model code separate.
 
 The associations of URL paths to pages are determined by the page's location in the file system. The following table shows a Razor Page path and the matching URL:
 
@@ -290,17 +290,17 @@ The following page generates markup for two page handlers using the `asp-page-ha
 [!code-html[main](index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml?highlight=12-13)]
 
 <!-- Review: Where is the FormActionTagHelper?  How is it used in conjunction? -->
-The form in the preceeding example has two submit buttons, each using the new `FormActionTagHelper` in conjunction to submit to a different URL. The `asp-handler` attribute is a companion to `asp-page` and generates URLs that submit to each of the handler methods defined by the page. We don't need to specify `asp-page` because we're linking to the current page.
+The form in the preceding example has two submit buttons, each using the new `FormActionTagHelper` in conjunction to submit to a different URL. The `asp-handler` attribute is a companion to `asp-page` and generates URLs that submit to each of the handler methods defined by the page. We don't need to specify `asp-page` because we're linking to the current page.
 
 The code-behind file:
 
 [!code-cs[main](index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml.cs?highlight=20,32)]
 
-The preceeding code uses *named handler methods*. Named handler methods are created by taking the text in the name after `On<HTTP Verb>` and before `Async` (if present). In the preceeding example, the page methods are OnPost**JoinList**Async and OnPost**JoinListUC**Async. The handler names when *OnPost* and *Async* are removed are `JoinList` and `JoinListUC`.
+The preceding code uses *named handler methods*. Named handler methods are created by taking the text in the name after `On<HTTP Verb>` and before `Async` (if present). In the preceding example, the page methods are OnPost**JoinList**Async and OnPost**JoinListUC**Async. The handler names when *OnPost* and *Async* are removed are `JoinList` and `JoinListUC`.
 
 [!code-html[main](index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml?highlight=12-13)]
 
-Using the preceeding code, the URL path that submits to `OnPostJoinListAsync` is `http://localhost:5000/Customers/CreateFATH?handler=JoinList`. The URL path that submits to `OnPostJoinListUCAsync` is `http://localhost:5000/Customers/CreateFATH?handler=JoinListUC`. 
+Using the preceding code, the URL path that submits to `OnPostJoinListAsync` is `http://localhost:5000/Customers/CreateFATH?handler=JoinList`. The URL path that submits to `OnPostJoinListUCAsync` is `http://localhost:5000/Customers/CreateFATH?handler=JoinListUC`. 
 
 ## Customizing Routing
 

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -1,8 +1,3 @@
-<!--   TODO
-
-check lang type [!code-
-
--->
 ---
 title: Introduction to Razor Pages in ASP.NET Core
 author: Rick-Anderson
@@ -139,7 +134,7 @@ The home page (*Index.cshtml*)
 
 The code behind *Index.cshtml.cs* file:
 
-[!code-html[main](index/sample/RazorPagesContacts/Pages/Index.cshtml.cs)]
+[!code-cs[main](index/sample/RazorPagesContacts/Pages/Index.cshtml.cs)]
 
 The *Index.cshtml* file contains the following markup to create an edit link for each contact:
 
@@ -176,7 +171,7 @@ Let's declutter this page by taking advantage of some of those features.
 
 Add a [layout page](xref:mvc/views/layout) to Pages/_Layout.cshtm:
 
-[!code-cs[main](index/sample/RazorPagesContacts2/Pages/_LayoutSimple.cshtml)]
+[!code-html[main](index/sample/RazorPagesContacts2/Pages/_LayoutSimple.cshtml)]
 
 The [Layout](xref:mvc/views/layout#specifying-a-layout) property is set in *Pages/_ViewStart.cshtml*:
 
@@ -190,7 +185,7 @@ View search from a Razor Page will include the *Pages* folder. The layouts, temp
 
 Add a *Pages/_ViewImports.cshtml* file:
 
-[!code-cs[main](index/sample/RazorPagesContacts2/Pages/_ViewImports.cshtml)]
+[!code-html[main](index/sample/RazorPagesContacts2/Pages/_ViewImports.cshtml)]
 
 I'll explain the `@namespace` later. The `@addTagHelper` directive will bring in the [built-in tag helpers](https://docs.microsoft.com/aspnet/core/mvc/views/tag-helpers/built-in/) to all the pages in the *Pages* folder.
 
@@ -210,16 +205,16 @@ For example, the code behind file *Pages/Customers/Edit.cshtml.cs* explicitly se
 
 The *Pages/_ViewImports.cshtml* file sets the following namespace:
 
-[!code-cs[main](index/sample/RazorPagesContacts2/Pages/_ViewImports.cshtml?highlight=1)]
+[!code-html[main](index/sample/RazorPagesContacts2/Pages/_ViewImports.cshtml?highlight=1)]
 
 The generated namespace for the *Pages/Customers/Edit.cshtml* Razor Page is the same as the code behind file. The `@namespace` directive was designed so the C# classes you add and pages-generated code *just work* without having to add an `@using` statement for the code behind file.
 
 Note: `@namespace` also works with conventional Razor views.
 
-<!--
+<!-- rick todo
 Add a *Pages/_ValidationScriptsPartial.cshtml* file to enable client side validation.
 
-[!code-cs[main](index/sample/RazorPagesContacts/Pages/_ValidationScriptsPartial.cshtml)]
+[!code-html[main](index/sample/RazorPagesContacts/Pages/_ValidationScriptsPartial.cshtml)]
 
 -->
 
@@ -317,7 +312,7 @@ You can use `@page` to add additional segments and parameters to a page's route.
 
 Use the extension method `AddRazorPagesOptions` on the MVC builder to configure advanced options such as the following example:
 
-<!-- Review - please update the sample code to do this and I'll import the snippet
+<!-- Review - please update the sample code to configure advanced options  and I'll import the snippet
 -->
 
 ```c#

--- a/aspnetcore/mvc/razor-pages/index/sample/NuGet.config
+++ b/aspnetcore/mvc/razor-pages/index/sample/NuGet.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="aspnetcore-release" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Data/AppDbContext.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Data/AppDbContext.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace RazorPagesContacts.Data
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions options)
+            : base(options)
+        {
+
+        }
+
+        public DbSet<Customer> Customers { get; set; }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Data/Customer.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Data/Customer.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace RazorPagesContacts.Data
+{
+    public class Customer
+    {
+        public int Id { get; set; }
+
+        [Required, StringLength(100)]
+        public string Name { get; set; }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/Create.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/Create.cshtml
@@ -1,0 +1,16 @@
+﻿@page
+@model RazorPagesContacts.Pages.CreateModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<html>
+<body>
+    <p>
+        Enter your name.
+    </p>
+    <div asp-validation-summary="All"></div>
+    <form method="POST">
+        <div>Name: <input asp-for="Customer.Name" /></div>
+        <input type="submit" />
+    </form>
+</body>
+</html>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/Create.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/Create.cshtml.cs
@@ -1,0 +1,38 @@
+﻿#region ALL
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using RazorPagesContacts.Data;
+
+namespace RazorPagesContacts.Pages
+{
+    #region PageModel
+    public class CreateModel : PageModel
+    {
+        private readonly AppDbContext _db;
+
+        public CreateModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        [BindProperty]
+        public Customer Customer { get; set; }
+
+        #region OnPostAsync
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            _db.Customers.Add(Customer);
+            await _db.SaveChangesAsync();
+            return RedirectToPage("/Index");
+        }
+        #endregion
+    }
+    #endregion
+}
+#endregion

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/CreateCombined.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/CreateCombined.cshtml
@@ -1,0 +1,35 @@
+﻿@page
+@using RazorPagesContacts.Data
+@using Microsoft.AspNetCore.Mvc.RazorPages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@inject AppDbContext Db
+
+@functions {
+      [BindProperty]
+        public Customer Customer { get; set; }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            Db.Customers.Add(Customer);
+            await Db.SaveChangesAsync();
+            return RedirectToPage("/Index");
+        }
+}
+
+<html>
+<body>
+    <p>
+        Enter your contact info (Combined page).
+    </p>
+    <div asp-validation-summary="All"></div>
+    <form method="POST">
+        <div>Name: <input asp-for="Customer.Name" /></div>
+        <input type="submit" />
+    </form>
+</body>
+</html>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/Edit.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/Edit.cshtml
@@ -1,0 +1,26 @@
+﻿@page "{id:int}"
+@model RazorPagesContacts.Pages.EditModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+
+@{
+    ViewData["Title"] = "Edit Customer";
+}
+
+<h1>Edit Customer - @Model.Customer.Id</h1>
+<form method="post">
+    <div asp-validation-summary="All"></div>
+    <input asp-for="Customer.Id" type="hidden" />
+    <div>
+        <label asp-for="Customer.Name"></label>
+        <div>
+            <input asp-for="Customer.Name" />
+            <span asp-validation-for="Customer.Name" ></span>
+        </div>
+    </div>
+ 
+        <div>
+            <button type="submit">Save</button>
+        </div>
+ 
+</form>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/Edit.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/Edit.cshtml.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using RazorPagesContacts.Data;
+
+namespace RazorPagesContacts.Pages
+{
+    public class EditModel : PageModel
+    {
+        private readonly AppDbContext _db;
+
+        public EditModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        [BindProperty]
+        public Customer Customer { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int id)
+        {
+            Customer = await _db.Customers.FindAsync(id);
+
+            if (Customer == null)
+            {
+                return RedirectToPage("/Index");
+            }
+
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            _db.Attach(Customer).State = EntityState.Modified;
+
+            try
+            {
+                await _db.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                throw new Exception($"Customer {Customer.Id} not found!");
+            }
+
+            return RedirectToPage("/Index");
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/Index.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/Index.cshtml
@@ -1,0 +1,31 @@
+﻿@page
+@model RazorPagesContacts.Pages.IndexModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<h1>Contacts</h1>
+<form method="post">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var contact in Model.Customers)
+            {
+                <tr>
+                    <td>@contact.Id</td>
+                    <td>@contact.Name</td>
+                    <td>
+                        <a asp-page="./Edit" asp-route-id="@contact.Id">edit</a>
+                        <button type="submit" asp-page-handler="delete" 
+                                asp-route-id="@contact.Id">delete</button>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+
+    <a asp-page="./Create">Create</a>
+</form>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/Index.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/Index.cshtml.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using RazorPagesContacts.Data;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+
+namespace RazorPagesContacts.Pages
+{
+    public class IndexModel : PageModel
+    {
+        private readonly AppDbContext _db;
+
+        public IndexModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        public IList<Customer> Customers { get; private set; }
+
+        public async Task OnGetAsync()
+        {
+            Customers = await _db.Customers.AsNoTracking().ToListAsync();
+
+        }
+
+        public async Task<IActionResult> OnPostDeleteAsync(int id)
+        {
+            var contact = await _db.Customers.FindAsync(id);
+
+            if (contact != null)
+            {
+                _db.Customers.Remove(contact);
+                await _db.SaveChangesAsync();
+            }
+
+            return RedirectToPage();
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/IndexCombined.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Pages/IndexCombined.cshtml
@@ -1,0 +1,72 @@
+﻿@page
+@namespace RazorPagesContacts.Pages
+@using RazorPagesContacts.Data
+@using Microsoft.AspNetCore.Mvc.RazorPages
+@using Microsoft.EntityFrameworkCore
+
+
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@inject AppDbContext Db
+@model IndexCombinedModel
+
+@functions {
+    public class IndexCombinedModel : PageModel
+    {
+        private readonly AppDbContext _db;
+
+        public IndexCombinedModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        public IList<Customer> Customers { get; private set; }
+
+        public async Task OnGetAsync()
+        {
+            Customers = await _db.Customers.AsNoTracking().ToListAsync();
+
+        }
+
+        public async Task<IActionResult> OnPostDeleteAsync(int id)
+        {
+            var contact = await _db.Customers.FindAsync(id);
+
+            if (contact != null)
+            {
+                _db.Customers.Remove(contact);
+                await _db.SaveChangesAsync();
+            }
+
+            return RedirectToPage();
+        }
+    }
+}
+
+
+<h1>Contacts Combined page</h1>
+<form method="post">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var contact in Model.Customers)
+            {
+                <tr>
+                    <td>@contact.Id</td>
+                    <td>@contact.Name</td>
+                    <td>
+                        <a asp-page="./Edit" asp-route-id="@contact.Id">edit</a>
+                        <button type="submit" asp-page-handler="delete" 
+                                asp-route-id="@contact.Id">delete</button>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+
+    <a asp-page="./CreateCombined">Create</a>
+</form>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Program.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Program.cs
@@ -1,0 +1,26 @@
+﻿#define Debug
+
+using Microsoft.AspNetCore.Hosting;
+using System.IO;
+
+namespace RazorPagesContacts
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+#if  Debug
+                .UseStartup<StartupDebug>()
+#else
+                .UseStartup<Startup>()
+#endif
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/RazorPagesContacts.csproj
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/RazorPagesContacts.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25794" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Startup.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/Startup.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using RazorPagesContacts.Data;
+
+namespace RazorPagesContacts
+{
+    public class Startup
+    {
+        public IHostingEnvironment HostingEnvironment { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddDbContext<AppDbContext>(options =>
+                              options.UseInMemoryDatabase("name"));
+            services.AddMvc();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseMvc();
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/StartupDebug.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts/StartupDebug.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using RazorPagesContacts.Data;
+
+namespace RazorPagesContacts
+{
+    public class StartupDebug
+    {
+        public StartupDebug(IHostingEnvironment env)
+        {
+                  HostingEnvironment = env;
+        }
+
+        public IHostingEnvironment HostingEnvironment { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddDbContext<AppDbContext>(options => 
+                              options.UseInMemoryDatabase("name"));
+            services.AddMvc();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            if (HostingEnvironment.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/error");
+            }
+
+            app.UseStaticFiles();
+
+            app.UseMvc();
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Data/AppDbContext.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Data/AppDbContext.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace RazorPagesContacts.Data
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions options)
+            : base(options)
+        {
+
+        }
+
+        public DbSet<Customer> Customers { get; set; }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Data/Customer.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Data/Customer.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace RazorPagesContacts.Data
+{
+    public class Customer
+    {
+        public int Id { get; set; }
+
+        [Required, StringLength(100)]
+        public string Name { get; set; }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Create.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Create.cshtml
@@ -1,0 +1,15 @@
+﻿@page
+@model CreateModel
+
+<html>
+<body>
+    <p>
+        Enter your name.
+    </p>
+    <div asp-validation-summary="All"></div>
+    <form method="POST">
+        <div>Name: <input asp-for="Customer.Name" /></div>
+        <input type="submit" />
+    </form>
+</body>
+</html>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Create.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Create.cshtml.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using RazorPagesContacts.Data;
+
+namespace RazorPagesContacts.Pages.Customers
+{
+      public class CreateModel : PageModel
+    {
+        private readonly AppDbContext _db;
+
+        public CreateModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        [BindProperty]
+        public Customer Customer { get; set; }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            _db.Customers.Add(Customer);
+            await _db.SaveChangesAsync();
+            return RedirectToPage("/Index");
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Create2Dot.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Create2Dot.cshtml
@@ -1,0 +1,15 @@
+﻿@page
+@model Create2DotModel
+
+<html>
+<body>
+    <p>
+        RedirectToPage("../Index");
+    </p>
+    <div asp-validation-summary="All"></div>
+    <form method="POST">
+        <div>Name: <input asp-for="Customer.Name" /></div>
+        <input type="submit" />
+    </form>
+</body>
+</html>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Create2Dot.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Create2Dot.cshtml.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using RazorPagesContacts.Data;
+
+namespace RazorPagesContacts.Pages.Customers
+{
+      public class Create2DotModel : PageModel
+    {
+        private readonly AppDbContext _db;
+
+        public Create2DotModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        [BindProperty]
+        public Customer Customer { get; set; }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            _db.Customers.Add(Customer);
+            await _db.SaveChangesAsync();
+            return RedirectToPage("../Index");
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateBlank.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateBlank.cshtml
@@ -1,0 +1,15 @@
+﻿@page
+@model CreateBlankModel
+
+<html>
+<body>
+    <p>
+        RedirectToPage("Index");
+    </p>
+    <div asp-validation-summary="All"></div>
+    <form method="POST">
+        <div>Name: <input asp-for="Customer.Name" /></div>
+        <input type="submit" />
+    </form>
+</body>
+</html>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateBlank.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateBlank.cshtml.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using RazorPagesContacts.Data;
+
+namespace RazorPagesContacts.Pages.Customers
+{
+      public class CreateBlankModel : PageModel
+    {
+        private readonly AppDbContext _db;
+
+        public CreateBlankModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        [BindProperty]
+        public Customer Customer { get; set; }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            _db.Customers.Add(Customer);
+            await _db.SaveChangesAsync();
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateDot.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateDot.cshtml
@@ -1,0 +1,15 @@
+﻿@page
+@model CreateDotModel
+
+<html>
+<body>
+    <p>
+        RedirectToPage("./Index");
+    </p>
+    <div asp-validation-summary="All"></div>
+    <form method="POST">
+        <div>Name: <input asp-for="Customer.Name" /></div>
+        <input type="submit" />
+    </form>
+</body>
+</html>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateDot.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateDot.cshtml.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using RazorPagesContacts.Data;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace RazorPagesContacts.Pages.Customers
+{
+      public class CreateDotModel : PageModel
+    {
+        private readonly AppDbContext _db;
+
+        public CreateDotModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        [TempData] public string Message { get; set; }
+
+
+        [BindProperty]
+        public Customer Customer { get; set; }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            _db.Customers.Add(Customer);
+            await _db.SaveChangesAsync();
+            Message = "it worked";
+            return RedirectToPage("./Index");
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml
@@ -1,0 +1,16 @@
+﻿@page
+@model CreateFATHModel
+
+<html>
+<body>
+    <p>
+        Enter your name.
+    </p>
+    <div asp-validation-summary="All"></div>
+    <form method="POST">
+        <div>Name: <input asp-for="Customer.Name" /></div>
+        <input type="submit" asp-page-handler="JoinList" value="Join" />
+        <input type="submit" asp-page-handler="JoinListUC" value="JOIN UC" />
+    </form>
+</body>
+</html>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml.cs
@@ -1,0 +1,42 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using RazorPagesContacts.Data;
+
+namespace RazorPagesContacts.Pages.Customers
+{
+    public class CreateFATHModel : PageModel
+    {
+        private readonly AppDbContext _db;
+
+        public CreateFATHModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        [BindProperty]
+        public Customer Customer { get; set; }
+
+        public async Task<IActionResult> OnPostJoinListAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            _db.Customers.Add(Customer);
+            await _db.SaveChangesAsync();
+            return RedirectToPage("/Index");
+        }
+
+        public async Task<IActionResult> OnPostJoinListUCAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+            Customer.Name = Customer.Name?.ToUpper();
+            return await OnPostJoinListAsync();
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml
@@ -1,0 +1,17 @@
+﻿@page "{handler?}"
+
+@model CreateRouteModel
+
+<html>
+<body>
+    <p>
+        Enter your name.
+    </p>
+    <div asp-validation-summary="All"></div>
+    <form method="POST">
+        <div>Name: <input asp-for="Customer.Name" /></div>
+        <input type="submit" asp-page-handler="JoinList" value="Join" />
+        <input type="submit" asp-page-handler="JoinListUC" value="JOIN UC" />
+    </form>
+</body>
+</html>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml
@@ -1,5 +1,4 @@
 ﻿@page "{handler?}"
-
 @model CreateRouteModel
 
 <html>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml.cs
@@ -1,0 +1,42 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using RazorPagesContacts.Data;
+
+namespace RazorPagesContacts.Pages.Customers
+{
+    public class CreateRouteModel : PageModel
+    {
+        private readonly AppDbContext _db;
+
+        public CreateRouteModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        [BindProperty]
+        public Customer Customer { get; set; }
+
+        public async Task<IActionResult> OnPostJoinListAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            _db.Customers.Add(Customer);
+            await _db.SaveChangesAsync();
+            return RedirectToPage("/Index");
+        }
+
+        public async Task<IActionResult> OnPostJoinListUCAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+            Customer.Name = Customer.Name?.ToUpper();
+            return await OnPostJoinListAsync();
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateTempData.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateTempData.cshtml
@@ -1,0 +1,15 @@
+﻿@page
+@model CreateTempDataModel
+
+<html>
+<body>
+    <p>
+        CreateTempDataModel
+    </p>
+    <div asp-validation-summary="All"></div>
+    <form method="POST">
+        <div>Name: <input asp-for="Customer.Name" /></div>
+        <input type="submit" />
+    </form>
+</body>
+</html>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateTempData.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/CreateTempData.cshtml.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using RazorPagesContacts.Data;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace RazorPagesContacts.Pages.Customers
+{
+      public class CreateTempDataModel : PageModel
+    {
+        private readonly AppDbContext _db;
+
+        public CreateTempDataModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        [BindProperty]
+        public Customer Customer { get; set; }
+
+        [TempData]
+        public string Message { get; set; }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            _db.Customers.Add(Customer);
+            await _db.SaveChangesAsync();
+            Message = "Cust ID = " + Customer.Id.ToString();
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Edit.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Edit.cshtml
@@ -1,0 +1,20 @@
+﻿@page "{id:int}"
+@model EditModel
+@{
+    ViewData["Title"] = "Edit Customer";
+}
+<h1>Edit Customer - @Model.Customer.Id</h1>
+<form method="post">
+    <div asp-validation-summary="All"></div>
+    <input asp-for="Customer.Id" type="hidden" />
+    <div>
+        <label asp-for="Customer.Name"></label>
+        <div>
+            <input asp-for="Customer.Name" />
+            <span asp-validation-for="Customer.Name"></span>
+        </div>
+    </div>
+    <div>
+        <button type="submit">Save</button>
+    </div>
+</form>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Edit.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Edit.cshtml.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using RazorPagesContacts.Data;
+
+#region namespace
+namespace RazorPagesContacts.Pages
+
+{
+    public class EditModel : PageModel
+    {
+        private readonly AppDbContext _db;
+
+        public EditModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        // Code removed for brevity.
+        #endregion
+        [BindProperty]
+        public Customer Customer { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int id)
+        {
+            Customer = await _db.Customers.FindAsync(id);
+
+            if (Customer == null)
+            {
+                return RedirectToPage("/Index");
+            }
+
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            _db.Attach(Customer).State = EntityState.Modified;
+
+            try
+            {
+                await _db.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                throw new Exception($"Customer {Customer.Id} not found!");
+            }
+
+            return RedirectToPage("/Index");
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Index.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Index.cshtml
@@ -1,0 +1,33 @@
+﻿@page
+@model IndexModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<h2>Pages/Customers/Index</h2>
+
+<h3>Msg: @Model.Message</h3>
+
+<form method="post">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var contact in Model.Customers)
+            {
+                <tr>
+                    <td>@contact.Id</td>
+                    <td>@contact.Name</td>
+                    <td>
+                        <a asp-page="/Customers/Edit" asp-route-id="@contact.Id">edit</a>
+                        <button type="submit" asp-page-handler="delete" 
+                                asp-route-id="@contact.Id">delete</button>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+
+</form>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Index.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Customers/Index.cshtml.cs
@@ -1,0 +1,43 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using RazorPagesContacts.Data;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace RazorPagesContacts.Pages.Customers
+{
+    public class IndexModel : PageModel
+    {
+        private readonly AppDbContext _db;
+        [TempData]
+        public string Message { get; set; }
+
+        public IndexModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        public IList<Customer> Customers { get; private set; }
+
+        public async Task OnGetAsync()
+        {
+            Customers = await _db.Customers.AsNoTracking().ToListAsync();
+
+        }
+
+        public async Task<IActionResult> OnPostDeleteAsync(int id)
+        {
+            var contact = await _db.Customers.FindAsync(id);
+
+            if (contact != null)
+            {
+                _db.Customers.Remove(contact);
+                await _db.SaveChangesAsync();
+            }
+
+            return RedirectToPage();
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Index.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Index.cshtml
@@ -1,0 +1,30 @@
+﻿@page
+@model RazorPagesContacts.Pages.IndexModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<h2>Contacts</h2>
+<form method="post">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var contact in Model.Customers)
+            {
+                <tr>
+                    <td>@contact.Id</td>
+                    <td>@contact.Name</td>
+                    <td>
+                        <a asp-page="/Customers/Edit" asp-route-id="@contact.Id">edit</a>
+                        <button type="submit" asp-page-handler="delete" 
+                                asp-route-id="@contact.Id">delete</button>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+
+</form>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Index.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Index.cshtml.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using RazorPagesContacts.Data;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+
+namespace RazorPagesContacts.Pages
+{
+    public class IndexModel : PageModel
+    {
+        private readonly AppDbContext _db;
+
+        public IndexModel(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        public IList<Customer> Customers { get; private set; }
+
+        public async Task OnGetAsync()
+        {
+            Customers = await _db.Customers.AsNoTracking().ToListAsync();
+
+        }
+
+        public async Task<IActionResult> OnPostDeleteAsync(int id)
+        {
+            var contact = await _db.Customers.FindAsync(id);
+
+            if (contact != null)
+            {
+                _db.Customers.Remove(contact);
+                await _db.SaveChangesAsync();
+            }
+
+            return RedirectToPage();
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Reports/Class.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Reports/Class.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace RazorPagesContacts2.Pages.Reports
+{
+    public class Class
+    {
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Reports/Test.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Reports/Test.cshtml
@@ -1,0 +1,28 @@
+﻿@page
+@model TestModel
+@{
+
+    ViewData["Title"] = "Hello from pages";
+}
+@functions {
+
+    [TempData]
+    public string Message { get; set; }
+}
+<div class="row">
+    <div class="col-md-3">
+        <h2>RazorPages says Hello @Model.Name!</h2>
+        <ul>
+            <li>This file should give you a quick view of a Mvc Razor Page in action.</li>
+        </ul>
+        <p>Message from TempData: @Message</p>
+        @{
+            Message = $"You visited this page at {DateTime.Now}.";
+        }
+    </div>
+    <form method="post">
+        <label>Say hello to <input type="text" name="name" /></label>
+        <input type="submit" value="Say" />
+    </form>
+
+</div>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Reports/Time.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Reports/Time.cshtml
@@ -1,0 +1,20 @@
+﻿@page
+@model TimeModel
+@using Microsoft.AspNetCore.Mvc.RazorPages
+
+@functions {
+    public class TimeModel : PageModel
+    {
+        public string Message { get; private set; }
+
+        public void OnGet()
+        {
+            Message = $" Server seconds  { DateTime.Now.Second.ToString() }";
+        }
+    }
+}
+
+<h2>Server Seconds using @@Model</h2>
+<p>
+    @Model.Message
+</p>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Reports/TimeTempData.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/Reports/TimeTempData.cshtml
@@ -1,0 +1,22 @@
+﻿@page
+@model TimeTempDataModel
+@using Microsoft.AspNetCore.Mvc.RazorPages
+
+
+@functions {
+    public class TimeTempDataModel : PageModel
+    {
+        [TempData]
+        public string Message { get; set; }
+
+        public void OnGet()
+        {
+            Message = $" Server seconds  { DateTime.Now.Second.ToString() }";
+        }
+    }
+}
+
+<h2>Server Seconds using [TempData] </h2>
+<p>
+        <h3>@Model.Message</h3>        
+</p>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/_Layout.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/_Layout.cshtml
@@ -1,0 +1,17 @@
+﻿<!DOCTYPE html>
+<html>
+<head> 
+    <title>Razor Pages Sample</title>      
+</head>
+<body>    
+   <a asp-page="/Index">Home</a>
+    @RenderBody()  
+    <a asp-page="/Customers/Create">Create</a> <br />
+    <a asp-page="/Customers/CreateDot">Create ./Index</a><br />
+    <a asp-page="/Customers/Create2Dot">Create ../Index</a><br />
+    <a asp-page="/Customers/CreateBlank">Create Index</a><br />
+    <a asp-page="/Customers/CreateFATH">Create Form Action TH</a><br />
+    <a asp-page="/Customers/CreateRoute">Create Route</a><br />
+
+</body>
+</html>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/_LayoutSimple.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/_LayoutSimple.cshtml
@@ -1,0 +1,17 @@
+﻿<!DOCTYPE html>
+<html>
+<head> 
+    <title>Razor Pages Sample</title>      
+</head>
+<body>    
+   <a asp-page="/Index">Home</a>
+    @RenderBody()  
+    <a asp-page="/Customers/Create">Create</a> <br />
+    <a asp-page="/Customers/CreateDot">Create ./Index</a><br />
+    <a asp-page="/Customers/Create2Dot">Create ../Index</a><br />
+    <a asp-page="/Customers/CreateBlank">Create Index</a><br />
+    <a asp-page="/Customers/CreateFATH">Create Form Action TH</a><br />
+    <a asp-page="/Customers/CreateRoute">Create Route</a><br />
+
+</body>
+</html>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/_LayoutSimple.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/_LayoutSimple.cshtml
@@ -7,11 +7,5 @@
    <a asp-page="/Index">Home</a>
     @RenderBody()  
     <a asp-page="/Customers/Create">Create</a> <br />
-    <a asp-page="/Customers/CreateDot">Create ./Index</a><br />
-    <a asp-page="/Customers/Create2Dot">Create ../Index</a><br />
-    <a asp-page="/Customers/CreateBlank">Create Index</a><br />
-    <a asp-page="/Customers/CreateFATH">Create Form Action TH</a><br />
-    <a asp-page="/Customers/CreateRoute">Create Route</a><br />
-
 </body>
 </html>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/_ViewImports.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+﻿@namespace RazorPagesContacts.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/_ViewStart.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout";
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Program.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Program.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using System.IO;
+
+namespace RazorPagesContacts
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/RazorPagesContacts2.csproj
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/RazorPagesContacts2.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25794" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Startup.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesContacts2/Startup.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using RazorPagesContacts.Data;
+
+namespace RazorPagesContacts
+{
+    public class Startup
+    {
+        public Startup(IHostingEnvironment env)
+        {
+                  HostingEnvironment = env;
+        }
+
+        public IHostingEnvironment HostingEnvironment { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddDbContext<AppDbContext>(options => 
+                              options.UseInMemoryDatabase("name"));
+            services.AddMvc();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            if (HostingEnvironment.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/error");
+            }
+
+            app.UseStaticFiles();
+
+            app.UseMvc();
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Pages/Customers/Namespace2.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Pages/Customers/Namespace2.cshtml
@@ -1,0 +1,9 @@
+﻿@page
+@namespace RazorPagesIntro.Pages.Customers
+
+@model NameSpaceModel
+
+<h2>Name space</h2>
+<p>
+    @Model.Message
+</p>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Pages/Customers/Namespace2.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Pages/Customers/Namespace2.cshtml.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+using System;
+
+namespace RazorPagesIntro.Pages.Customers
+{
+    public class NameSpaceModel : PageModel
+    {
+        public string Message { get; private set; } = "";
+
+        public void OnGet()
+        {
+            Message += $" Server time is { DateTime.Now }";
+        }
+    }
+}
+
+// docFX won't allow a filename namespace.cshtml

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Pages/Index.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Pages/Index.cshtml
@@ -1,0 +1,20 @@
+﻿@page
+@model IndexModel
+@using Microsoft.AspNetCore.Mvc.RazorPages
+
+@functions {
+    public class IndexModel : PageModel
+    {
+        public string Message { get; private set; } = "In page model: ";
+
+        public void OnGet()
+        {
+            Message += $" Server seconds  { DateTime.Now.Second.ToString() }";
+        }
+    }
+}
+
+<h2>In page sample</h2>
+<p>
+    @Model.Message
+</p>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Pages/Index2.cshtml
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Pages/Index2.cshtml
@@ -1,0 +1,9 @@
+﻿@page
+@using RazorPages
+
+@model IndexModel2
+
+<h2>Seperate page model</h2>
+<p>
+    @Model.Message
+</p>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Pages/Index2.cshtml.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Pages/Index2.cshtml.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+using System;
+
+namespace RazorPages
+{
+    public class IndexModel2 : PageModel
+    {
+        public string Message { get; private set; } = "PageModel in C#";
+
+        public void OnGet()
+        {
+            Message += $" Server time is { DateTime.Now }";
+        }
+    }
+}
+

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Program.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Program.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using System.IO;
+
+namespace RazorPagesIntro
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/RazorPagesIntro.csproj
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/RazorPagesIntro.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <UserSecretsId>707f292c-9e8d-446b-a53d-80ae8716212c</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25794" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Startup.cs
+++ b/aspnetcore/mvc/razor-pages/index/sample/RazorPagesIntro/Startup.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace RazorPagesIntro
+{
+    #region Startup
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Includes support for Razor Pages and controllers.
+            services.AddMvc();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseMvc();
+        }
+    }
+    #endregion
+}

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -496,6 +496,8 @@ When passed "[Rick@contoso.com](mailto:Rick@contoso.com)" in the model:
 
 The `@inject` directive enables you to inject a service from your [service container](../../fundamentals/dependency-injection.md)  into your Razor page for use. See [Dependency injection into views](dependency-injection.md).
 
+<a name="functions"></a>
+
 ### `@functions`
 
 The `@functions` directive enables you to add function level content to your Razor page. The syntax is:


### PR DESCRIPTION
[Internal Preview link](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/razor-pages/?branch=pr-en-us-3722)

Ryan: Search for `Review` in *aspnetcore/mvc/razor-pages/index.md*

* Using a `PageModel` code-behind file supports unit testing, but requires you to write an explicit constructor and class. Pages without `PageModel` code-behind files support runtime compilation, which can be an advantage in development.  <!-- review: advantage because you can make changes and refresh the browser without explicitly compiling the app -->
* The `Async` naming suffix is optional but is often used by convention. The code that's in `OnPostAsync` in the preceding example looks similar to what you would normally write in a controller. This is typical for Razor Pages. Most of the MVC primitives like [model binding](xref:mvc/models/model-binding), [validation](xref:mvc/models/validation), and action results are shared.  <!-- Review: Ryan, can we get a list of what is shared and what isn't? -->
* When the submitted form has validation errors (that are passed to the server), the`OnPostAsync` handler method calls the `Page` helper method. `Page` returns an instance of `PageResult`. This is similar to how actions in controllers return `View`. `PageResult` is the default <!-- Review default what?  --> for a handler method. A handler method that returns `void` will render the page.
* `<!-- REVIEW -->`
The first line contains the `@page "{id:int}"` directive. `"{id:int}"` tells the page to accept requests to the page that contain `int` route data. If a request to the page doesn't contain route data that can be converted to an `int`, the runtime returns an HTTP 404 (not found) error.
* `RedirectToPage("Index")`, `RedirectToPage("./Index")`, and `RedirectToPage("../Index")`  are *relative names*. The `RedirectToPage` parameter is *combined* with the path of the current page to compute the name of the destination page.  <!-- Review: Original had The provided string is combined with the page name of the current page to compute the name of the destination page. -- page name, not page path -->
* `<!-- Review: Where is the FormActionTagHelper?  How is it used in conjunction? -->`
The form in the preceding example has two submit buttons, each using the new `FormActionTagHelper` in conjunction to submit to a different URL. The `asp-handler` attribute is a companion to `asp-page` and generates URLs that submit to each of the handler methods defined by the page. We don't need to specify `asp-page` because we're linking to the current page.
* <!-- Review - please update the sample code to configure advanced options  and I'll import the snippet
-->