### PR TITLE
Add link to Runtime Store

### DIFF
--- a/aspnetcore/fundamentals/metapackage.md
+++ b/aspnetcore/fundamentals/metapackage.md
@@ -1,11 +1,11 @@
 ---
 title: Microsoft.AspNetCore.All metapackage for ASP.NET Core 2.x and later
 author: Rick-Anderson
-description: Microsoft.AspNetCore.All metapackage includes all supported packages.
-keywords: ASP.NET Core, NuGet, package, Microsoft.AspNetCore.All, metapackage
+description: The Microsoft.AspNetCore.All metapackage includes all supported ASP.NET Core and Entity Framework Core packages, along with their dependencies.
+keywords: ASP.NET Core,NuGet,package,Microsoft.AspNetCore.All,metapackage
 ms.author: riande
 manager: wpickett
-ms.date: 07/16/2017
+ms.date: 09/20/2017
 ms.topic: article
 ms.technology: aspnet
 ms.prod: asp.net-core
@@ -26,7 +26,7 @@ All the features of ASP.NET Core 2.x and Entity Framework Core 2.x are included 
 
 The version number of the `Microsoft.AspNetCore.All` metapackage represents the ASP.NET Core version and Entity Framework Core version (aligned with the .NET Core version).
 
-Applications that use the `Microsoft.AspNetCore.All` metapackage automatically take advantage of the .NET Core Runtime Store. The Runtime Store contains all the runtime assets needed to run ASP.NET Core 2.x applications. When you use the `Microsoft.AspNetCore.All` metapackage, **no** assets from the referenced ASP.NET Core NuGet packages are deployed with the application &mdash; the .NET Core Runtime Store contains these assets. <!-- todo add link to Runtime store --> The assets in the Runtime Store are precompiled to improve application startup time.
+Applications that use the `Microsoft.AspNetCore.All` metapackage automatically take advantage of the [.NET Core Runtime Store](https://docs.microsoft.com/dotnet/core/deploying/runtime-store). The Runtime Store contains all the runtime assets needed to run ASP.NET Core 2.x applications. When you use the `Microsoft.AspNetCore.All` metapackage, **no** assets from the referenced ASP.NET Core NuGet packages are deployed with the application &mdash; the .NET Core Runtime Store contains these assets. The assets in the Runtime Store are precompiled to improve application startup time.
 
 You can use the package trimming process to remove packages that you don't use. Trimmed packages are excluded in published application output.
 


### PR DESCRIPTION
Delete the "todo" comment and include a link to the Runtime Store doc. Also, fix Gauntlet warnings related to description and keywords.