### PR TITLE
Update apache-proxy.md

### DIFF
--- a/aspnetcore/publishing/apache-proxy.md
+++ b/aspnetcore/publishing/apache-proxy.md
@@ -131,7 +131,8 @@ An example service file for our application.
     WorkingDirectory=/var/aspnetcore/hellomvc
     ExecStart=/usr/local/bin/dotnet /var/aspnetcore/hellomvc/hellomvc.dll
     Restart=always
-    RestartSec=10                                          # Restart service after 10 seconds if dotnet service crashes
+    # Restart service after 10 seconds if dotnet service crashes
+    RestartSec=10
     SyslogIdentifier=dotnet-example
     User=apache
     Environment=ASPNETCORE_ENVIRONMENT=Production 


### PR DESCRIPTION
The example systemd unit file causes an error if copied directly and used as is (which a lot of first time users likely will).

Although the example service will run it will cause a systemd error because comments in systemd unit files need to be on a newline. In this case I've moved the comment to the line above. Now when you do `systemctl status kestrel-hellomvc.service` you won't see an error in the output.
