### PR TITLE
Add a missing closing tag `<\a>`

### DIFF
--- a/aspnetcore/data/ef-mvc/advanced.md
+++ b/aspnetcore/data/ef-mvc/advanced.md
@@ -175,7 +175,7 @@ Although the source code is open, Entity Framework Core is fully supported as a 
 
 To reverse engineer a data model including entity classes from an existing database, use the [scaffold-dbcontext](https://docs.microsoft.com/ef/core/miscellaneous/cli/powershell#scaffold-dbcontext) command. See the [getting-started tutorial](https://docs.microsoft.com/ef/core/get-started/aspnetcore/existing-db).
 
-<a id="dynamic-linq">
+<a id="dynamic-linq"></a>
 ## Use dynamic LINQ to simplify sort selection code
 
 The [third tutorial in this series](sort-filter-page.md) shows how to write LINQ code by hard-coding column names in a `switch` statement. With two columns to choose from, this works fine, but if you have many columns the code could get verbose. To solve that problem, you can use the `EF.Property` method to specify the name of the property as a string. To try out this approach, replace the `Index` method in the `StudentsController` with the following code.


### PR DESCRIPTION
I believe I saw some code doing the same! I'm not sure about it and couldn't find info about this in DocFX docs. Is there any place to read about this? because the `id="dynamic-linq"` is changed to `id="use-dynamic-linq-to-simplify-sort-selection-code"` when I use docfx to preview changes locally! 