### PR TITLE
use correct github url in link to project source code

### DIFF
--- a/aspnetcore/data/ef-mvc/intro/samples/cu-final/Views/Home/Index.cshtml
+++ b/aspnetcore/data/ef-mvc/intro/samples/cu-final/Views/Home/Index.cshtml
@@ -21,6 +21,6 @@
     <div class="col-md-4">
         <h2>Download it</h2>
         <p>You can download the completed project from GitHub.</p>
-        <p><a class="btn btn-default" href="https://github.com/aspnet/Docs/tree/master/aspnet/data/ef-mvc/intro/samples/cu-final">See project source code &raquo;</a></p>
+        <p><a class="btn btn-default" href="https://github.com/aspnet/Docs/tree/master/aspnetcore/data/ef-mvc/intro/samples/cu-final">See project source code &raquo;</a></p>
     </div>
 </div>

--- a/aspnetcore/data/ef-mvc/intro/samples/cu/Views/Home/Index.cshtml
+++ b/aspnetcore/data/ef-mvc/intro/samples/cu/Views/Home/Index.cshtml
@@ -22,6 +22,6 @@
     <div class="col-md-4">
         <h2>Download it</h2>
         <p>You can download the completed project from GitHub.</p>
-        <p><a class="btn btn-default" href="https://github.com/aspnet/Docs/tree/master/aspnet/data/ef-mvc/intro/samples/cu-final">See project source code &raquo;</a></p>
+        <p><a class="btn btn-default" href="https://github.com/aspnet/Docs/tree/master/aspnetcore/data/ef-mvc/intro/samples/cu-final">See project source code &raquo;</a></p>
     </div>
 </div>


### PR DESCRIPTION
The final source code and a snippet referenced in "EF Core with ASP.NET Core MVC" tutorial needs correct url,
currently:  "https://github.com/aspnet/Docs/tree/master/aspnet/data/ef-mvc/intro/samples/cu-final"
should be:
"https://github.com/aspnet/Docs/tree/master/aspnetcore/data/ef-mvc/intro/samples/cu-final"
