### PR TITLE
Remove note about calling AddAuthentcation multiple times

### DIFF
--- a/aspnetcore/security/authentication/social/microsoft-logins.md
+++ b/aspnetcore/security/authentication/social/microsoft-logins.md
@@ -85,8 +85,6 @@ services.AddAuthentication().AddMicrosoftAccount(microsoftOptions =>
 });
 ```
 
-The `AddAuthentication` method should only be called once when adding multiple authentication providers. Subsequent calls to it have the potential of overriding any previously configured [AuthenticationOptions](https://docs.microsoft.com/aspnet/core/api/microsoft.aspnetcore.builder.authenticationoptions) properties.
-
 # [ASP.NET Core 1.x](#tab/aspnetcore1x)
 
 Add the Microsoft Account middleware in the `Configure` method in *Startup.cs* file:


### PR DESCRIPTION
Discussed with @blowdart and @HaoK and it sounds like this warning isn't actually needed.