### PR TITLE
Update toc.md

### DIFF
--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -217,7 +217,7 @@
 #### [Integrating Azure AD Into an ASP.NET Core Web App](https://azure.microsoft.com/documentation/samples/active-directory-dotnet-webapp-openidconnect-aspnetcore/)
 #### [Calling a ASP.NET Core Web API From a WPF Application Using Azure AD](https://azure.microsoft.com/documentation/samples/active-directory-dotnet-native-aspnetcore/)
 #### [Calling a Web API in an ASP.NET Core Web Application Using Azure AD](https://azure.microsoft.com/documentation/samples/active-directory-dotnet-webapp-webapi-openidconnect-aspnetcore/)
-### [Securing ASP.NET Core apps with IdentityServer4](https://identityserver4.readthedocs.io/release/)
+### [Securing ASP.NET Core apps with IdentityServer4](https://identityserver4.readthedocs.io/)
 ## [Authorization](xref:security/authorization/index)
 ### [Introduction](xref:security/authorization/introduction)
 ### [Create an app with user data protected by authorization](xref:security/authorization/secure-data)


### PR DESCRIPTION
The link to IdentityServer4 is now https://identityserver4.readthedocs.io/en/release/, but it would be better to direct to the root path so if languages are added, they will automatically get redirected to.