### PR TITLE
correct small typo in logging.md  for How filtering rules are applied" table

### DIFF
--- a/aspnetcore/fundamentals/logging.md
+++ b/aspnetcore/fundamentals/logging.md
@@ -301,7 +301,7 @@ Number|Provider|Categories that begin with|Minimum log level|
 3|Console|Microsoft.AspNetCore.Mvc.Razor.Razor|Debug|
 4|Console|Microsoft.AspNetCore.Mvc.Razor|Error|
 5|Console|All categories|Information|
-6|All providers|All categories|Warning
+6|All providers|All categories|Debug
 7|All providers|System|Debug
 8|Debug|Microsoft|Trace
 


### PR DESCRIPTION
as per configuration JSON example in  "Create filter rules in configuration" section, "How filtering rules are applied" table rule # 6 should  at Debug log level instead of Warring log level.

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.

* Suggest reviewers if you know who should review the PR, using the GitHub **Reviewers** UI.
