### PR TITLE
Alter app cookie configuration code samples

### DIFF
--- a/aspnetcore/security/authentication/identity/sample/src/ASPNET-IdentityDemo-PrimaryKeysConfig/Startup.cs
+++ b/aspnetcore/security/authentication/identity/sample/src/ASPNET-IdentityDemo-PrimaryKeysConfig/Startup.cs
@@ -76,8 +76,9 @@ namespace webapptemplate
                 options.Cookies.ApplicationCookie.LogoutPath = "/Account/LogOff";
                 options.Cookies.ApplicationCookie.AccessDeniedPath = "/Account/AccessDenied";
                 options.Cookies.ApplicationCookie.AutomaticAuthenticate = true;
-                options.Cookies.ApplicationCookie.AuthenticationScheme = Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationDefaults.AuthenticationScheme;
-                options.Cookies.ApplicationCookie.ReturnUrlParameter = Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationDefaults.ReturnUrlParameter;
+                // Requires `using Microsoft.AspNetCore.Authentication.Cookies;`
+                options.Cookies.ApplicationCookie.AuthenticationScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                options.Cookies.ApplicationCookie.ReturnUrlParameter = CookieAuthenticationDefaults.ReturnUrlParameter;
                 
                 // User settings
                 options.User.RequireUniqueEmail = true;

--- a/aspnetcore/security/authentication/identity/sample/src/ASPNETv2-IdentityDemo-Configuration/Startup.cs
+++ b/aspnetcore/security/authentication/identity/sample/src/ASPNETv2-IdentityDemo-Configuration/Startup.cs
@@ -61,6 +61,8 @@ namespace WebApplication5
                 options.LogoutPath = "/Account/Logout";
                 options.AccessDeniedPath = "/Account/AccessDenied"; 
                 options.SlidingExpiration = true;
+                // Requires `using Microsoft.AspNetCore.Authentication.Cookies;`
+                options.ReturnUrlParameter = CookieAuthenticationDefaults.ReturnUrlParameter;
             });
             #endregion
 


### PR DESCRIPTION
- Shorten the 1.x `AuthenticationScheme` and `ReturnUrlParameter` setter lines to improve display
- Add missing `ReturnUrlParameter` setter line to 2.x sample. This makes it clear that the property still exists in 2.x.