### PR TITLE
escape asterisk to look properly on ms-docs

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/adding-model.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-model.md
@@ -62,7 +62,7 @@ Visual Studio creates:
 
 * An Entity Framework Core [database context class](xref:data/ef-mvc/intro#create-the-database-context) (*Data/MvcMovieContext.cs*)
 * A movies controller (*Controllers/MoviesController.cs*)
-* Razor view files for Create, Delete, Details, Edit and Index pages (*Views/Movies/\*.cshtml*)
+* Razor view files for Create, Delete, Details, Edit and Index pages (*Views/Movies/&ast;.cshtml*)
 
 The automatic creation of the database context and [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) (create, read, update, and delete) action methods and views is known as *scaffolding*. You'll soon have a fully functional web application that lets you manage a movie database.
 


### PR DESCRIPTION
The last *list item* above [Add EF tooling and perform initial migration](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model#add-ef-tooling-and-perform-initial-migration) is shown as:

* Razor view files for Create, Delete, Details, Edit and Index pages (Views/Movies/\.cshtml*)

which I believe should be rendered as ... (*Views/Movies/\*.cshtml*) based on its source `*Views/Movies/\*.cshtml*`

I think this is an issue with docfx! and I didn't test this change locally because I couldn't get docfx to work on Ubuntu!