### PR TITLE
Delete web.config from ResponseFormattingSample

### DIFF
--- a/aspnetcore/mvc/models/formatting/sample/src/ResponseFormattingSample/wwwroot/web.config
+++ b/aspnetcore/mvc/models/formatting/sample/src/ResponseFormattingSample/wwwroot/web.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <system.webServer>
-    <handlers>
-      <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
-    </handlers>
-    <httpPlatform processPath="%DNX_PATH%" arguments="%DNX_ARGS%" forwardWindowsAuthToken="false" startupTimeLimit="3600" />
-  </system.webServer>
-</configuration>


### PR DESCRIPTION
Because *wwwroot* is in the *.gitignore*, this change to the sample wasn't picked up on the PR for the sample update.