### PR TITLE
Remove unnecessary section anchor from Configuration doc

### DIFF
--- a/aspnetcore/fundamentals/configuration.md
+++ b/aspnetcore/fundamentals/configuration.md
@@ -12,8 +12,6 @@ ms.technology: aspnet
 ms.prod: asp.net-core
 uid: fundamentals/configuration
 ---
-<a name=fundamentals-configuration></a>
-
 # Configuration in ASP.NET Core
 
 [Rick Anderson](https://twitter.com/RickAndMSFT), [Mark Michaelis](http://intellitect.com/author/mark-michaelis/), [Steve Smith](https://ardalis.com/), and [Daniel Roth](https://github.com/danroth27)

--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -112,7 +112,7 @@ The preceding line prevents registered users from being logged in until their em
 
 In this tutorial, SendGrid is used to send email. You need a SendGrid account and key to send email. You can use other email providers. ASP.NET Core 2.x includes `System.Net.Mail`, which allows you to send email from your app. We recommend you use SendGrid or another email service to send email.
 
-The [Options pattern](xref:fundamentals/configuration#options-config-objects) is used to access the user account and key settings. For more information, see [configuration](xref:fundamentals/configuration#fundamentals-configuration).
+The [Options pattern](xref:fundamentals/configuration#options-config-objects) is used to access the user account and key settings. For more information, see [configuration](xref:fundamentals/configuration).
 
 Create a class to fetch the secure email key. For this sample, the `AuthMessageSenderOptions` class is created in the *Services/AuthMessageSenderOptions.cs* file.
 


### PR DESCRIPTION
Since the anchor appears at the top of the doc, it serves no purpose and can safely be removed.