### PR TITLE
Added generic param on AddEntityFrameworkStores

### DIFF
--- a/aspnetcore/migration/1x-to-2x/identity-2x.md
+++ b/aspnetcore/migration/1x-to-2x/identity-2x.md
@@ -50,7 +50,7 @@ The following 2.0 example configures Facebook authentication with Identity in *S
 public void ConfigureServices(IServiceCollection services)
 {
     services.AddIdentity<ApplicationUser, IdentityRole>()
-            .AddEntityFrameworkStores();
+            .AddEntityFrameworkStores<ApplicationDbContext>();
 
     // If you want to tweak Identity cookies, they're no longer part of IdentityOptions.
     services.ConfigureApplicationCookie(options => options.LoginPath = "/Account/LogIn");


### PR DESCRIPTION
The 2.0 version of AddEntityFrameworkStores still needs the DbContext type
