### PR TITLE
Escape <

### DIFF
--- a/aspnetcore/data/ef-mvc/migrations.md
+++ b/aspnetcore/data/ef-mvc/migrations.md
@@ -105,7 +105,7 @@ Migrations also creates a *snapshot* of the current database schema in *Migratio
 
 Because the current database schema is represented in code, EF Core doesn't have to interact with the database to create migrations. When you add a migration, EF determines what changed by comparing the data model to the snapshot file. EF interacts with the database only when it has to update the database. 
 
-The snapshot file has to be kept in sync with the migrations that create it, so you can't remove a migration just by deleting the file named  *<timestamp>_<migrationname>.cs*. If you delete that file, the remaining migrations will be out of sync with the database snapshot file. To delete the last migration that you added, use the [dotnet ef migrations remove](https://docs.microsoft.com/ef/core/miscellaneous/cli/dotnet#dotnet-ef-migrations-remove) command.
+The snapshot file has to be kept in sync with the migrations that create it, so you can't remove a migration just by deleting the file named  *\<timestamp>_\<migrationname>.cs*. If you delete that file, the remaining migrations will be out of sync with the database snapshot file. To delete the last migration that you added, use the [dotnet ef migrations remove](https://docs.microsoft.com/ef/core/miscellaneous/cli/dotnet#dotnet-ef-migrations-remove) command.
 
 ## Apply the migration to the database
 


### PR DESCRIPTION
Above https://docs.microsoft.com/en-us/aspnet/core/data/ef-mvc/migrations#apply-the-migration-to-the-database, there's **_.cs** which isn't rendered appropriately! I think this PR will fix it but I don't understand why we have to escape `<` in markdown! I couldn't find info about it in docfx docs...

There is other place precedes `<` with  `\` and it looks fine in GitHub preview page so I think this fix is fine (or I should use HTML escape `&lt;`?)