### PR TITLE
Fix a sample for OWIN Startup Class Detection

### DIFF
--- a/aspnet/aspnet/overview/owin-and-katana/owin-startup-class-detection/samples/sample6.xml
+++ b/aspnet/aspnet/overview/owin-and-katana/owin-startup-class-detection/samples/sample6.xml
@@ -1,1 +1,1 @@
-<add key="owin:AutomaticAppStartup " value="false" />
+<add key="owin:AutomaticAppStartup" value="false" />


### PR DESCRIPTION
The redundant space there makes the option inoperative.

I just spent some time to debug the issue in my application that was caused by the documentation copy-pasted into `Web.config`, and I'd like to help all the other folks around by fixing that typo.