### PR TITLE
Fix demo code for AddAuthentication.AddCookie

### DIFF
--- a/aspnetcore/security/authentication/cookie.md
+++ b/aspnetcore/security/authentication/cookie.md
@@ -40,7 +40,7 @@ Complete the following steps:
 
     ```csharp
     services.AddAuthentication("MyCookieAuthenticationScheme")
-            .AddCookie(options => {
+            .AddCookie("MyCookieAuthenticationScheme", options => {
                 options.AccessDeniedPath = "/Account/Forbidden/";
                 options.LoginPath = "/Account/Unauthorized/";
             });


### PR DESCRIPTION
In .Net Core 2.0 using the code as supplied results in an exception, the fix is to pass the scheme name when calling AddCookie.

Fails:
services.AddAuthentication("MyCookieAuthenticationScheme")
        .AddCookie

Works:
Fix demo code for services.AddAuthentication.AddCookie
services.AddAuthentication("MyCookieAuthenticationScheme")
        .AddCookie("MyCookieAuthenticationScheme",
