### PR TITLE
Trim keywords of keyword metadata

### DIFF
--- a/aspnet/mvc/overview/deployment/docker-aspnetmvc.md
+++ b/aspnet/mvc/overview/deployment/docker-aspnetmvc.md
@@ -2,7 +2,7 @@
 uid: mvc/overview/deployment/docker-aspnetmvc
 title: Migrating ASP.NET MVC Applications to Windows Containers
 description: Learn how to take an existing ASP.NET MVC application and run it in a Windows Docker Container
-keywords: Windows Containers, Docker, ASP.NET MVC
+keywords: Windows Containers,Docker,ASP.NET MVC
 author: BillWagner
 ms.author: wiwagn
 ms.date: 02/01/2017

--- a/aspnet/signalr/overview/performance/using-signalr-performance-counters-in-an-azure-web-role.md
+++ b/aspnet/signalr/overview/performance/using-signalr-performance-counters-in-an-azure-web-role.md
@@ -3,7 +3,7 @@ uid: signalr/overview/performance/using-signalr-performance-counters-in-an-azure
 title: Using SignalR performance counters in an Azure Web Role | Microsoft Docs
 author: guardrex
 description: How to install and use SignalR performance counters in an Azure Web Role.
-keywords: ASP.NET, signalr, performance counter, azure web role
+keywords: ASP.NET,signalr,performance counter,azure web role
 ms.author: aspnetcontent
 manager: wpickett
 ms.date: 02/11/2017

--- a/aspnetcore/aspnetcore-1.1.md
+++ b/aspnetcore/aspnetcore-1.1.md
@@ -2,7 +2,7 @@
 title: What's new in ASP.NET Core 1.1
 author: rick-anderson
 description: What's new in ASP.NET Core 1.1
-keywords: ASP.NET Core, bower
+keywords: ASP.NET Core,bower
 ms.author: riande
 manager: wpickett
 ms.date: 02/14/2017

--- a/aspnetcore/aspnetcore-2.0.md
+++ b/aspnetcore/aspnetcore-2.0.md
@@ -2,7 +2,7 @@
 title: What's new in ASP.NET Core 2.0
 author: rick-anderson
 description: What's new in ASP.NET Core 2.0
-keywords: ASP.NET Core, release notes, what's new
+keywords: ASP.NET Core,release notes,what's new
 ms.author: riande
 manager: wpickett
 ms.date: 07/10/2017

--- a/aspnetcore/client-side/angular.md
+++ b/aspnetcore/client-side/angular.md
@@ -2,7 +2,7 @@
 title: Using AngularJS for Single Page Applications (SPAs)
 author: rick-anderson
 description: Learn how to build a SPA-style ASP.NET application using AngularJS
-keywords: ASP.NET Core, AngularJS, SPA
+keywords: ASP.NET Core,AngularJS,SPA
 ms.author: riande
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/client-side/bower.md
+++ b/aspnetcore/client-side/bower.md
@@ -2,7 +2,7 @@
 title: Using Bower in ASP.NET Core
 author: rick-anderson
 description: Managing client-side packages with Bower.
-keywords: ASP.NET Core, bower
+keywords: ASP.NET Core,bower
 ms.author: riande
 manager: wpickett
 ms.date: 02/14/2017

--- a/aspnetcore/client-side/bundling-and-minification.md
+++ b/aspnetcore/client-side/bundling-and-minification.md
@@ -2,7 +2,7 @@
 title: Bundling and minification in ASP.NET Core
 author: spboyer
 description: 
-keywords: ASP.NET Core, Bundling and Minification, CSS, JavaScript, Minify, BuildBundlerMinifier
+keywords: ASP.NET Core,Bundling and Minification,CSS,JavaScript,Minify,BuildBundlerMinifier
 ms.author: riande
 manager: wpickett
 ms.date: 02/28/2017

--- a/aspnetcore/client-side/less-sass-fa.md
+++ b/aspnetcore/client-side/less-sass-fa.md
@@ -2,7 +2,7 @@
 title: Less, Sass, and Font Awesome in ASP.NET Core
 author: ardalis
 description: Learn how to use Less, Sass, and Font Awesome in ASP.NET Core applications.
-keywords: ASP.NET Core, Less, Sass, Font Awesome, preprocessors
+keywords: ASP.NET Core,Less,Sass,Font Awesome,preprocessors
 ms.author: tdykstra
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/client-side/using-browserlink.md
+++ b/aspnetcore/client-side/using-browserlink.md
@@ -2,7 +2,7 @@
 title: Browser Link in ASP.NET Core
 author: ncarandini
 description: A Visual Studio feature that links the development environment with one or more web browsers
-keywords: ASP.NET Core, browser link, CSS sync
+keywords: ASP.NET Core,browser link,CSS sync
 ms.author: riande
 manager: wpickett
 ms.date: 12/28/2016

--- a/aspnetcore/client-side/using-gulp.md
+++ b/aspnetcore/client-side/using-gulp.md
@@ -2,7 +2,7 @@
 title: Using Gulp in ASP.NET Core
 author: rick-anderson
 description: Learn how to use Gulp in ASP.NET Core.
-keywords: ASP.NET Core, Gulp
+keywords: ASP.NET Core,Gulp
 ms.author: riande
 manager: wpickett
 ms.date: 02/28/2017

--- a/aspnetcore/client-side/yeoman.md
+++ b/aspnetcore/client-side/yeoman.md
@@ -2,7 +2,7 @@
 title: Building projects with Yeoman in ASP.NET Core
 author: spboyer
 description: This article walks through building an ASP.NET Core web application using the Yeoman generator on macOS.
-keywords: ASP.NET Core, Yeoman, Cross Platform, yo aspnet
+keywords: ASP.NET Core,Yeoman,Cross Platform,yo aspnet
 ms.author: spboyer
 manager: wpickett
 ms.date: 07/05/2017

--- a/aspnetcore/data/ef-mvc/advanced.md
+++ b/aspnetcore/data/ef-mvc/advanced.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core MVC with EF Core - Advanced - 10 of 10
 author: tdykstra
 description: This tutorial introduces several topics that are useful to be aware of when you go beyond the basics of developing ASP.NET web applications that use Entity Framework Core.
-keywords: ASP.NET Core, Entity Framework Core, raw sql, examine sql, repository pattern, unit of work pattern, automatic change detection, existing database
+keywords: ASP.NET Core,Entity Framework Core,raw sql,examine sql,repository pattern,unit of work pattern,automatic change detection,existing database
 ms.author: tdykstra
 manager: wpickett
 ms.date: 03/15/2017

