### PR TITLE
Add missing param to AddCookie call

### DIFF
--- a/aspnetcore/security/authentication/cookie.md
+++ b/aspnetcore/security/authentication/cookie.md
@@ -173,7 +173,7 @@ This would then be wired up during cookie service registration in the `Configure
 
 ```csharp
 services.AddAuthentication("MyCookieAuthenticationScheme")
-        .AddCookie(options =>
+        .AddCookie("MyCookieAuthenticationScheme", options =>
         {
             options.Events = new CookieAuthenticationEvents
             {


### PR DESCRIPTION
Adding a missing parameter to the `AddCookie` call, per Chris' request in https://github.com/aspnet/Docs/pull/4422.