### PR TITLE
Fix link by fixing anchor point

### DIFF
--- a/aspnetcore/tutorials/razor-pages/new-field.md
+++ b/aspnetcore/tutorials/razor-pages/new-field.md
@@ -67,7 +67,7 @@ See the [completed SeedData.cs file](https://github.com/aspnet/Docs/blob/master/
 
 Build the solution.
 
-<a name="pmc"></a>
+<a id="pmc"></a>
 
 From the **Tools** menu, select **NuGet Package Manager > Package Manager Console**.
 In the PMC, enter the following commands:


### PR DESCRIPTION
This might not have been an issue for the repo builds, but I noticed when I was building the docs locally that it was complaining about a bad link (bad anchor). Turns out that just switching from the `name` attribute to `id` on the anchor does the trick.