--- a/aspnetcore/data/ef-mvc/complex-data-model.md
+++ b/aspnetcore/data/ef-mvc/complex-data-model.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core MVC with EF Core - Data Model - 5 of 10
 author: tdykstra
 description: In this tutorial you add more entities and relationships and customize the data model by specifying formatting, validation, and database mapping rules.
-keywords: ASP.NET Core, Entity Framework Core, data annotations
+keywords: ASP.NET Core,Entity Framework Core,data annotations
 ms.author: tdykstra
 manager: wpickett
 ms.date: 03/15/2017

--- a/aspnetcore/data/ef-mvc/concurrency.md
+++ b/aspnetcore/data/ef-mvc/concurrency.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core MVC with EF Core - Concurrency - 8 of 10
 author: tdykstra
 description: This tutorial shows how to handle conflicts when multiple users update the same entity at the same time.
-keywords: ASP.NET Core, Entity Framework Core, concurrency
+keywords: ASP.NET Core,Entity Framework Core,concurrency
 ms.author: tdykstra
 manager: wpickett
 ms.date: 03/15/2017

--- a/aspnetcore/data/ef-mvc/crud.md
+++ b/aspnetcore/data/ef-mvc/crud.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core MVC with EF Core - CRUD - 2 of 10
 author: tdykstra
 description: 
-keywords: ASP.NET Core, Entity Framework Core, CRUD, create, read, update, delete
+keywords: ASP.NET Core,Entity Framework Core,CRUD,create,read,update,delete
 ms.author: tdykstra
 manager: wpickett
 ms.date: 03/15/2017

--- a/aspnetcore/data/ef-mvc/inheritance.md
+++ b/aspnetcore/data/ef-mvc/inheritance.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core MVC with EF Core - Inheritance - 9 of 10
 author: tdykstra
 description: This tutorial will show you how to implement inheritance in the data model, using Entity Framework Core in an ASP.NET Core application.
-keywords: ASP.NET Core, Entity Framework Core, inheritance
+keywords: ASP.NET Core,Entity Framework Core,inheritance
 ms.author: tdykstra
 manager: wpickett
 ms.date: 03/15/2017

--- a/aspnetcore/data/ef-mvc/intro.md
+++ b/aspnetcore/data/ef-mvc/intro.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core MVC with Entity Framework Core - Tutorial 1 of 10
 author: tdykstra
 description: 
-keywords: ASP.NET Core, Entity Framework Core, tutorial
+keywords: ASP.NET Core,Entity Framework Core,tutorial
 ms.author: tdykstra
 manager: wpickett
 ms.date: 03/15/2017

--- a/aspnetcore/data/ef-mvc/migrations.md
+++ b/aspnetcore/data/ef-mvc/migrations.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core MVC with EF Core - Migrations - 4 of 10
 author: tdykstra
 description: In this tutorial, you start using the EF Core migrations feature for managing data model changes in an ASP.NET Core MVC application.
-keywords: ASP.NET Core, Entity Framework Core, migrations
+keywords: ASP.NET Core,Entity Framework Core,migrations
 ms.author: tdykstra
 manager: wpickett
 ms.date: 03/15/2017

--- a/aspnetcore/data/ef-mvc/read-related-data.md
+++ b/aspnetcore/data/ef-mvc/read-related-data.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core MVC with EF Core - Read Related Data - 6 of 10
 author: tdykstra
 description: In this tutorial you'll read and display related data -- that is, data that the Entity Framework loads into navigation properties.
-keywords: ASP.NET Core, Entity Framework Core, related data, joins
+keywords: ASP.NET Core,Entity Framework Core,related data,joins
 ms.author: tdykstra
 manager: wpickett
 ms.date: 03/15/2017

--- a/aspnetcore/data/ef-mvc/sort-filter-page.md
+++ b/aspnetcore/data/ef-mvc/sort-filter-page.md
@@ -3,7 +3,7 @@ title: ASP.NET Core MVC with EF Core - Sort, Filter, Paging - 3 of 10
 author: tdykstra
 author: tdykstra
 description: In this tutorial you'll add sorting, filtering, and paging functionality to page using ASP.NET Core and Entity Framework Core.
-keywords: ASP.NET Core, Entity Framework Core, sort, filter, paging, grouping
+keywords: ASP.NET Core,Entity Framework Core,sort,filter,paging,grouping
 ms.author: tdykstra
 ms.date: 03/15/2017
 ms.topic: get-started-article

--- a/aspnetcore/data/ef-mvc/update-related-data.md
+++ b/aspnetcore/data/ef-mvc/update-related-data.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core MVC with EF Core - Update Related Data - 7 of 10
 author: tdykstra
 description: In this tutorial you'll update related data by updating foreign key fields and navigation properties.
-keywords: ASP.NET Core, Entity Framework Core, related data, joins
+keywords: ASP.NET Core,Entity Framework Core,related data,joins
 ms.author: tdykstra
 manager: wpickett
 ms.date: 03/15/2017

--- a/aspnetcore/data/entity-framework-6.md
+++ b/aspnetcore/data/entity-framework-6.md
@@ -2,7 +2,7 @@
 title: Getting Started with ASP.NET Core and Entity Framework 6
 author: tdykstra
 description: This article shows how to use Entity Framework 6 in an ASP.NET Core application.
-keywords: ASP.NET Core, Entity Framework, EF 6
+keywords: ASP.NET Core,Entity Framework,EF 6
 ms.author: tdykstra
 manager: wpickett
 ms.date: 02/24/2017

--- a/aspnetcore/fundamentals/app-state.md
+++ b/aspnetcore/fundamentals/app-state.md
@@ -2,7 +2,7 @@
 title: Session and application state in ASP.NET Core
 author: rick-anderson
 description: Approaches to preserving application and user (session) state between requests.
-keywords: ASP.NET Core, Application state, session state, querystring, post
+keywords: ASP.NET Core,Application state,session state,querystring,post
 ms.author: riande
 manager: wpickett
 ms.date: 06/08/2017

--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -2,7 +2,7 @@
 title: Dependency Injection in ASP.NET Core
 author: ardalis
 description: Learn how ASP.NET Core implements dependency injection and how to use it.
-keywords: ASP.NET Core, dependency injection, di
+keywords: ASP.NET Core,dependency injection,di
 ms.author: riande
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -2,7 +2,7 @@
 title: Working with Multiple Environments
 author: ardalis
 description: 
-keywords: ASP.NET Core, Environment settings, ASPNETCORE_ENVIRONMENT
+keywords: ASP.NET Core,Environment settings,ASPNETCORE_ENVIRONMENT
 ms.author: riande
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/fundamentals/error-handling.md
+++ b/aspnetcore/fundamentals/error-handling.md
@@ -2,7 +2,7 @@
 title: Error Handling in ASP.NET Core
 author: ardalis
 description: Explains how to handle errors in ASP.NET Core applications
