### PR TITLE
Update tooling links

### DIFF
--- a/aspnetcore/includes/make-ssl-cert.md
+++ b/aspnetcore/includes/make-ssl-cert.md
@@ -1,7 +1,4 @@
-For generating self-signed SSL certificates on Windows, you can use the PowerShell cmdlet [New-SelfSignedCertificate](https://technet.microsoft.com/itpro/powershell/windows/pki/new-selfsignedcertificate). There are also third-party tools that make it easier for you to generate self-signed certificates:
-
-* [SelfCert](https://www.pluralsight.com/blog/software-development/selfcert-create-a-self-signed-certificate-interactively-gui-or-programmatically-in-net)
-* [Makecert UI](http://makecertui.codeplex.com/)
+For generating self-signed SSL certificates on Windows, you can use the PowerShell cmdlet [New-SelfSignedCertificate](/powershell/module/pkiclient/new-selfsignedcertificate?view=win10-ps). For a third-party tool that makes it easier for you to generate self-signed certificates, see [SelfCert](https://www.pluralsight.com/blog/software-development/selfcert-create-a-self-signed-certificate-interactively-gui-or-programmatically-in-net).
 
 On macOS and Linux you can create a self-signed certificate using [OpenSSL](https://www.openssl.org/).
 


### PR DESCRIPTION
Fixes #4373 

@scottaddie @mairaw Looks like there's a bad 🐁 in the redirect 🕰️. The link:

> https://technet.microsoft.com/itpro/powershell/windows/pki/new-selfsignedcertificate

... redirects to ...

> https://docs.microsoft.com/powershell/module/pki/new-selfsignedcertificate

... but should go to ...

> https://docs.microsoft.com/powershell/module/pkiclient/new-selfsignedcertificate?view=win10-ps

... perhaps because it changed modules without an update to their redirect file.