### PR TITLE
Upgrade NuGet packages to 2.0 RTM

### DIFF
--- a/aspnetcore/security/authentication/accconfirm/sample/WebPW/WebPW.csproj
+++ b/aspnetcore/security/authentication/accconfirm/sample/WebPW/WebPW.csproj
@@ -5,18 +5,17 @@
     <UserSecretsId>aspnet-WebPW-01472414-A8F1-4770-9C75-B4D0CBEADF12</UserSecretsId>
   </PropertyGroup>
 
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-rtm-26380" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0-rtm-26380" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0-rtm-26380" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="SendGrid" Version="9.5.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.0-rtm-26380" />
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0-rtm-26380" />
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0-rtm-26380" />
+    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.0" />
+    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/security/authentication/accconfirm/sample/WebPW/WebPW.csproj
+++ b/aspnetcore/security/authentication/accconfirm/sample/WebPW/WebPW.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="SendGrid" Version="9.5.1" />
   </ItemGroup>


### PR DESCRIPTION
Resolve project warnings by upgrading the *.csproj* package references to 2.0.0.