### PR TITLE
Remove duplicated instances of 'the'

### DIFF
--- a/aspnetcore/migration/webapi.md
+++ b/aspnetcore/migration/webapi.md
@@ -57,7 +57,7 @@ Next, choose the Web API project template. We will migrate the *ProductsApp* con
 
 Delete the `Project_Readme.html` file from the new project. Your solution should now look like this:
 
-![Application solution open in Solution Explorer showing files and folders of the the ProductsApp and ProductsCore projects](webapi/_static/webapimigration-solution.png)
+![Application solution open in Solution Explorer showing files and folders of the ProductsApp and ProductsCore projects](webapi/_static/webapimigration-solution.png)
 
 ## Migrate Configuration
 

--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -158,7 +158,7 @@ The `DisableFormValueModelBinding` attribute, shown below, is used to disable mo
 
 [!code-csharp[Main](file-uploads/sample/FileUploadSample/Filters/DisableFormValueModelBindingAttribute.cs?name=snippet1)]
 
-Since model binding is disabled, the `Upload` action method doesn't accept parameters. It works directly with the `Request` property of `ControllerBase`. A `MultipartReader` is used to read each section. The file is saved with a GUID filename and the the key/value data is stored in a `KeyValueAccumulator`. Once all sections have been read, the contents of the `KeyValueAccumulator` are used to bind the form data to a model type.
+Since model binding is disabled, the `Upload` action method doesn't accept parameters. It works directly with the `Request` property of `ControllerBase`. A `MultipartReader` is used to read each section. The file is saved with a GUID filename and the key/value data is stored in a `KeyValueAccumulator`. Once all sections have been read, the contents of the `KeyValueAccumulator` are used to bind the form data to a model type.
 
 The complete `Upload` method is shown below:
 

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -258,7 +258,7 @@ The app has the following file/folder structure
     * *Edit.cshtml*
     * *Index.cshtml*
 
-The *Pages/Customers/Create.cshtml* and *Pages/Customers/Edit.cshtml* pages redirect to *Pages/Index.cshtml* after success. The string `/Index` is part of the URI to access the the preceding page. The string `/Index` can be used to generate URIs to the *Pages/Index.cshtml* page. For example:
+The *Pages/Customers/Create.cshtml* and *Pages/Customers/Edit.cshtml* pages redirect to *Pages/Index.cshtml* after success. The string `/Index` is part of the URI to access the preceding page. The string `/Index` can be used to generate URIs to the *Pages/Index.cshtml* page. For example:
 
 
 * `Url.Page("/Index", ...)`

--- a/aspnetcore/mvc/views/tag-helpers/built-in/CacheTagHelper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/CacheTagHelper.md
@@ -278,7 +278,7 @@ Example:
 
 The `priority` attribute does not guarantee a specific level of cache retention. `CacheItemPriority` is only a suggestion. Setting this attribute to `NeverRemove` does not guarantee that the cache will always be retained. See [Additional Resources](#additional-resources) for more information.
 
-The Cache Tag Helper is dependent on the the [memory cache service](xref:performance/caching/memory). The Cache Tag Helper adds the service if it has not been added.
+The Cache Tag Helper is dependent on the [memory cache service](xref:performance/caching/memory). The Cache Tag Helper adds the service if it has not been added.
 
 ## Additional resources
 

--- a/aspnetcore/publishing/apache-proxy.md
+++ b/aspnetcore/publishing/apache-proxy.md
@@ -293,7 +293,7 @@ Edit the httpd.conf file.
     sudo nano /etc/httpd/conf/httpd.conf
 ```
 
-Add the the line `Header append X-FRAME-OPTIONS "SAMEORIGIN"` and save the file, then restart Apache.
+Add the line `Header append X-FRAME-OPTIONS "SAMEORIGIN"` and save the file, then restart Apache.
 
 #### MIME-type sniffing
 
@@ -305,7 +305,7 @@ Edit the httpd.conf file.
     sudo nano /etc/httpd/conf/httpd.conf
 ```
 
-Add the the line `Header set X-Content-Type-Options "nosniff"` and save the file, then restart Apache.
+Add the line `Header set X-Content-Type-Options "nosniff"` and save the file, then restart Apache.
 
 ### Load Balancing 
 


### PR DESCRIPTION
Remove doubled-up occurrences of "the" which I stumbled upon while writing another doc.