### PR TITLE
Remove unnecessary warnings from social auth docs

### DIFF
--- a/aspnetcore/security/authentication/social/facebook-logins.md
+++ b/aspnetcore/security/authentication/social/facebook-logins.md
@@ -81,8 +81,6 @@ services.AddAuthentication().AddFacebook(facebookOptions =>
 });
 ```
 
-The `AddAuthentication` method should only be called once when adding multiple authentication providers. Subsequent calls to it have the potential of overriding any previously configured [AuthenticationOptions](https://docs.microsoft.com/aspnet/core/api/microsoft.aspnetcore.builder.authenticationoptions) properties.
-
 # [ASP.NET Core 1.x](#tab/aspnetcore1x)
 
 Add the Facebook middleware in the `Configure` method in *Startup.cs* file:

--- a/aspnetcore/security/authentication/social/google-logins.md
+++ b/aspnetcore/security/authentication/social/google-logins.md
@@ -103,8 +103,6 @@ services.AddAuthentication().AddGoogle(googleOptions =>
 });
 ```
 
-The `AddAuthentication` method should only be called once when adding multiple authentication providers. Subsequent calls to it have the potential of overriding any previously configured [AuthenticationOptions](https://docs.microsoft.com/aspnet/core/api/microsoft.aspnetcore.builder.authenticationoptions) properties.
-
 # [ASP.NET Core 1.x](#tab/aspnetcore1x)
 
 Add the Google middleware in the `Configure` method in *Startup.cs* file:

--- a/aspnetcore/security/authentication/social/twitter-logins.md
+++ b/aspnetcore/security/authentication/social/twitter-logins.md
@@ -67,8 +67,6 @@ services.AddAuthentication().AddTwitter(twitterOptions =>
 });
 ```
 
-The `AddAuthentication` method should only be called once when adding multiple authentication providers. Subsequent calls to it have the potential of overriding any previously configured [AuthenticationOptions](https://docs.microsoft.com/aspnet/core/api/microsoft.aspnetcore.builder.authenticationoptions) properties.
-
 # [ASP.NET Core 1.x](#tab/aspnetcore1x)
 
 Add the Twitter middleware in the `Configure` method in *Startup.cs* file:


### PR DESCRIPTION
Applying the same change as https://github.com/aspnet/Docs/pull/4377 to the Twitter, Google, & Facebook social auth docs.