### PR TITLE
Removing broken install link

### DIFF
--- a/aspnet/mvc/mvc3.md
+++ b/aspnet/mvc/mvc3.md
@@ -21,8 +21,7 @@ ASP.NET MVC 3
 > 
 > It installs side-by-side with ASP.NET MVC 2, so get started using it today!
 > 
-> [Install MVC3 Free](javascript:;)   
-> or download the [installer here](https://go.microsoft.com/fwlink/?LinkID=208140)
+> Download the [installer here](https://go.microsoft.com/fwlink/?LinkID=208140)
 
 
 ## Top Features


### PR DESCRIPTION
Install links broken for 3 MVC pages, because they had been JavaScript popups on the original www.asp.net website. We still do not have the ability to add these links, so removing them and leaving the standalone installer links.