-keywords: ASP.NET Core, error handling, exception handling, 
+keywords: ASP.NET Core,error handling,exception handling
 ms.author: tdykstra
 manager: wpickett
 ms.date: 11/30/2016

--- a/aspnetcore/fundamentals/logging.md
+++ b/aspnetcore/fundamentals/logging.md
@@ -2,7 +2,7 @@
 title: Logging in ASP.NET Core
 author: ardalis
 description: Introduces the logging framework in ASP.NET Core. Includes a section for each built-in logging provider and links to some popular third-party providers.
-keywords: ASP.NET Core, logging, logging providers, Microsoft.Extensions.Logging, ILogger, ILoggerFactory, LogLevel, WithFilter, TraceSource, EventLog, EventSource, scopes
+keywords: ASP.NET Core,logging,logging providers,Microsoft.Extensions.Logging,ILogger,ILoggerFactory,LogLevel,WithFilter,TraceSource,EventLog,EventSource,scopes
 ms.author: tdykstra
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/fundamentals/middleware.md
+++ b/aspnetcore/fundamentals/middleware.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core Middleware
 author: rick-anderson
 description: Explains middleware and the request pipeline.
-keywords: ASP.NET Core, Middleware, pipeline, delegate
+keywords: ASP.NET Core,Middleware,pipeline,delegate
 ms.author: riande
 manager: wpickett
 ms.date: 08/14/2017

--- a/aspnetcore/fundamentals/owin.md
+++ b/aspnetcore/fundamentals/owin.md
@@ -2,7 +2,7 @@
 title: Open Web Interface for .NET (OWIN)
 author: ardalis
 description: Introduction to Open Web Interface for .NET (OWIN).
-keywords: ASP.NET Core, Open Web Interface for .NET, OWIN
+keywords: ASP.NET Core,Open Web Interface for .NET,OWIN
 ms.author: riande
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/fundamentals/servers/aspnet-core-module.md
+++ b/aspnetcore/fundamentals/servers/aspnet-core-module.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core Module
 author: tdykstra
 description: Introduces ASP.NET Core Module (ANCM), an IIS module that lets the Kestrel web server use IIS or IIS Express as a reverse proxy server.
-keywords: ASP.NET Core, IIS, IIS Express, ASP.NET Core Module, UseIISIntegration
+keywords: ASP.NET Core,IIS,IIS Express,ASP.NET Core Module,UseIISIntegration
 ms.author: tdykstra
 manager: wpickett
 ms.date: 08/03/2017

--- a/aspnetcore/fundamentals/servers/httpsys.md
+++ b/aspnetcore/fundamentals/servers/httpsys.md
@@ -2,7 +2,7 @@
 title: HTTP.sys web server implementation in ASP.NET Core
 author: rick-anderson
 description: Introduces HTTP.sys, a web server for ASP.NET Core on Windows. Built on the Http.Sys kernel mode driver, HTTP.sys is an alternative to Kestrel that can be used for direct connection to the Internet without IIS.
-keywords: ASP.NET Core, HttpSys, HTTP.sys, HttpListener, url prefixes, SSL 
+keywords: ASP.NET Core,HttpSys,HTTP.sys,HttpListener,url prefixes,SSL
 ms.author: riande
 manager: wpickett
 ms.date: 08/07/2017

--- a/aspnetcore/fundamentals/servers/index.md
+++ b/aspnetcore/fundamentals/servers/index.md
@@ -2,7 +2,7 @@
 title: Web server implementations in ASP.NET Core
 author: tdykstra
 description: Introduces web servers Kestrel and WebListener for ASP.NET Core. Provides guidance on how to choose one and when to use one with a reverse proxy server.
-keywords: ASP.NET Core, IServer, web server, Kestrel, WebListener, reverse proxy
+keywords: ASP.NET Core,IServer,web server,Kestrel,WebListener,reverse proxy
 ms.author: tdykstra
 manager: wpickett
 ms.date: 08/03/2017

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -2,7 +2,7 @@
 title: Kestrel web server implementation in ASP.NET Core
 author: tdykstra
 description: Introduces Kestrel, the cross-platform web server for ASP.NET Core based on libuv.
-keywords: ASP.NET Core, Kestrel, libuv, url prefixes
+keywords: ASP.NET Core,Kestrel,libuv,url prefixes
 ms.author: tdykstra
 manager: wpickett
 ms.date: 08/02/2017

--- a/aspnetcore/fundamentals/servers/weblistener.md
+++ b/aspnetcore/fundamentals/servers/weblistener.md
@@ -2,7 +2,7 @@
 title: WebListener web server implementation in ASP.NET Core
 author: rick-anderson
 description: Introduces WebListener, a web server for ASP.NET Core on Windows. Built on the Http.Sys kernel mode driver, WebListener is an alternative to Kestrel that can be used for direct connection to the Internet without IIS.
-keywords: ASP.NET Core, WebListener, HttpListener, url prefixes, SSL 
+keywords: ASP.NET Core,WebListener,HttpListener,url prefixes,SSL
 ms.author: riande
 manager: wpickett
 ms.date: 08/07/2017

--- a/aspnetcore/fundamentals/startup.md
+++ b/aspnetcore/fundamentals/startup.md
@@ -2,7 +2,7 @@
 title: Application Startup in ASP.NET Core
 author: ardalis
 description: Explains the Startup class in ASP.NET Core.
-keywords: ASP.NET Core, Startup, Configure method, ConfigureServices method
+keywords: ASP.NET Core,Startup,Configure method,ConfigureServices method
 ms.author: tdykstra
 manager: wpickett
 ms.date: 02/29/2017

--- a/aspnetcore/fundamentals/static-files.md
+++ b/aspnetcore/fundamentals/static-files.md
@@ -2,7 +2,7 @@
 title: Working with static files in ASP.NET Core
 author: rick-anderson
 description: Working with Static Files
-keywords: ASP.NET Core, static files, static assets, HTML, CSS, JavaScript
+keywords: ASP.NET Core,static files,static assets,HTML,CSS,JavaScript
 ms.author: riande
 manager: wpickett
 ms.date: 4/07/2017

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -2,7 +2,7 @@
 title: WebSockets support in ASP.NET Core
 author: tdykstra
 description: What is WebSockets support in ASP.NET Core and how to use it.
-keywords: ASP.NET Core, WebSockets
+keywords: ASP.NET Core,WebSockets
 ms.author: tdykstra
 manager: wpickett
 ms.date: 03/25/2017

