### PR TITLE
Clarify MySQL schema in topic example

### DIFF
--- a/aspnet/identity/overview/getting-started/aspnet-identity-using-mysql-storage-with-an-entityframework-mysql-provider/samples/sample6.cs
+++ b/aspnet/identity/overview/getting-started/aspnet-identity-using-mysql-storage-with-an-entityframework-mysql-provider/samples/sample6.cs
@@ -18,9 +18,7 @@ namespace IdentityMySQLDemo
       {
         // query to check if MigrationHistory table is present in the database 
         var migrationHistoryTableExists = ((IObjectContextAdapter)context).ObjectContext.ExecuteStoreQuery<int>(
-        string.Format(
-          "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '{0}' AND table_name = '__MigrationHistory'",
-          "[Insert your database schema here - such as 'users']"));
+          "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'IdentityMySQLDatabase' AND table_name = '__MigrationHistory'");
 
         // if MigrationHistory table is not there (which is the case first time we run) - create it
         if (migrationHistoryTableExists.FirstOrDefault() == 0)


### PR DESCRIPTION
Fixes #3260

[Review topic (internal only)](https://review.docs.microsoft.com/en-us/aspnet/identity/overview/getting-started/aspnet-identity-using-mysql-storage-with-an-entityframework-mysql-provider?branch=pr-en-us-4366)

@Kyoraku I've only very rarely ever used MySQL, but is this correct? Does this clarify the value?

```
"SELECT COUNT(*) 
          FROM information_schema.tables 
          WHERE table_schema = 'IdentityMySQLDatabase' AND table_name = '__MigrationHistory'"
```

In spite of the topic showing a MySQL Workbench screenshot with the name in lowercase, I think the guidance is that it should be provided the way it was created in the Azure portal. Although Windows is case insensitive, other systems (Unix) or certain Mac scenarios are case sensitive.

Original (unfixed) topic: https://docs.microsoft.com/aspnet/identity/overview/getting-started/aspnet-identity-using-mysql-storage-with-an-entityframework-mysql-provider