### PR TITLE
Add missing uid to metadata

### DIFF
--- a/aspnetcore/tutorials/first-web-api-mac.md
+++ b/aspnetcore/tutorials/first-web-api-mac.md
@@ -6,6 +6,7 @@ ms.author: riande
 ms.date: 09/15/2017
 ms.topic: get-started-article
 ms.prod: asp.net-core
+uid: tutorials/first-web-api-mac
 helpviewer_heywords: ASP.NET Core, WebAPI, Web API, REST, mac, macOS, HTTP, Service, HTTP Service
 
 #ROBOTS: 


### PR DESCRIPTION
The "uid" metadata field was removed in https://github.com/aspnet/Docs/commit/42a48de471aaa42526dfa3f37415f7b43aa3afa2. This PR adds it back to fix a build warning.