--- a/aspnetcore/hosting/aspnet-core-module.md
+++ b/aspnetcore/hosting/aspnet-core-module.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core Module configuration reference
 author: guardrex
 description: How to configure the ASP.NET Core Module for hosting ASP.NET Core applications.
-keywords: ASP.NET Core, ancm, core module, iis, stdout logging, environment variable, env var, subapplication, subapp, appoffline, app_offline, 502, schema
+keywords: ASP.NET Core,ancm,core module,iis,stdout logging,environment variable,env var,subapplication,subapp,appoffline,app_offline,502,schema
 ms.author: riande
 manager: wpickett
 ms.date: 03/07/2017

--- a/aspnetcore/hosting/directory-structure.md
+++ b/aspnetcore/hosting/directory-structure.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core directory structure
 author: guardrex
 description: The directory structure of published ASP.NET Core applications.
-keywords: ASP.NET Core, directory structure
+keywords: ASP.NET Core,directory structure
 ms.author: riande
 manager: wpickett
 ms.date: 03/15/2017

--- a/aspnetcore/hosting/iis-modules.md
+++ b/aspnetcore/hosting/iis-modules.md
@@ -2,7 +2,7 @@
 title: Using IIS modules with ASP.NET Core
 author: guardrex
 description: Reference document describing active and inactive IIS modules for ASP.NET Core applications.
-keywords: ASP.NET Core, iis, module, reverse-proxy
+keywords: ASP.NET Core,iis,module,reverse-proxy
 ms.author: riande
 manager: wpickett
 ms.date: 03/08/2017

--- a/aspnetcore/hosting/windows-service.md
+++ b/aspnetcore/hosting/windows-service.md
@@ -2,7 +2,7 @@
 title: Host in a Windows Service
 author: tdykstra
 description: Learn how to host an ASP.NET Core application in a Windows Service.
-keywords: ASP.NET Core, Windows service, hosting
+keywords: ASP.NET Core,Windows service,hosting
 ms.author: tdykstra
 manager: wpickett
 ms.date: 03/30/2017

--- a/aspnetcore/migration/mvc.md
+++ b/aspnetcore/migration/mvc.md
@@ -2,7 +2,7 @@
 title: Migrating From ASP.NET MVC to ASP.NET Core MVC
 author: ardalis
 description: 
-keywords: ASP.NET Core, MVC, migrating
+keywords: ASP.NET Core,MVC,migrating
 ms.author: riande
 manager: wpickett
 ms.date: 03/07/2017

--- a/aspnetcore/mvc/advanced/custom-formatters.md
+++ b/aspnetcore/mvc/advanced/custom-formatters.md
@@ -2,7 +2,7 @@
 title: Custom formatters in ASP.NET Core MVC web APIs
 author: tdykstra
 description: Learn how to create and use custom formatters for web APIs in ASP.NET Core. 
-keywords: ASP.NET Core, web api, custom formatters
+keywords: ASP.NET Core,web api,custom formatters
 ms.author: tdykstra
 manager: wpickett
 ms.date: 02/08/2017

--- a/aspnetcore/mvc/advanced/custom-model-binding.md
+++ b/aspnetcore/mvc/advanced/custom-model-binding.md
@@ -2,7 +2,7 @@
 title: Custom Model Binding
 author: ardalis
 description: Customizing model binding in ASP.NET Core MVC.
-keywords: ASP.NET Core, model binding, custom model binder
+keywords: ASP.NET Core,model binding,custom model binder
 ms.author: riande
 manager: wpickett
 ms.date: 04/10/2017

--- a/aspnetcore/mvc/controllers/application-model.md
+++ b/aspnetcore/mvc/controllers/application-model.md
@@ -2,7 +2,7 @@
 title: Working with the Application Model
 author: ardalis
 description: 
-keywords: ASP.NET Core, ASP.NET Core MVC, application model
+keywords: ASP.NET Core,ASP.NET Core MVC,application model
 ms.author: riande
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/mvc/controllers/areas.md
+++ b/aspnetcore/mvc/controllers/areas.md
@@ -2,7 +2,7 @@
 title: Areas
 author: rick-anderson
 description: Shows how to work with areas.
-keywords: ASP.NET Core, areas, routing, views
+keywords: ASP.NET Core,areas,routing,views
 ms.author: riande
 manager: wpickett
 ms.date: 02/14/2017

--- a/aspnetcore/mvc/controllers/filters.md
+++ b/aspnetcore/mvc/controllers/filters.md
@@ -2,7 +2,7 @@
 title: Filters
 author: ardalis
 description: Learn how *Filters* work and how to use them in ASP.NET Core MVC.
-keywords: ASP.NET Core, filters, mvc filters, action filters, authorization filters, resource filters, result filters, exception filters
+keywords: ASP.NET Core,filters,mvc filters,action filters,authorization filters,resource filters,result filters,exception filters
 ms.author: tdykstra
 manager: wpickett
 ms.date: 12/12/2016

--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -2,7 +2,7 @@
 title: File uploads in ASP.NET Core
 author: ardalis
 description: How to use model binding and streaming to upload files in ASP.NET Core MVC.
-keywords: ASP.NET Core, file upload, model binding, IFormFile, streaming
+keywords: ASP.NET Core,file upload,model binding,IFormFile,streaming
 ms.author: riande
 manager: wpickett
 ms.date: 07/05/2017

--- a/aspnetcore/mvc/models/formatting.md
+++ b/aspnetcore/mvc/models/formatting.md
@@ -2,7 +2,7 @@
 title: Formatting response data in ASP.NET Core MVC
 author: ardalis
 description: Learn how to format response data in ASP.NET Core MVC.
-keywords: ASP.NET Core, response data, IOutputFormatter, IActionResult
+keywords: ASP.NET Core,response data,IOutputFormatter,IActionResult
 ms.author: riande
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/mvc/models/validation.md
+++ b/aspnetcore/mvc/models/validation.md
@@ -2,7 +2,7 @@
 title: Model validation in ASP.NET Core MVC
 author: rick-anderson
 description: Introduces model validation in ASP.NET Core MVC.
-keywords: ASP.NET Core, MVC, validation
+keywords: ASP.NET Core,MVC,validation
 ms.author: riande
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/mvc/views/partial.md
+++ b/aspnetcore/mvc/views/partial.md
@@ -2,7 +2,7 @@
 title: Partial Views
 author: ardalis
 description: Using partial views in ASP.NET Core MVC
