### PR TITLE
Match the ASP.NET 4.x cookie name with the AuthenticationScheme created at first section

### DIFF
--- a/aspnetcore/security/data-protection/compatibility/cookie-sharing.md
+++ b/aspnetcore/security/data-protection/compatibility/cookie-sharing.md
@@ -92,7 +92,7 @@ To share authentication cookies between your ASP.NET 4.x applications and your A
     app.UseCookieAuthentication(new CookieAuthenticationOptions
        {
            AuthenticationType = DefaultAuthenticationTypes.ApplicationCookie,
-           CookieName = ".AspNetCore.Cookies",
+           CookieName = ".AspNetCore.ApplicationCookie",
            // CookiePath = "...", (if necessary)
            // ...
            TicketDataFormat = new AspNetTicketDataFormat(

--- a/aspnetcore/security/data-protection/compatibility/cookie-sharing.md
+++ b/aspnetcore/security/data-protection/compatibility/cookie-sharing.md
@@ -92,7 +92,8 @@ To share authentication cookies between your ASP.NET 4.x applications and your A
     app.UseCookieAuthentication(new CookieAuthenticationOptions
        {
            AuthenticationType = DefaultAuthenticationTypes.ApplicationCookie,
-           CookieName = ".AspNetCore.ApplicationCookie",
+           CookieName = ".AspNetCore.Cookies",
+           // CookieName = ".AspNetCore.ApplicationCookie", (if you're using identity)
            // CookiePath = "...", (if necessary)
            // ...
            TicketDataFormat = new AspNetTicketDataFormat(


### PR DESCRIPTION
Match the ASP.NET 4.x cookie name with the AuthenticationScheme created at first section