### PR TITLE
Fix inadvertent uid change (typo)

### DIFF
--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -7,7 +7,7 @@
 # [Tutorials](tutorials/index.md)
 ## [Create a Razor Pages web app on Windows](xref:tutorials/razor-pages/index)
 ### [Getting started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start)
-### [Adding a model](xref:tutorials/razor-pages/modelz)
+### [Adding a model](xref:tutorials/razor-pages/model)
 ### [Scaffolded Razor Pages](xref:tutorials/razor-pages/page)
 ### [SQL Server LocalDB](xref:tutorials/razor-pages/sql)
 ### [Updating the pages](xref:tutorials/razor-pages/da1)

--- a/aspnetcore/tutorials/razor-pages/index.md
+++ b/aspnetcore/tutorials/razor-pages/index.md
@@ -16,7 +16,7 @@ uid: tutorials/razor-pages/index
 This series explains the basics of building a Razor Pages web app with ASP.NET Core using Visual Studio. For the Mac version, see [this](xref:tutorials/razor-pages-mac/index). For the Visual Studio Code version, see [this](xref:tutorials/razor-pages-vsc/index).
 
 1. [Getting started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start)
-1. [Adding a model to a Razor Pages app](xref:tutorials/razor-pages/modelz)
+1. [Adding a model to a Razor Pages app](xref:tutorials/razor-pages/model)
 1. [Scaffolded Razor Pages](xref:tutorials/razor-pages/page)
 1. [Working with SQL Server LocalDB](xref:tutorials/razor-pages/sql)
 1. [Updating the pages](xref:tutorials/razor-pages/da1)

--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -9,7 +9,7 @@ ms.date: 07/27/2017
 ms.topic: get-started-article
 ms.technology: aspnet
 ms.prod: aspnet-core
-uid: tutorials/razor-pages/modelz
+uid: tutorials/razor-pages/model
 ---
 # Adding a model to a Razor Pages app
 

--- a/aspnetcore/tutorials/razor-pages/page.md
+++ b/aspnetcore/tutorials/razor-pages/page.md
@@ -140,5 +140,5 @@ The [Input Tag Helper](xref:mvc/views/working-with-forms) (`<input asp-for="Movi
 The next tutorial explains SQL Server LocalDB and seeding the database.
 
 >[!div class="step-by-step"]
-[Previous: Adding a model](xref:tutorials/razor-pages/modelz)
+[Previous: Adding a model](xref:tutorials/razor-pages/model)
 [Next: SQL Server LocalDB](xref:tutorials/razor-pages/sql)

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start.md
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start.md
@@ -43,4 +43,4 @@ Press **F5** to run the app in debug mode or **Ctrl-F5** to run without attachin
 [!INCLUDE[razor-pages-start](../../includes/RP/razor-pages-start.md)]
 
 >[!div class="step-by-step"]
-[Next: Adding a model](xref:tutorials/razor-pages/modelz)
+[Next: Adding a model](xref:tutorials/razor-pages/model)


### PR DESCRIPTION
A trailing "z" was added in the following commit: https://github.com/aspnet/Docs/commit/d9ec19e5452af83648074db5d96c0a0f4f9e7f9a#diff-fd72d6004b543ea4d6849242cb8b45ea. Reverting, as there are references in the docset that still reference the old value without the "z".