### PR TITLE
Call `UseMvc()` instead of `UseMvcWithDefaultRoute()`

### DIFF
--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/sample/TodoApi/Startup2.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/sample/TodoApi/Startup2.cs
@@ -36,7 +36,7 @@ namespace TodoApi
                 c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
             });
 
-            app.UseMvcWithDefaultRoute();
+            app.UseMvc();
         }
         #endregion
     }


### PR DESCRIPTION
app.UseMvcWithDefaultRoute() neither used in the previous Todo Api nor in the swagger tutorial