### PR TITLE
Fix version number and region issue in 2.0 migration doc

### DIFF
--- a/aspnetcore/migration/1x-to-2x/index.md
+++ b/aspnetcore/migration/1x-to-2x/index.md
@@ -87,7 +87,7 @@ Rename both the node and variable to `AssetTargetFallback`:
 ## Update Main method in Program.cs
 In 1.x projects, the `Main` method of *Program.cs* looked like this:
 
-[!code-csharp[Main](../1x-to-2x/samples/AspNetCoreDotNetCore1.1App/AspNetCoreDotNetCore1.1App/Program.cs?highlight=9-20)]
+[!code-csharp[Main](../1x-to-2x/samples/AspNetCoreDotNetCore1.1App/AspNetCoreDotNetCore1.1App/Program.cs?name=snippet_ProgramCs&highlight=8-19)]
 
 In 2.0 projects, the `Main` method of *Program.cs* has been simplified:
 

--- a/aspnetcore/migration/1x-to-2x/samples/AspNetCoreDotNetCore1.1App/AspNetCoreDotNetCore1.1App/Program.cs
+++ b/aspnetcore/migration/1x-to-2x/samples/AspNetCoreDotNetCore1.1App/AspNetCoreDotNetCore1.1App/Program.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿#region snippet_ProgramCs
+using System.IO;
 using Microsoft.AspNetCore.Hosting;
 
 namespace AspNetCoreDotNetCore1._1App
@@ -21,3 +22,4 @@ namespace AspNetCoreDotNetCore1._1App
         #endregion
     }
 }
+#endregion

--- a/aspnetcore/migration/1x-to-2x/samples/AspNetCoreDotNetCore2.0App/global.json
+++ b/aspnetcore/migration/1x-to-2x/samples/AspNetCoreDotNetCore2.0App/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "2.0.0-preview3-006912"
+    "version": "2.0.0"
   }
 }


### PR DESCRIPTION
- Change a `global.json` sdk version number to 2.0.0
- Remove the region displayed in the `Program.cs` code snippet
