### PR TITLE
Update SampleAsyncActionFilter.cs

### DIFF
--- a/aspnetcore/mvc/controllers/filters/sample/src/FiltersSample/Filters/SampleAsyncActionFilter.cs
+++ b/aspnetcore/mvc/controllers/filters/sample/src/FiltersSample/Filters/SampleAsyncActionFilter.cs
@@ -10,8 +10,8 @@ namespace FiltersSample.Filters
             ActionExecutionDelegate next)
         {
             // do something before the action executes
-            await next();
-            // do something after the action executes
+            var resultContext = await next();
+            // do something after the action executes; resultContext.Result will be set
         }
     }
 }


### PR DESCRIPTION
The existing code sample implies that the user can access the result of the action method in `context.Result`, but that is not the case. User needs to capture the result of the `next` delegate in order to access this info.