### PR TITLE
Remove redunant "dotnet restore"

### DIFF
--- a/aspnetcore/getting-started.md
+++ b/aspnetcore/getting-started.md
@@ -28,19 +28,13 @@ uid: getting-started
     - On macOS and Linux, open a terminal window. On Windows, open a command prompt.
     - Previous versions of .NET Core required a `t` parameter, that is   `dotnet new -t web`. If you get an error running `dotnet new web`, install the latest [.NET Core](https://microsoft.com/net/core).  `dotnet` (with no parameters)  will display the .NET Core version.
 
-3.  Restore the packages:
-
-    ```terminal
-    dotnet restore
-    ```
-
-4.  Run the app  (the `dotnet run` command will build the app when it's out of date):
+3.  Run the app  (the `dotnet run` command will build the app when it's out of date):
 
     ```terminal
     dotnet run
     ```
 
-5.  Browse to `http://localhost:5000`
+4.  Browse to `http://localhost:5000`
 
 ## Next steps
 


### PR DESCRIPTION
"dotnet new" automatically runs "dotnet restore" unless the "--no-restore" option is passed: 

```
> dotnet new web
Getting ready...
The template "ASP.NET Core Empty" was created successfully.
This template contains technologies from parties other than Microsoft, see https://aka.ms/template-3pn for details.

Processing post-creation actions...
Running 'dotnet restore' on C:\Temp\aspnetcoreapp\aspnetcoreapp.csproj...
  Restoring packages for C:\Temp\aspnetcoreapp\aspnetcoreapp.csproj...
  Generating MSBuild file C:\Temp\aspnetcoreapp\obj\aspnetcoreapp.csproj.nuget.g.props.
  Generating MSBuild file C:\Temp\aspnetcoreapp\obj\aspnetcoreapp.csproj.nuget.g.targets.
  Restore completed in 7.22 sec for C:\Temp\aspnetcoreapp\aspnetcoreapp.csproj.
```