### PR TITLE
Fix snippet content type issues

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/built-in/AnchorTagHelper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/AnchorTagHelper.md
@@ -34,13 +34,13 @@ The speaker controller below is used in samples in this document.
 
 `asp-controller` is used to associate which controller will be used to generate the URL. The controllers specified must exist in the current project. The following code lists all speakers: 
 
-```
-<a asp-controller="Speaker" asp-action="Index" >All Speakers</a>
+```cshtml
+<a asp-controller="Speaker" asp-action="Index">All Speakers</a>
 ```
 
-The generated URL will be:
+The generated markup will be:
 
-```
+```html
 <a href="/Speaker">All Speakers</a>
 ```
 
@@ -58,10 +58,10 @@ If the `asp-controller` is specified and `asp-action` is not, the default `asp-a
 `asp-action` is the name of the action method in the controller that will be included in the generated `href`. For example, the following code set the generated `href` to point to the speaker detail page:
 
 ```html
-<a asp-controller="Speaker" asp-action="Detail" >Speaker Detail</a>
+<a asp-controller="Speaker" asp-action="Detail">Speaker Detail</a>
 ```
 
-The generated URL will be:
+The generated markup will be:
 
 ```html
 <a href="/Speaker/Detail">Speaker Detail</a>
@@ -91,7 +91,7 @@ public IActionResult AnchorTagHelper(string id)
 }
 ```
 
-And have the default route template defined in your **Startup.cs** as follows:
+And have the default route template defined in your *Startup.cs* as follows:
 
 ```csharp
 app.UseMvc(routes =>
@@ -105,7 +105,7 @@ app.UseMvc(routes =>
 
 The **cshtml** file that contains the Anchor Tag Helper necessary to use the **speaker** model parameter passed in from the controller to the view is as follows:
 
-```html
+```cshtml
 @model SpeakerData
 <!DOCTYPE html>
 <html><body>
@@ -121,7 +121,7 @@ The generated HTML will then be as follows because **id** was found in the defau
 
 If the route prefix is not part of the routing template found, which is the case with the following **cshtml** file:
 
-```html
+```cshtml
 @model SpeakerData
 <!DOCTYPE html>
 <html><body>
@@ -154,7 +154,7 @@ If either `asp-controller` or `asp-action` are not specified, then the same defa
 
 As the example below shows, an inline dictionary is created and the data is passed to the razor view. As an alternative, the data could also be passed in with your model.
 
-```
+```cshtml
 @{
     var dict =
         new Dictionary<string, string>
@@ -167,11 +167,7 @@ As the example below shows, an inline dictionary is created and the data is pass
    asp-all-route-data="dict">SpeakerEvals</a>
 ```
 
-The code above generates the following HTML:
-
-```
-http://localhost/Speaker/EvaluationsCurrent?speakerId=11&currentYear=true
-```
+The code above generates the following URL: http://localhost/Speaker/EvaluationsCurrent?speakerId=11&currentYear=true
 
 When the link is clicked, the controller method `EvaluationsCurrent` is called. It is called because that controller has two string parameters that match what has been created from the `asp-all-route-data` dictionary.
 
@@ -183,16 +179,12 @@ If any keys in the dictionary match route parameters, those values will be subst
 
 `asp-fragment` defines a URL fragment to append to the URL. The Anchor Tag Helper will add the hash character (#). If you create a tag:
 
-```
+```cshtml
 <a asp-action="Evaluations" asp-controller="Speaker"  
    asp-fragment="SpeakerEvaluations">About Speaker Evals</a>
 ```
 
-The generated URL will be:
-
-```
-http://localhost/Speaker/Evaluations#SpeakerEvaluations
-```
+The generated URL will be: http://localhost/Speaker/Evaluations#SpeakerEvaluations
 
 Hash tags are useful when building client-side applications. They can be used for easy marking and searching in JavaScript, for example.
 
@@ -228,24 +220,24 @@ Hash tags are useful when building client-side applications. They can be used fo
         
 Specifying an area tag that is valid, such as ```area="Blogs"``` when referencing the ```AboutBlog.cshtml``` file will look like the following using the Anchor Tag Helper.
 
-```
+```cshtml
 <a asp-action="AboutBlog" asp-controller="Home" asp-area="Blogs">Blogs About</a>
 ```
 
 The generated HTML will include the areas segment and will be as follows:
 
-```
+```html
 <a href="/Blogs/Home/AboutBlog">Blogs About</a>
 ```
 
 > [!TIP]
-> For MVC areas to work in a web application, the route template must include a reference to the area if it exists. That template, which is the second parameter of the `routes.MapRoute` method call, will appear as: template: '"{area:exists}/{controller=Home}/{action=Index}"'
+> For MVC areas to work in a web application, the route template must include a reference to the area if it exists. That template, which is the second parameter of the `routes.MapRoute` method call, will appear as: `template: '"{area:exists}/{controller=Home}/{action=Index}"'`
 
 - - -
 
 ### asp-protocol
 
-The `asp-protocol` is for specifying a  protocol (such as `https`) in your URL. An example Anchor Tag Helper that includes the protocol will look as follows:
+The `asp-protocol` is for specifying a protocol (such as `https`) in your URL. An example Anchor Tag Helper that includes the protocol will look as follows:
 
 ```<a asp-protocol="https" asp-action="About" asp-controller="Home">About</a>```
 
@@ -260,7 +252,3 @@ The domain in the example is localhost, but the Anchor Tag Helper uses the websi
 ## Additional resources
 
 * [Areas](xref:mvc/controllers/areas)
-
-
-
-

--- a/aspnetcore/mvc/views/tag-helpers/built-in/CacheTagHelper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/CacheTagHelper.md
@@ -23,7 +23,7 @@ The Razor View Engine sets the default `expires-after` to twenty minutes.
 
 The following Razor markup caches the date/time:
 
-```html
+```cshtml
 <Cache>@DateTime.Now<Cache>
 ```
 
@@ -48,7 +48,7 @@ Determines whether the content enclosed by the Cache Tag Helper is cached. The d
 
 Example:
 
-```html
+```cshtml
 <Cache enabled="true">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </Cache>
@@ -67,7 +67,7 @@ Sets an absolute expiration date. The following example will cache the contents 
 
 Example:
 
-```html
+```cshtml
 <Cache expires-on="@new DateTime(2025,1,29,17,02,0)">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </Cache>
@@ -86,7 +86,7 @@ Sets the length of time from the first request time to cache the contents.
 
 Example:
 
-```html
+```cshtml
 <Cache expires-on="@TimeSpan.FromSeconds(120)">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </Cache>
@@ -105,7 +105,7 @@ Sets the time that a cache entry should be evicted if it has not been accessed.
 
 Example:
 
-```html
+```cshtml
 <Cache expires-sliding="@TimeSpan.FromSeconds(60)">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </Cache>
@@ -124,7 +124,7 @@ Accepts a single header value or a comma-separated list of header values that tr
 
 Example:
 
-```html
+```cshtml
 <Cache vary-by-header="User-Agent">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </Cache>
@@ -143,8 +143,7 @@ Accepts a single header value or a comma-separated list of header values that tr
 
 Example:
 
-```
-html
+```cshtml
 <Cache vary-by-query="Make,Model">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </Cache>
@@ -172,7 +171,7 @@ routes.MapRoute(
   
 *Index.cshtml*
 
-```html
+```cshtml
 <Cache vary-by-route="Make,Model">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </Cache>
@@ -191,7 +190,7 @@ Accepts a single header value or a comma-separated list of header values that tr
 
 Example:
 
-```html
+```cshtml
 <Cache vary-by-cookie=".AspNetCore.Identity.Application">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </Cache>
@@ -212,7 +211,7 @@ The following example looks at the current logged in user.
 
 Example:
 
-```html
+```cshtml
 <Cache vary-by-user="true">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </Cache>
@@ -250,7 +249,7 @@ public IActionResult Index(string myParam1,string myParam2,string myParam3)
 
 *Index.cshtml*
 
-```html
+```cshtml
 <Cache vary-by="@Model"">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </Cache>
@@ -271,7 +270,7 @@ Provides cache eviction guidance to the built-in cache provider. The web server 
 
 Example:
 
-```html
+```cshtml
 <Cache priority="High">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </Cache>
@@ -285,7 +284,3 @@ The Cache Tag Helper is dependent on the the [memory cache service](xref:perform
 
 * <xref:performance/caching/memory>
 * <xref:security/authentication/identity>
-
-
-
-

--- a/aspnetcore/mvc/views/tag-helpers/built-in/DistributedCacheTagHelper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/DistributedCacheTagHelper.md
@@ -17,7 +17,7 @@ uid: mvc/views/tag-helpers/builtin-th/DistributedCacheTagHelper
 By [Peter Kellner](http://peterkellner.net) 
 
 
-The  Distributed Cache Tag Helper provides the ability to dramatically improve the performance of your ASP.NET Core app by caching its content to a distributed cache source.
+The Distributed Cache Tag Helper provides the ability to dramatically improve the performance of your ASP.NET Core app by caching its content to a distributed cache source.
 
 The Distributed Cache Tag Helper inherits from the same base class as the Cache Tag Helper.  All attributes associated with the Cache Tag Helper will also work on the Distributed Tag Helper.
 
@@ -30,7 +30,7 @@ The Distributed Cache Tag Helper follows the **Explicit Dependencies Principle**
 
 ### enabled expires-on expires-after expires-sliding vary-by-header vary-by-query vary-by-route vary-by-cookie vary-by-user vary-by priority
 
-See Cache Tag Helper for definitions.  Distributed Cache Tag Helper inherits from the same class as Cache Tag Helper so all these attributes are common from Cache Tag Helper.
+See Cache Tag Helper for definitions. Distributed Cache Tag Helper inherits from the same class as Cache Tag Helper so all these attributes are common from Cache Tag Helper.
 
 - - -
 
@@ -44,7 +44,7 @@ The required `name` attribute is used as a key to that cache stored for each ins
 
 Usage Example:
 
-```html
+```cshtml
 <distributed-cache name="my-distributed-cache-unique-key-101">
     Time Inside Cache Tag Helper: @DateTime.Now
 </Cache>
@@ -69,7 +69,3 @@ There no tag attributes specifically associated with using any specific implemen
 * <xref:performance/caching/distributed>
 * <xref:performance/caching/memory>
 * <xref:security/authentication/identity>
-
-
-
-

--- a/aspnetcore/mvc/views/tag-helpers/built-in/EnvironmentTagHelper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/EnvironmentTagHelper.md
@@ -27,7 +27,7 @@ These value(s) are compared to the current value returned from the ASP.NET Core 
 
 An example of a valid `environment` tag helper is:
 
-```html
+```cshtml
 <environment names="Staging,Production">
   <strong>HostingEnvironment.EnvironmentName is Staging or Production</strong>
 </environment>
@@ -41,7 +41,7 @@ ASP.NET Core 2.x adds the `include` & `exclude` attributes. These attributes con
 
 The `include` property has a similar behavior of the `names` attribute in ASP.NET Core 1.0.
 
-```html
+```cshtml
 <environment include="Staging,Production">
   <strong>HostingEnvironment.EnvironmentName is Staging or Production</strong>
 </environment>
@@ -49,9 +49,9 @@ The `include` property has a similar behavior of the `names` attribute in ASP.NE
 
 ### exclude ASP.NET Core 2.0 and later
 
-In constract the `exclude` property let the `EnvironmentTagHelper` to render the enclosed content for all hosting environment names except the one(s) that you specified.
+In contrast, the `exclude` property lets the `EnvironmentTagHelper` render the enclosed content for all hosting environment names except the one(s) that you specified.
 
-```html
+```cshtml
 <environment exclude="Development">
   <strong>HostingEnvironment.EnvironmentName is Staging or Production</strong>
 </environment>
@@ -61,5 +61,3 @@ In constract the `exclude` property let the `EnvironmentTagHelper` to render the
 
 * <xref:fundamentals/environments>
 * <xref:fundamentals/dependency-injection#service-lifetimes-and-registration-options>
-
-

--- a/aspnetcore/mvc/views/tag-helpers/built-in/ImageTagHelper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/ImageTagHelper.md
@@ -18,7 +18,7 @@ By [Peter Kellner](http://peterkellner.net)
 
 The Image Tag Helper enhances the `img` (`<img>`) tag. It requires a `src` tag as well as the `boolean` attribute `asp-append-version`.
 
-If the image source (`src`) is a static file on the host web server, a unique cache busting string is appended as a query parameter to the image source. This insures that if the file on the host web server changes, a unique request URL is generated that includes the updated request parameter. The cache busting string is a unique value representing the hash of the static image file.
+If the image source (`src`) is a static file on the host web server, a unique cache busting string is appended as a query parameter to the image source. This ensures that if the file on the host web server changes, a unique request URL is generated that includes the updated request parameter. The cache busting string is a unique value representing the hash of the static image file.
 
 If the image source (`src`) isn't a static file (for example a remote URL or the file doesn't exist on the server), the `<img>` tag's `src` attribute is generated with no cache busting query string parameter.
 
@@ -31,7 +31,7 @@ When specified along with a `src` attribute, the Image Tag Helper is invoked.
 
 An example of a valid `img` tag helper is:
 
-```html
+```cshtml
 <img src="~/images/asplogo.png" 
     asp-append-version="true"  />
 ```
@@ -52,10 +52,8 @@ The value assigned to the parameter `v` is the hash value of the file on disk. I
 To activate the Image Tag Helper, the src attribute is required on the `<img>` element. 
 
 > [!NOTE]
->  The Image Tag Helper uses the `Cache` provider on the local web server to store the calculated `Sha512` of a given file. If the file is requested again the `Sha512` does not need to be recalculated.  The Cache is invalidated by a file watcher that is attached to the file when the file's `Sha512` is calculated.
+> The Image Tag Helper uses the `Cache` provider on the local web server to store the calculated `Sha512` of a given file. If the file is requested again the `Sha512` does not need to be recalculated. The Cache is invalidated by a file watcher that is attached to the file when the file's `Sha512` is calculated.
 
 ## Additional resources
 
 * <xref:performance/caching/memory>
-
-


### PR DESCRIPTION
The built-in Tag Helper docs were missing snippet content types, and in some cases the types were incorrect. This PR cleans up that issue and addresses a few other minor formatting issues.
