### PR TITLE
Remove extra instruction in ef-mvc tutorial

### DIFF
--- a/aspnetcore/data/ef-mvc/concurrency.md
+++ b/aspnetcore/data/ef-mvc/concurrency.md
@@ -172,8 +172,6 @@ The `ModelState.Remove` statement is required because `ModelState` has the old `
 
 In *Views/Departments/Edit.cshtml*, make the following changes:
 
-* Remove the `<div>` element that was scaffolded for the `RowVersion` field.
-
 * Add a hidden field to save the `RowVersion` property value, immediately following the hidden field for the `DepartmentID` property.
 
 * Add a "Select Administrator" option to the drop-down list.


### PR DESCRIPTION
I used `dotnet aspnet-codegenerator controller -name DepartmentsController -m ContosoUniversity.Models.Department -udl -scripts -dc ContosoUniversity.Data.SchoolContext -outDir Controllers` on Ubuntu 17 and the scaffolded *Edit* view doesn't have this div!

Maybe older version of `dotnet aspnet-codegenerator` adds this `div` or when using VS on Windows?! I'm not sure...

Edit: I'm using SQL Server on Ubuntu and the tutorial uses LocalDB if this matters to `aspnet-codegenerator`!