-keywords: ASP.NET Core,Partial Views, partial
+keywords: ASP.NET Core,Partial Views,partial
 ms.author: riande
 manager: wpickett
 ms.date: 03/14/2017

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -2,7 +2,7 @@
 title: Razor Syntax Reference for ASP.NET Core
 author: rick-anderson
 description: Details Razor syntax
-keywords: ASP.NET Core, Razor
+keywords: ASP.NET Core,Razor
 ms.author: riande
 manager: wpickett
 ms.date: 07/04/2017

--- a/aspnetcore/mvc/views/tag-helpers/intro.md
+++ b/aspnetcore/mvc/views/tag-helpers/intro.md
@@ -2,7 +2,7 @@
 title: Tag Helpers in ASP.NET Core
 author: rick-anderson
 description: Learn what tag helpers are and how to use them in ASP.NET Core.
-keywords: ASP.NET Core, tag helpers
+keywords: ASP.NET Core,tag helpers
 ms.author: riande
 manager: wpickett
 ms.date: 7/14/2017

--- a/aspnetcore/mvc/views/view-components.md
+++ b/aspnetcore/mvc/views/view-components.md
@@ -2,7 +2,7 @@
 title: View components
 author: rick-anderson
 description: View Components are intended anywhere you have reusable rendering logic.
-keywords: ASP.NET Core,view components, partial view
+keywords: ASP.NET Core,view components,partial view
 ms.author: riande
 manager: wpickett
 ms.date: 02/14/2017

--- a/aspnetcore/mvc/views/working-with-forms.md
+++ b/aspnetcore/mvc/views/working-with-forms.md
@@ -2,7 +2,7 @@
 title: Tag helpers in forms in ASP.NET Core
 author: rick-anderson
 description: Describes the built-in Tag Helpers used with Forms.
-keywords: ASP.NET Core, Tag Helper, TagHelper, HTML Form, Forms
+keywords: ASP.NET Core,Tag Helper,TagHelper,HTML Form,Forms
 ms.author: riande
 manager: wpickett
 ms.date: 02/14/2017

--- a/aspnetcore/performance/caching/index.md
+++ b/aspnetcore/performance/caching/index.md
@@ -2,7 +2,7 @@
 title: Caching
 author: ardalis
 description: Demonstrates how to use caching for higher performance.
-keywords: ASP.NET Core, caching, performance
+keywords: ASP.NET Core,caching,performance
 ms.author: riande
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/performance/caching/memory.md
+++ b/aspnetcore/performance/caching/memory.md
@@ -2,7 +2,7 @@
 title: In-memory caching in ASP.NET Core
 author: rick-anderson
 description: Shows how to cache data in memory in ASP.NET Core.
-keywords: ASP.NET Core, cache, in-memory, performance
+keywords: ASP.NET Core,cache,in-memory,performance
 ms.author: riande
 manager: wpickett
 ms.date: 12/14/2016

--- a/aspnetcore/performance/caching/response.md
+++ b/aspnetcore/performance/caching/response.md
@@ -2,7 +2,7 @@
 title: Response Caching
 author: rick-anderson
 description: Explains how to use Response caching to lower bandwidth and increase performance.
-keywords: ASP.NET Core, Response caching, HTTP headers
+keywords: ASP.NET Core,Response caching,HTTP headers
 ms.author: riande
 manager: wpickett
 ms.date: 07/10/2017

--- a/aspnetcore/publishing/apache-proxy.md
+++ b/aspnetcore/publishing/apache-proxy.md
@@ -1,7 +1,7 @@
 ---
 title: Host ASP.NET Core on Linux with Apache
 description: Learn how to set up Apache as a reverse proxy server on CentOS to redirect HTTP traffic to an ASP.NET Core web application running on Kestrel.
-keywords: ASP.NET Core, Apache, CentOS, Reverse Proxy, Linux, mod_proxy, httpd, hosting
+keywords: ASP.NET Core,Apache,CentOS,Reverse Proxy,Linux,mod_proxy,httpd,hosting
 author: spboyer
 ms.author: spboyer
 manager: wpickett

--- a/aspnetcore/publishing/iis.md
+++ b/aspnetcore/publishing/iis.md
@@ -2,7 +2,7 @@
 title: Host ASP.NET Core on Windows with IIS
 author: guardrex
 description:  Windows Server Internet Information Services (IIS) configuration and deployment of ASP.NET Core applications.
-keywords: ASP.NET Core, internet information services, iis, windows server, hosting bundle, asp.net core module, web deploy
+keywords: ASP.NET Core,internet information services,iis,windows server,hosting bundle,asp.net core module,web deploy
 ms.author: riande
 manager: wpickett
 ms.date: 03/13/2017

--- a/aspnetcore/publishing/web-publishing-vs.md
+++ b/aspnetcore/publishing/web-publishing-vs.md
@@ -2,7 +2,7 @@
 title: Create publish profiles for Visual Studio and MSBuild
 author: rick-anderson
 description: Explains web publishing in Visual Studio.
-keywords: ASP.NET Core, web publishing, publishing, msbuild, web deploy, dotnet publish, Visual Studio 2017
+keywords: ASP.NET Core,web publishing,publishing,msbuild,web deploy,dotnet publish,Visual Studio 2017
 ms.author: riande
 manager: wpickett
 ms.date: 03/14/2017

--- a/aspnetcore/security/authentication/2fa.md
+++ b/aspnetcore/security/authentication/2fa.md
@@ -2,7 +2,7 @@
 title: Two-factor authentication with SMS
 author: rick-anderson
 description: Shows how to set up two-factor authentication (2FA) with ASP.NET Core
-keywords: ASP.NET Core,SMS, authentication,2FA,two-factor authentication,two factor authentication 
+keywords: ASP.NET Core,SMS,authentication,2FA,two-factor authentication,two factor authentication
 ms.author: riande
 manager: wpickett
 ms.date: 08/15/2017

--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -2,7 +2,7 @@
 title: Account Confirmation and Password Recovery in ASP.NET Core
 author: rick-anderson
 description: Shows how to build an ASP.NET Core app with email confirmation and password reset.
-keywords: ASP.NET Core, password reset, email confirmation, security
+keywords: ASP.NET Core,password reset,email confirmation,security
 ms.author: riande
 manager: wpickett
 ms.date: 07/19/2017

--- a/aspnetcore/security/authentication/identity-custom-storage-providers.md
+++ b/aspnetcore/security/authentication/identity-custom-storage-providers.md
@@ -2,7 +2,7 @@
 title: Custom storage providers for ASP.NET Core Identity | Microsoft Docs
 author: ardalis
 description: How to configure custom storage providers for ASP.NET Core Identity.
