### PR TITLE
Remove Visual Studio as a prerequisite

### DIFF
--- a/aspnetcore/migration/proper-to-2x/index.md
+++ b/aspnetcore/migration/proper-to-2x/index.md
@@ -22,7 +22,6 @@ This article serves as a reference guide for migrating ASP.NET applications to A
 ## Prerequisites
 
 * [.NET Core 2.0.0 SDK](https://dot.net/core) or later.
-* [Visual Studio 2017](https://docs.microsoft.com/visualstudio/install/install-visual-studio) version 15.3 or later with the **ASP.NET and web development** workload.
 
 ## Target Frameworks
 ASP.NET Core 2.0 projects offer developers the flexibility of targeting .NET Core, .NET Framework, or both. See [Choosing between .NET Core and .NET Framework for server apps](https://docs.microsoft.com/dotnet/standard/choosing-core-framework-server) to determine which target framework is most appropriate.


### PR DESCRIPTION
With .NET Core now being cross-platform and IDE agnostic, listing Visual Studio 2017 as a prerequisite (thus *required*) is misleading and confusing to newcomers to the platform using one of the many alternative editors.

As a .NET developer using a Macbook with VS Code, Visual Studio for Mac and/or JetBrains' Rider, this prerequisite implies that I'm unable to upgrade to .NET Core 2.0 because I don't have Visual Studio 2017.

An alternative approach could be to reword it to something similar to 

> Visual Studio 2017, Visual Studio for Mac, Visual Studio Code or an alternative .NET Core compatible IDE

If this is preferred then let me know and I'll update my PR.

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.

* Suggest reviewers if you know who should review the PR, using the GitHub **Reviewers** UI.
