### PR TITLE
CommandLine config provider overhaul

### DIFF
--- a/aspnetcore/fundamentals/configuration.md
+++ b/aspnetcore/fundamentals/configuration.md
@@ -290,55 +290,187 @@ key3=value_from_json_3
 
 ## CommandLine configuration provider
 
-The following sample enables the CommandLine configuration provider last:
+The [CommandLine configuration provider](/aspnet/core/api/microsoft.extensions.configuration.commandline.commandlineconfigurationprovider) receives command-line argument key-value pairs for configuration at runtime.
 
-[!code-csharp[Main](configuration/sample/CommandLine/Program.cs)]
+[View or download the CommandLine configuration sample](https://github.com/aspnet/docs/tree/master/aspnetcore/fundamentals/configuration/sample/CommandLine)
+
+### Setting up the provider
+
+# [Basic Configuration](#tab/basicconfiguration)
+
+To activate command-line configuration, call the `AddCommandLine` extension method on an instance of [ConfigurationBuilder](/api/microsoft.extensions.configuration.configurationbuilder):
+
+[!code-csharp[Main](configuration/sample_snapshot/CommandLine/Program.cs?highlight=18,21)]
+
+Running the code, the following output is displayed:
+
+```console
+MachineName: MairaPC
+Left: 1980
+```
+
+Passing argument key-value pairs on the command line changes the values of `Profile:MachineName` and `App:MainWindow:Left`:
+
+```console
+dotnet run Profile:MachineName=BartPC App:MainWindow:Left=1979
+```
+
+The console window displays:
+
+```console
+MachineName: BartPC
+Left: 1979
+```
+
+To override configuration provided by other configuration providers with command-line configuration, call `AddCommandLine` last on `ConfigurationBuilder`:
+
+[!code-csharp[Main](configuration/sample_snapshot/CommandLine/Program2.cs?range=11-16&highlight=1,5)]
+
+# [ASP.NET Core 2.x](#tab/aspnetcore2x)
+
+Typical ASP.NET Core 2.x apps use the static convenience method `CreateDefaultBuilder` to build the host:
+
+[!code-csharp[Main](configuration/sample_snapshot/Program.cs?highlight=12)]
+
+`CreateDefaultBuilder` loads optional configuration from *appsettings.json*, *appsettings.{Environment}.json*, [user secrets](xref:security/app-secrets) (in the `Development` environment), environment variables, and command-line arguments. The CommandLine configuration provider is called last. Calling the provider last allows the command-line arguments passed at runtime to override configuration set by the other configuration providers called earlier.
+
+Note that for *appsettings* files that `reloadOnChange` is enabled. Command-line arguments are overridden if a matching configuration value in an *appsettings* file is changed after the app starts.
+
+> [!NOTE]
+> As an alternative to using the `CreateDefaultBuilder` method, creating a host using [WebHostBuilder](/dotnet/api/microsoft.aspnetcore.hosting.webhostbuilder) and manually building configuration with [ConfigurationBuilder](/api/microsoft.extensions.configuration.configurationbuilder) is supported in ASP.NET Core 2.x. See the ASP.NET Core 1.x tab for more information.
+
+# [ASP.NET Core 1.x](#tab/aspnetcore1x)
+
+Create a [ConfigurationBuilder](/api/microsoft.extensions.configuration.configurationbuilder) and call the `AddCommandLine` method to use the CommandLine configuration provider. Calling the provider last allows the command-line arguments passed at runtime to override configuration set by the other configuration providers called earlier. Apply the configuration to [WebHostBuilder](/dotnet/api/microsoft.aspnetcore.hosting.webhostbuilder) with the `UseConfiguration` method:
+
+[!code-csharp[Main](configuration/sample_snapshot/CommandLine/Program2.cs?highlight=11,15,19)]
+
+---
+
+### Arguments
+
+Arguments passed on the command line must conform to one of two formats:
+
+| Argument format                                                     | Example        |
+| ------------------------------------------------------------------- | :------------: |
+| Single argument: a key-value pair separated by an equals sign (`=`) | `key1=value`   |
+| Sequence of two arguments: a key-value pair separated by a space    | `/key1 value1` |
+
+**Single argument**
+
+The value must follow an equals sign (`=`). The value can be null (for example, `mykey=`).
+
+The key may have a prefix:
+
+| Key prefix               | Example         |
+| ------------------------ | :-------------: |
+| No prefix                | `key1=value1`   |
+| Single dash (`-`)&#8224; | `-key2=value2`  |
+| Two dashes (`--`)        | `--key3=value3` |
+| Forward slash (`/`)      | `/key4=value4`  |
+
+&#8224;A key with a single dash prefix (`-`) must be provided in [switch mappings](#switch-mappings), described below.
+
+Example command:
+
+```console
+dotnet run key1=value1 -key2=value2 --key3=value3 /key4=value4
+```
+
+Note: If `-key1` isn't present in the [switch mappings](#switch-mappings) given to the configuration provider, a `FormatException` is thrown.
+
+**Sequence of two arguments**
+
+The value can't be null and must follow the key separated by a space.
+
+The key must have a prefix:
+
+| Key prefix               | Example         |
+| ------------------------ | :-------------: |
+| Single dash (`-`)&#8224; | `-key1 value1`  |
+| Two dashes (`--`)        | `--key2 value2` |
+| Forward slash (`/`)      | `/key3 value3`  |
+
+&#8224;A key with a single dash prefix (`-`) must be provided in [switch mappings](#switch-mappings), described below.
+
+Example command:
+
+```console
+dotnet run -key1 value1 --key2 value2 /key3 value3
+```
+
+Note: If `-key1` isn't present in the [switch mappings](#switch-mappings) given to the configuration provider, a `FormatException` is thrown.
+
+### Duplicate keys
+
+If duplicate keys are provided, the last key-value pair is used.
+
+### Switch mappings
+
+When manually building configuration with `ConfigurationBuilder`, you can optionally provide a switch mappings dictionary to the `AddCommandLine` method. Switch mappings allow you to provide key name replacement logic.
+
+When the switch mappings dictionary is used, the dictionary is checked for a key that matches the key provided by a command-line argument. If the command-line key is found in the dictionary, the dictionary value (the key replacement) is passed back to set the configuration. A switch mapping is required for any command-line key prefixed with a single dash (`-`).
+
+Switch mappings dictionary key rules:
+
+* Switches must start with a dash (`-`) or double-dash (`--`).
+* The switch mappings dictionary must not contain duplicate keys.
+
+In the following example, the `GetSwitchMappings` method allows your command-line arguments to use a single dash (`-`) key prefix and avoid leading subkey prefixes.
+
+[!code-csharp[Main](configuration/sample/CommandLine/Program.cs?highlight=10-19,32)]
+
+Without providing command-line arguments, the dictionary provided to `AddInMemoryCollection` sets the configuration values. Run the app with the following command:
+
+```console
+dotnet run
+```
+
+The console window displays:
+
+```console
+MachineName: RickPC
+Left: 1980
+```
 
 Use the following to pass in configuration settings:
 
 ```console
-dotnet run /Profile:MachineName=Bob /App:MainWindow:Left=1234
+dotnet run /Profile:MachineName=DahliaPC /App:MainWindow:Left=1984
 ```
 
-Which displays:
+The console window displays:
 
 ```console
-Hello Bob
-Left 1234
+MachineName: DahliaPC
+Left: 1984
 ```
 
-The `GetSwitchMappings` method allows you to use `-` rather than `/` and it strips the leading subkey prefixes. For example:
+After the switch mappings dictionary is created, it contains the following data:
+
+| Key            | Value                 |
+| -------------- | --------------------- |
+| `-MachineName` | `Profile:MachineName` |
+| `-Left`        | `App:MainWindow:Left` |
+
+To demonstrate key switching using the dictionary, run the following command:
 
 ```console
-dotnet run -MachineName=Bob -Left=7734
+dotnet run -MachineName=ChadPC -Left=1988
 ```
 
-Displays:
+The command-line keys are swapped. The console window displays the configuration values for `Profile:MachineName` and `App:MainWindow:Left`:
 
 ```console
-Hello Bob
-Left 7734
+MachineName: ChadPC
+Left: 1988
 ```
-
-Command-line arguments must include a value (it can be null). For example:
-
-```console
-dotnet run /Profile:MachineName=
-```
-
-Is OK, but
-
-```console
-dotnet run /Profile:MachineName
-```
-
-results in an exception. An exception will be thrown if you specify a command-line switch prefix of - or -- for which there's no corresponding switch mapping.
 
 ## The web.config file
 
 A *web.config* file is required when you host the app in IIS or IIS-Express. *web.config* turns on the AspNetCoreModule in IIS to launch your app. Settings in *web.config* enable the AspNetCoreModule in IIS to launch your app and configure other IIS settings and modules. If you are using Visual Studio and delete *web.config*, Visual Studio will create a new one.
 
-### Additional notes
+## Additional notes
 
 * Dependency Injection (DI) is not set up until after `ConfigureServices` is invoked.
 * The configuration system is not DI aware.
@@ -346,9 +478,10 @@ A *web.config* file is required when you host the app in IIS or IIS-Express. *we
   * `IConfigurationRoot`  Used for the root node. Can trigger a reload.
   * `IConfigurationSection`  Represents a section of configuration values. The `GetSection` and `GetChildren` methods return an `IConfigurationSection`.
 
-### Additional resources
+## Additional resources
 
 * [Working with Multiple Environments](environments.md)
 * [Safe storage of app secrets during development](../security/app-secrets.md)
+* [Hosting in ASP.NET Core](xref:fundamentals/hosting)
 * [Dependency Injection](dependency-injection.md)
 * [Azure Key Vault configuration provider](xref:security/key-vault-configuration)

--- a/aspnetcore/fundamentals/configuration.md
+++ b/aspnetcore/fundamentals/configuration.md
@@ -14,7 +14,7 @@ uid: fundamentals/configuration
 ---
 # Configuration in ASP.NET Core
 
-[Rick Anderson](https://twitter.com/RickAndMSFT), [Mark Michaelis](http://intellitect.com/author/mark-michaelis/), [Steve Smith](https://ardalis.com/), and [Daniel Roth](https://github.com/danroth27)
+[Rick Anderson](https://twitter.com/RickAndMSFT), [Mark Michaelis](http://intellitect.com/author/mark-michaelis/), [Steve Smith](https://ardalis.com/), [Daniel Roth](https://github.com/danroth27), and [Luke Latham](https://github.com/guardrex)
 
 The Configuration API provides a way of configuring an app based on a list of name-value pairs. Configuration is read at runtime from multiple sources. The name-value pairs can be grouped into a multi-level hierarchy. There are configuration providers for:
 

--- a/aspnetcore/fundamentals/configuration.md
+++ b/aspnetcore/fundamentals/configuration.md
@@ -349,7 +349,7 @@ Create a [ConfigurationBuilder](/api/microsoft.extensions.configuration.configur
 
 ### Arguments
 
-Arguments passed on the command line must conform to one of two formats:
+Arguments passed on the command line must conform to one of two formats shown in the following table.
 
 | Argument format                                                     | Example        |
 | ------------------------------------------------------------------- | :------------: |
@@ -360,7 +360,7 @@ Arguments passed on the command line must conform to one of two formats:
 
 The value must follow an equals sign (`=`). The value can be null (for example, `mykey=`).
 
-The key may have a prefix:
+The key may have a prefix.
 
 | Key prefix               | Example         |
 | ------------------------ | :-------------: |
@@ -383,7 +383,7 @@ Note: If `-key1` isn't present in the [switch mappings](#switch-mappings) given 
 
 The value can't be null and must follow the key separated by a space.
 
-The key must have a prefix:
+The key must have a prefix.
 
 | Key prefix               | Example         |
 | ------------------------ | :-------------: |
@@ -446,7 +446,7 @@ MachineName: DahliaPC
 Left: 1984
 ```
 
-After the switch mappings dictionary is created, it contains the following data:
+After the switch mappings dictionary is created, it contains the data shown in the following table.
 
 | Key            | Value                 |
 | -------------- | --------------------- |

--- a/aspnetcore/fundamentals/configuration/sample_snapshot/CommandLine/Program.cs
+++ b/aspnetcore/fundamentals/configuration/sample_snapshot/CommandLine/Program.cs
@@ -7,29 +7,18 @@ public class Program
 {
     public static IConfigurationRoot Configuration { get; set; }
 
-    public static Dictionary<string, string> GetSwitchMappings(
-        IReadOnlyDictionary<string, string> configurationStrings)
-    {
-        return configurationStrings.Select(item =>
-            new KeyValuePair<string, string>(
-                "-" + item.Key.Substring(item.Key.LastIndexOf(':') + 1),
-                item.Key))
-                .ToDictionary(
-                    item => item.Key, item => item.Value);
-    }
-
     public static void Main(string[] args = null)
     {
         var dict = new Dictionary<string, string>
             {
-                {"Profile:MachineName", "RickPC"},
+                {"Profile:MachineName", "MairaPC"},
                 {"App:MainWindow:Left", "1980"}
             };
 
         var builder = new ConfigurationBuilder();
 
         builder.AddInMemoryCollection(dict)
-            .AddCommandLine(args, GetSwitchMappings(dict));
+            .AddCommandLine(args);
 
         Configuration = builder.Build();
 

--- a/aspnetcore/fundamentals/configuration/sample_snapshot/CommandLine/Program2.cs
+++ b/aspnetcore/fundamentals/configuration/sample_snapshot/CommandLine/Program2.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        var config = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+            .AddEnvironmentVariables()
+            .AddCommandLine(args)
+            .Build();
+
+        var host = new WebHostBuilder()
+            .UseConfiguration(config)
+            .UseKestrel()
+            .Configure(app =>
+            {
+                app.Run(context => context.Response.WriteAsync("Hello World!"));
+            })
+            .Build();
+
+        host.Run();
+    }
+}

--- a/aspnetcore/fundamentals/configuration/sample_snapshot/Program.cs
+++ b/aspnetcore/fundamentals/configuration/sample_snapshot/Program.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        BuildWebHost(args).Run();
+    }
+
+    public static IWebHost BuildWebHost(string[] args) =>
+        WebHost.CreateDefaultBuilder(args)
+            .UseStartup<Startup>()
+            .Build();
+}

--- a/aspnetcore/fundamentals/configuration/sample_snapshot/readme.md
+++ b/aspnetcore/fundamentals/configuration/sample_snapshot/readme.md
@@ -1,0 +1,1 @@
+The code in this folder is used for snapshots of code in the Configuration topic at: https://docs.microsoft.com/aspnet/core/fundamentals/configuration

--- a/aspnetcore/fundamentals/configuration/sample_snapshot/readme.md
+++ b/aspnetcore/fundamentals/configuration/sample_snapshot/readme.md
@@ -1,1 +1,0 @@
-The code in this folder is used for snapshots of code in the Configuration topic at: https://docs.microsoft.com/aspnet/core/fundamentals/configuration


### PR DESCRIPTION
[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration?branch=pr-en-us-4307&tabs=basicconfiguration#commandline-configuration-provider)
Fixes #2409 
Fixes #1382

### 🎸 *Jam'in!* 🎷

[Review site topic](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration?branch=pr-en-us-4307#commandline-configuration-provider)

This turned out to be a considerable overhaul of the CommandLine config provider section:
* The whole topic (big IMHO here) is *toooooo console app-ish*. We want to maintain the basic config explanations. What's a :boy: to do? 💡 :zap: **3RD TAB!** :zap: :bulb: The "Basic Configuration" is a tab with the basics (as the topic currently embraces in each of its samples). We can have the 2.x and 1.x bits in tabs 2 and 3 showing how the config applies to web apps. The reader isn't left wondering how it looks in a web app setup and then annoyed by the need to go look at other topics. If u don't like this, then I recommend we pull that tab 1 content out above the tab control and create a new section for the web app config (tabs).
* I attempt to clarify the argument format situation. Lists didn't look good, so I went with tables.
* I made an effort to explain out what's happening in the switch mappings, including a table of what's in the dictionary.
* @rachelappel, you may need to gut this or make large changes to it when you come to this topic for 2.0 updates. It's cool. In the meantime tho, this fixes the two open issues pertaining to this section, and closing two issues feels really good.
* Of course, this needs a good dev team :eye: to make sure I have the logic and behaviors are correct.

cc/ @danroth27 