-keywords: ASP.NET Core, Identity, custom storage providers
+keywords: ASP.NET Core,Identity,custom storage providers
 ms.author: riande
 manager: wpickett
 ms.date: 05/24/2017

--- a/aspnetcore/security/authentication/identity-enable-qrcodes.md
+++ b/aspnetcore/security/authentication/identity-enable-qrcodes.md
@@ -2,7 +2,7 @@
 title: Enabling QR Code generation for authenticator apps in ASP.NET Core
 author: rick-anderson
 description: Enabling QR Code generation for authenticator apps in ASP.NET Core
-keywords: ASP.NET Core, MVC, QR Code generation, authenticator, 2FA
+keywords: ASP.NET Core,MVC,QR Code generation,authenticator,2FA
 ms.author: riande
 manager: wpickett
 ms.date: 07/24/2017

--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -2,7 +2,7 @@
 title: Introduction to Identity on ASP.NET Core
 author: rick-anderson
 description: Using Identity with an ASP.NET Core app
-keywords: ASP.NET Core, Identity, authorization, security
+keywords: ASP.NET Core,Identity,authorization,security
 ms.author: riande
 manager: wpickett
 ms.date: 07/07/2017

--- a/aspnetcore/security/authentication/social/index.md
+++ b/aspnetcore/security/authentication/social/index.md
@@ -2,7 +2,7 @@
 title: Enabling authentication using Facebook, Google and other external
 author: rick-anderson
 description: 
-keywords: ASP.NET Core, authentication, social, authentication providers, google, facebook, twitter, microsoft account
+keywords: ASP.NET Core,authentication,social,authentication providers,google,facebook,twitter,microsoft account
 ms.author: riande
 manager: wpickett
 ms.date: 11/01/2016

--- a/aspnetcore/security/authorization/secure-data.md
+++ b/aspnetcore/security/authorization/secure-data.md
@@ -1,7 +1,7 @@
 ---
 title: Create an ASP.NET Core app with user data protected by authorization
 author: rick-anderson
-keywords: ASP.NET Core, MVC, authorization, roles, security, administrator
+keywords: ASP.NET Core,MVC,authorization,roles,security,administrator
 ms.author: riande
 manager: wpickett
 ms.date: 05/22/2017

--- a/aspnetcore/security/data-protection/compatibility/cookie-sharing.md
+++ b/aspnetcore/security/data-protection/compatibility/cookie-sharing.md
@@ -2,7 +2,7 @@
 title: Sharing cookies between applications
 author: rick-anderson
 description: 
-keywords: ASP.NET Core, ASP.NET, cookies, Interop, cookie sharing
+keywords: ASP.NET Core,ASP.NET,cookies,Interop,cookie sharing
 ms.author: riande
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/security/data-protection/compatibility/replacing-machinekey.md
+++ b/aspnetcore/security/data-protection/compatibility/replacing-machinekey.md
@@ -2,7 +2,7 @@
 title: Replacing `<machineKey>` in ASP.NET
 author: rick-anderson
 description: Replacing `<machineKey>` in ASP.NET
-keywords: ASP.NET Core, security, `<machineKey>` 
+keywords: ASP.NET Core,security,<machineKey>,machineKey
 ms.author: riande
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/security/data-protection/configuration/default-settings.md
+++ b/aspnetcore/security/data-protection/configuration/default-settings.md
@@ -2,7 +2,7 @@
 title: Key management and lifetime
 author: rick-anderson
 description: Describes key management and lifetime.
-keywords: ASP.NET Core, key management, DPAPI, DataProtection
+keywords: ASP.NET Core,key management,DPAPI,DataProtection
 ms.author: riande
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/security/data-protection/implementation/key-storage-providers.md
+++ b/aspnetcore/security/data-protection/implementation/key-storage-providers.md
@@ -2,7 +2,7 @@
 title: Key storage providers
 author: rick-anderson
 description:  Key storage providers
-keywords: encryption, ASP.NET Core,
+keywords: encryption,ASP.NET Core
 ms.author: riande
 manager: wpickett
 ms.date: 01/14/2017

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -2,7 +2,7 @@
 title: Enforcing SSL in an ASP.NET Core app
 author: rick-anderson
 description: Shows how to require SSL in a ASP.NET Core web app
-keywords: ASP.NET Core, SSL, HTTPS, RequireHttpsAttribute, IIS Express
+keywords: ASP.NET Core,SSL,HTTPS,RequireHttpsAttribute,IIS Express
 ms.author: riande
 manager: wpickett
 ms.date: 07/19/2017

--- a/aspnetcore/security/https.md
+++ b/aspnetcore/security/https.md
@@ -2,7 +2,7 @@
 title: Setting up HTTPS for development in ASP.NET Core
 author: Rick-Anderson
 description: Shows how to set up HTTPS for development in ASP.NET Core 2.0.
-keywords: ASP.NET Core, SSL, HTTPS
+keywords: ASP.NET Core,SSL,HTTPS
 ms.author: riande
 manager: wpickett
 ms.date: 05/10/2017

--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -2,7 +2,7 @@
 title: Azure Key Vault configuration provider
 author: guardrex
 description: Learn how to use the Azure Key Vault Configuration Provider to configure an application using name-value pairs loaded at runtime.
-keywords: ASP.NET Core, configuration, Azure Key Vault
+keywords: ASP.NET Core,configuration,Azure Key Vault
 ms.author: riande
 manager: wpickett
 ms.date: 08/09/2017

--- a/aspnetcore/security/preventing-open-redirects.md
+++ b/aspnetcore/security/preventing-open-redirects.md
@@ -2,7 +2,7 @@
 title: Preventing Open Redirect Attacks in an ASP.NET Core app | Microsoft Docs
 author: ardalis
 description: Shows how to prevent open redirect attacks against an ASP.NET Core app
-keywords: ASP.NET Core, Security, Open Redirect Attack
+keywords: ASP.NET Core,Security,Open Redirect Attack
 ms.author: riande
 manager: wpickett
 ms.date: 07/07/2017

--- a/aspnetcore/testing/index.md
+++ b/aspnetcore/testing/index.md
@@ -2,7 +2,7 @@
 title: Testing and debugging ASP.NET Core
 author: ardalis
 description: Links to resources for testing and debugging ASP.NET Core applications.
-keywords: ASP.NET Core, unit testing, integration testing, controllers, debugging, remote debugging
+keywords: ASP.NET Core,unit testing,integration testing,controllers,debugging,remote debugging
 ms.author: riande
 manager: wpickett
 ms.date: 10/14/2016

