### PR TITLE
Updating "Define method on client (with the generated proxy)" code snippet

### DIFF
--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-javascript-client/samples/sample27.js
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-javascript-client/samples/sample27.js
@@ -5,4 +5,3 @@ contosoChatHubProxy.client.addContosoChatMessageToPage = function (userName, mes
 $.connection.hub.start()
     .done(function(){ console.log('Now connected, connection ID=' + $.connection.hub.id); })
     .fail(function(){ console.log('Could not Connect!'); });
-});


### PR DESCRIPTION
Small contribution to remove an extra }); found within "Define method on client (with the generated proxy)" JavaScript code snippet found after the .fail method.