### PR TITLE
Remove OutputType from project files

### DIFF
--- a/aspnetcore/fundamentals/file-providers/sample/src/WatchConsole/WatchConsole.csproj
+++ b/aspnetcore/fundamentals/file-providers/sample/src/WatchConsole/WatchConsole.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aspnetcore/fundamentals/url-rewriting/samples/1.x/URLRewritingSample.csproj
+++ b/aspnetcore/fundamentals/url-rewriting/samples/1.x/URLRewritingSample.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net451;netcoreapp1.1</TargetFrameworks>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aspnetcore/fundamentals/url-rewriting/samples/2.x/UrlRewritingSample.csproj
+++ b/aspnetcore/fundamentals/url-rewriting/samples/2.x/UrlRewritingSample.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aspnetcore/mvc/models/formatting/sample/ResponseFormattingSample.csproj
+++ b/aspnetcore/mvc/models/formatting/sample/ResponseFormattingSample.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aspnetcore/mvc/models/validation/sample/ValidationSample.csproj
+++ b/aspnetcore/mvc/models/validation/sample/ValidationSample.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aspnetcore/performance/caching/middleware/samples/1.x/ResponseCachingSample.csproj
+++ b/aspnetcore/performance/caching/middleware/samples/1.x/ResponseCachingSample.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net451;netcoreapp1.1</TargetFrameworks>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aspnetcore/performance/caching/middleware/samples/2.x/ResponseCachingSample.csproj
+++ b/aspnetcore/performance/caching/middleware/samples/2.x/ResponseCachingSample.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aspnetcore/performance/response-compression/samples/1.x/ResponseCompressionSample.csproj
+++ b/aspnetcore/performance/response-compression/samples/1.x/ResponseCompressionSample.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net451;netcoreapp1.1</TargetFrameworks>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aspnetcore/performance/response-compression/samples/2.x/ResponseCompressionSample.csproj
+++ b/aspnetcore/performance/response-compression/samples/2.x/ResponseCompressionSample.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Removing \<OutputType> from updated projects, as it's specified by `Sdk.Web`, and we're (generally) not showing defaults in the files.

There's a chance that we'll need to make an additional  update for *wwwroot* to match the templates. I'm checking on that now and will provide a new PR if an additional update is needed on a couple that have a *wwwroot* folder.