--- a/aspnetcore/tutorials/dotnet-watch.md
+++ b/aspnetcore/tutorials/dotnet-watch.md
@@ -2,7 +2,7 @@
 title: Developing ASP.NET Core apps using dotnet watch
 author: rick-anderson
 description: Shows how to use dotnet watch.
-keywords: ASP.NET Core, using dotnet watch
+keywords: ASP.NET Core,using dotnet watch
 ms.author: riande
 manager: wpickett
 ms.date: 03/09/2017

--- a/aspnetcore/tutorials/first-mvc-app-mac/adding-controller.md
+++ b/aspnetcore/tutorials/first-mvc-app-mac/adding-controller.md
@@ -2,7 +2,7 @@
 title: Adding a controller to an ASP.NET Core MVC app
 author: rick-anderson 
 description: How to add a controller to a basic ASP.NET Core MVC app using Visual Studio of Mac
-keywords: ASP.NET Core, MVC, controller
+keywords: ASP.NET Core,MVC,controller
 ms.author: riande
 manager: wpickett
 ms.date: 06/28/2017

--- a/aspnetcore/tutorials/first-mvc-app-mac/adding-model.md
+++ b/aspnetcore/tutorials/first-mvc-app-mac/adding-model.md
@@ -2,7 +2,7 @@
 title: Add a model to an ASP.NET MVC Core app
 author: rick-anderson
 description: Add a model to a simple ASP.NET Core app.
-keywords: ASP.NET Core, MVC, scaffold, scaffolding
+keywords: ASP.NET Core,MVC,scaffold,scaffolding
 ms.author: riande
 manager: wpickett  
 ms.devlang: csharp 

--- a/aspnetcore/tutorials/first-mvc-app-mac/index.md
+++ b/aspnetcore/tutorials/first-mvc-app-mac/index.md
@@ -2,7 +2,7 @@
 title: Create a web app with ASP.NET Core MVC on a Mac
 author: rick-anderson
 description: Create an ASP.NET Core MVC / Entity Framework app with Visual Studio for Mac 
-keywords: ASP.NET Core, MVC, Entity Framework, Visual Studio
+keywords: ASP.NET Core,MVC,Entity Framework,Visual Studio
 ms.author: riande
 manager: wpickett
 ms.date: 06/26/2017

--- a/aspnetcore/tutorials/first-mvc-app-mac/new-field.md
+++ b/aspnetcore/tutorials/first-mvc-app-mac/new-field.md
@@ -4,7 +4,7 @@ uid: tutorials/first-mvc-app-mac/new-field
 title: Adding a New Field to an ASP.NET Core app
 author: rick-anderson
 description: Shows you how to add an new field to an exiting ASP.NET Core EF/MVC app.
-keywords: ASP.NET Core, EF migrations
+keywords: ASP.NET Core,EF migrations
 ms.author: riande
 manager: wpickett
 ms.date: 04/14/2017

--- a/aspnetcore/tutorials/first-mvc-app-mac/validation.md
+++ b/aspnetcore/tutorials/first-mvc-app-mac/validation.md
@@ -2,7 +2,7 @@
 title: Adding Validation to an ASP.NET Core app
 author: rick-anderson
 description: How to add validation to a simple ASP.NET Core app.
-keywords: ASP.NET Core, validation, DataAnnotations
+keywords: ASP.NET Core,validation,DataAnnotations
 ms.author: riande
 manager: wpickett
 ms.date: 06/13/2017

--- a/aspnetcore/tutorials/first-mvc-app-mac/working-with-sql.md
+++ b/aspnetcore/tutorials/first-mvc-app-mac/working-with-sql.md
@@ -2,7 +2,7 @@
 title: Working with SQLite and ASP.NET Core MVC 
 author: rick-anderson
 description: Using SQLite with a basic MVC app
-keywords: ASP.NET Core,SQLite, SQL Server 
+keywords: ASP.NET Core,SQLite,SQL Server
 ms.author: riande
 manager: wpickett
 ms.date: 04/07/2017

--- a/aspnetcore/tutorials/first-mvc-app-xplat/adding-controller.md
+++ b/aspnetcore/tutorials/first-mvc-app-xplat/adding-controller.md
@@ -2,7 +2,7 @@
 title: Adding a controller
 author: rick-anderson 
 description: How to add a controller to a simple ASP.NET Core MVC app
-keywords: ASP.NET Core, MVC
+keywords: ASP.NET Core,MVC
 ms.author: riande
 manager: wpickett
 ms.date: 02/28/2017

--- a/aspnetcore/tutorials/first-mvc-app-xplat/adding-model.md
+++ b/aspnetcore/tutorials/first-mvc-app-xplat/adding-model.md
@@ -8,7 +8,7 @@ ms.topic: get-started-article
 
 #ROBOTS:
 ms.technology: aspnet
-keywords: ASP.NET Core, WebAPI, Web API, REST, Mac, Linux,HTTP, Service, HTTP Service, VS Code
+keywords: ASP.NET Core,WebAPI,Web API,REST,Mac,Linux,HTTP,Service,HTTP Service,VS Code
 ms.prod: asp.net-core
 #ms.devlang: 
 manager: wpickett

--- a/aspnetcore/tutorials/first-mvc-app-xplat/adding-view.md
+++ b/aspnetcore/tutorials/first-mvc-app-xplat/adding-view.md
@@ -2,7 +2,7 @@
 title: Adding a view
 author: rick-anderson
 description: Adding a view to a simple ASP.NET Core MVC app
-keywords: ASP.NET Core, cli
+keywords: ASP.NET Core,cli
 ms.author: riande
 manager: wpickett
 ms.date: 03/30/2017

--- a/aspnetcore/tutorials/first-mvc-app-xplat/index.md
+++ b/aspnetcore/tutorials/first-mvc-app-xplat/index.md
@@ -2,7 +2,7 @@
 title: Create an ASP.NET Core MVC app with Visual Studio Code
 author: rick-anderson
 description: Index page for first ASP.NET Core MVC app with Visual Studio Code
-keywords: ASP.NET Core,MVC, Entity Framework, Visual Studio Code, VS Code
+keywords: ASP.NET Core,MVC,Entity Framework,Visual Studio Code,VS Code
 ms.author: riande
 manager: wpickett
 ms.date: 05/17/2017

--- a/aspnetcore/tutorials/first-mvc-app-xplat/new-field.md
+++ b/aspnetcore/tutorials/first-mvc-app-xplat/new-field.md
@@ -4,7 +4,7 @@ uid: tutorials/first-mvc-app-xplat/new-field
 title: Adding a New Field to an ASP.NET Core app
 author: rick-anderson
 description: Shows you how to add an new field to an exiting ASP.NET Core EF/MVC app.
