### PR TITLE
Escape another <

### DIFF
--- a/aspnetcore/data/ef-mvc/complex-data-model.md
+++ b/aspnetcore/data/ef-mvc/complex-data-model.md
@@ -89,7 +89,7 @@ dotnet ef migrations add MaxLengthOnNames
 dotnet ef database update
 ```
 
-The `migrations add` command warns that data loss may occur, because the change makes the maximum length shorter for two columns.  Migrations creates a file named *<timeStamp>_MaxLengthOnNames.cs*. This file contains code in the `Up` method that will update the database to match the current data model. The `database update` command ran that code.
+The `migrations add` command warns that data loss may occur, because the change makes the maximum length shorter for two columns.  Migrations creates a file named *\<timeStamp>_MaxLengthOnNames.cs*. This file contains code in the `Up` method that will update the database to match the current data model. The `database update` command ran that code.
 
 The timestamp prefixed to the migrations file name is used by Entity Framework to order the migrations. You can create multiple migrations before running the update-database command, and then all of the migrations are applied in the order in which they were created.
 


### PR DESCRIPTION
A separate semi-related issue:

There is a sentence that uses `{` insted of `<` in this file: (inside [this section](https://docs.microsoft.com/en-us/aspnet/core/data/ef-mvc/complex-data-model#add-a-migration))
> Open the {timestamp}_ComplexDataModel.cs file.

Should it be changed to use <...>_... or left as is?