### PR TITLE
Add semicolon to nginx config line

### DIFF
--- a/aspnetcore/publishing/linuxproduction.md
+++ b/aspnetcore/publishing/linuxproduction.md
@@ -282,4 +282,4 @@ Edit the nginx.conf file.
 sudo nano /etc/nginx/nginx.conf
 ```
 
-Add the the line `add_header X-Content-Type-Options "nosniff"` and save the file, then restart Nginx.
+Add the the line `add_header X-Content-Type-Options "nosniff;"` and save the file, then restart Nginx.

--- a/aspnetcore/publishing/linuxproduction.md
+++ b/aspnetcore/publishing/linuxproduction.md
@@ -282,4 +282,4 @@ Edit the nginx.conf file.
 sudo nano /etc/nginx/nginx.conf
 ```
 
-Add the the line `add_header X-Content-Type-Options "nosniff;"` and save the file, then restart Nginx.
+Add the the line `add_header X-Content-Type-Options "nosniff";` and save the file, then restart Nginx.


### PR DESCRIPTION
There was a semicolon missing in a line for nginx:
should be: `add_header X-Content-Type-Options nosniff;`