### PR TITLE
Fixed an extra bracket in test method

### DIFF
--- a/aspnetcore/mvc/controllers/testing.md
+++ b/aspnetcore/mvc/controllers/testing.md
@@ -55,7 +55,7 @@ To demonstrate unit testing, review the following controller. It displays a list
 
 The controller is following the [explicit dependencies principle](http://deviq.com/explicit-dependencies-principle/), expecting dependency injection to provide it with an instance of `IBrainstormSessionRepository`. This makes it fairly easy to test using a mock object framework, like [Moq](https://www.nuget.org/packages/Moq/). The `HTTP GET Index` method has no looping or branching and only calls one method. To test this `Index` method, we need to verify that a `ViewResult` is returned, with a `ViewModel` from the repository's `List` method.
 
-[!code-csharp[Main](testing/sample/TestingControllersSample/tests/TestingControllersSample.Tests/UnitTests/HomeControllerTests.cs?highlight=17-18&range=1-33,75-95)]
+[!code-csharp[Main](testing/sample/TestingControllersSample/tests/TestingControllersSample.Tests/UnitTests/HomeControllerTests.cs?highlight=17-18&range=1-33,76-95)]
 
 The `HomeController` `HTTP POST Index` method (shown above) should verify:
 


### PR DESCRIPTION
The source listing of the GetTestSessions method of [Testing Controller Logic](https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/testing) included an end bracket due to an offset error in the line numbers:

```cs
[Fact]
public async Task Index_ReturnsAViewResult_WithAListOfBrainstormSessions()
{
	// Arrange
	var mockRepo = new Mock<IBrainstormSessionRepository>();
	mockRepo.Setup(repo => repo.ListAsync()).Returns(Task.FromResult(GetTestSessions()));
	var controller = new HomeController(mockRepo.Object);

	// Act
	var result = await controller.Index();

	// Assert
	var viewResult = Assert.IsType<ViewResult>(result);
	var model = Assert.IsAssignableFrom<IEnumerable<StormSessionViewModel>>(
		viewResult.ViewData.Model);
	Assert.Equal(2, model.Count());
}
}

private List<BrainstormSession> GetTestSessions()
{
	var sessions = new List<BrainstormSession>();
	sessions.Add(new BrainstormSession()
	{
		DateCreated = new DateTime(2016, 7, 2),
		Id = 1,
		Name = "Test One"
	});
	sessions.Add(new BrainstormSession()
	{
		DateCreated = new DateTime(2016, 7, 1),
		Id = 2,
		Name = "Test Two"
	});
	return sessions;
}
```

This has been fixed by increasing the starting offset by one.