-keywords: ASP.NET Core, EF migrations
+keywords: ASP.NET Core,EF migrations
 ms.author: riande
 manager: wpickett
 ms.date: 04/14/2017

--- a/aspnetcore/tutorials/first-mvc-app-xplat/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app-xplat/start-mvc.md
@@ -2,7 +2,7 @@
 title: Introduction to ASP.NET Core MVC on Mac, Linux, or Windows
 author: rick-anderson
 description: Getting started with ASP.NET Core MVC and Visual Studio Code on Mac, Linux, and Windows
-keywords: ASP.NET Core, MVC, VS Code, Visual Studio Code, Mac, Linux, Windows
+keywords: ASP.NET Core,MVC,VS Code,Visual Studio Code,Mac,Linux,Windows
 ms.author: riande
 manager: wpickett
 ms.date: 07/07/2017

--- a/aspnetcore/tutorials/first-mvc-app-xplat/validation.md
+++ b/aspnetcore/tutorials/first-mvc-app-xplat/validation.md
@@ -2,7 +2,7 @@
 title: Adding Validation
 author: rick-anderson
 description: How to add validation to a simple ASP.NET Core app.
-keywords: ASP.NET Core, validation, DataAnnotations
+keywords: ASP.NET Core,validation,DataAnnotations
 ms.author: riande
 manager: wpickett
 ms.date: 04/13/2017

--- a/aspnetcore/tutorials/first-mvc-app-xplat/working-with-sql.md
+++ b/aspnetcore/tutorials/first-mvc-app-xplat/working-with-sql.md
@@ -2,7 +2,7 @@
 title: Working with SQLite
 author: rick-anderson
 description: Using SQLite with a simple MVC app
-keywords: ASP.NET Core,SQLite, SQL Server 
+keywords: ASP.NET Core,SQLite,SQL Server
 ms.author: riande
 manager: wpickett
 ms.date: 04/07/2017

--- a/aspnetcore/tutorials/first-mvc-app/adding-controller.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-controller.md
@@ -2,7 +2,7 @@
 title: Adding a controller
 author: rick-anderson 
 description: How to add a controller to a simple ASP.NET Core MVC app
-keywords: ASP.NET Core, MVC
+keywords: ASP.NET Core,MVC
 ms.author: riande
 manager: wpickett
 ms.date: 02/28/2017

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc.md
@@ -2,7 +2,7 @@
 title: Getting started with ASP.NET Core MVC and Visual Studio
 author: rick-anderson
 description: Getting started with ASP.NET Core MVC and Visual Studio
-keywords: ASP.NET Core, MVC
+keywords: ASP.NET Core,MVC
 ms.author: riande
 manager: wpickett
 ms.date: 08/07/2017

--- a/aspnetcore/tutorials/first-mvc-app/validation.md
+++ b/aspnetcore/tutorials/first-mvc-app/validation.md
@@ -2,7 +2,7 @@
 title: Adding Validation
 author: rick-anderson
 description: How to add validation to an ASP.NET Core app.
-keywords: ASP.NET Core, validation, DataAnnotations
+keywords: ASP.NET Core,validation,DataAnnotations
 ms.author: riande
 manager: wpickett
 ms.date: 04/13/2017

--- a/aspnetcore/tutorials/first-mvc-app/working-with-sql.md
+++ b/aspnetcore/tutorials/first-mvc-app/working-with-sql.md
@@ -2,7 +2,7 @@
 title: Working with SQL Server LocalDB
 author: rick-anderson
 description: Using SQL Server LocalDB with a simple MVC app
-keywords: ASP.NET Core,SQL Server LocalDB, SQL Server, LocalDB 
+keywords: ASP.NET Core,SQL Server LocalDB,SQL Server,LocalDB
 ms.author: riande
 manager: wpickett
 ms.date: 03/07/2017

--- a/aspnetcore/tutorials/first-web-api-mac.md
+++ b/aspnetcore/tutorials/first-web-api-mac.md
@@ -11,7 +11,7 @@ helpviewer_heywords: ASP.NET Core, WebAPI, Web API, REST, mac, macOS, HTTP, Serv
 
 #ROBOTS: 
 ms.technology: aspnet
-keywords: ASP.NET Core, WebAPI, Web API, REST, mac, macOS, HTTP, Service, HTTP Service
+keywords: ASP.NET Core,WebAPI,Web API,REST,mac,macOS,HTTP,Service,HTTP Service
 #ms.devlang: [LANGUAGES]
 manager: wpickett
 ---

--- a/aspnetcore/tutorials/nano-server.md
+++ b/aspnetcore/tutorials/nano-server.md
@@ -2,7 +2,7 @@
 title: ASP.NET Core on Nano Server
 author: shirhatti
 description: Learn how to take an existing ASP.NET Core app and deploy it to a Nano Server instance running IIS.
-keywords: ASP.NET Core, nano server
+keywords: ASP.NET Core,nano server
 ms.author: riande
 manager: wpickett
 ms.date: 11/04/2016

--- a/aspnetcore/tutorials/razor-pages/sql.md
+++ b/aspnetcore/tutorials/razor-pages/sql.md
@@ -2,7 +2,7 @@
 title: Working with SQL Server LocalDB and ASP.NET Core
 author: rick-anderson
 description: Explains working with SQL Server LocalDB and ASP.NET Core.
-keywords: ASP.NET Core,Razor Pages,Razor,MVC, SQL, LocalDB
+keywords: ASP.NET Core,Razor Pages,Razor,MVC,SQL,LocalDB
 ms.author: riande
 manager: wpickett
 ms.date: 08/07/2017

--- a/aspnetcore/tutorials/web-api-vsc.md
+++ b/aspnetcore/tutorials/web-api-vsc.md
@@ -10,7 +10,7 @@ helpviewer_keywords: ASP.NET Core, WebAPI, Web API, REST, Mac, Linux,HTTP, Servi
 
 #ROBOTS:
 ms.technology: aspnet
-keywords: ASP.NET Core, WebAPI, Web API, REST, Mac, Linux,HTTP, Service, HTTP Service, VS Code
+keywords: ASP.NET Core,WebAPI,Web API,REST,Mac,Linux,HTTP,Service,HTTP Service,VS Code
 #ms.devlang: 
 manager: wpickett
 ms.assetid: 830b4bf5-dd14-423e-9f59-764a6f13a8f6


### PR DESCRIPTION
It's not super-critical that we do this, since parsers are supposed to trim the tokens of these strings, but why send the bytes? :smile:

[@]mairaw seemed to be making these consistent over in dotnet/docs, so I wondered if you'd like to do it globally over here. If not, please close this.