### PR TITLE
Revert "Fix QRCode generation data source"

### DIFF
--- a/aspnetcore/security/authentication/identity-enable-qrcodes.md
+++ b/aspnetcore/security/authentication/identity-enable-qrcodes.md
@@ -44,7 +44,7 @@ These instructions use *qrcode.js* from the https://davidshimjs.github.io/qrcode
     <script type="text/javascript">
         new QRCode(document.getElementById("qrCode"),
             {
-                text: document.getElementById('qrCodeData').dataset.url,
+                text: "@Html.Raw(Model.AuthenticatorUri)",
                 width: 150,
                 height: 150
             });
@@ -79,4 +79,9 @@ The second parameter in the call to `string.Format` is your site name, taken fro
 
 You can replace the QR Code library with your preferred library. The HTML contains a `qrCode` element into which you can place a QR Code by whatever mechanism your library provides.
 
-The correctly formatted URL for the QR Code is available in the `.dataset.url` property of the `qrCodeData` element, which can be accessed in JavaScript using `document.getElementById('qrCodeData').dataset.url`. 
+The correctly formatted URL for the QR Code is available in the:
+
+* `AuthenticatorUri` property of the model.
+* `data-url` property in the `qrCodeData` element. 
+
+Use `@Html.Raw` to access the model property in a view (otherwise the ampersands in the url will be double encoded and the label parameter of the QR Code will be ignored).


### PR DESCRIPTION
This reverts commit adb98d23559b19043b308b74208ca9c17bd36db6.

@blowdart was right all along

I added to the wrong page but that page's having model the `AuthenicatorUriFormat` reinforced it was the correct page https://github.com/dotnet/templating/pull/1214