### PR TITLE
Fix DELETE operation in TodoController

### DIFF
--- a/aspnetcore/tutorials/first-web-api/sample/TodoApi/Controllers/TodoController.cs
+++ b/aspnetcore/tutorials/first-web-api/sample/TodoApi/Controllers/TodoController.cs
@@ -85,7 +85,7 @@ namespace TodoApi.Controllers
         [HttpDelete("{id}")]
         public IActionResult Delete(long id)
         {
-            var todo = _context.TodoItems.First(t => t.Id == id);
+            var todo = _context.TodoItems.FirstOrDefault(t => t.Id == id);
             if (todo == null)
             {
                 return NotFound();


### PR DESCRIPTION
By using First(), there's the opportunity for an uncaught exception when the endpoint is called with an ID not present in the database.
