### PR TITLE
Added @ symbol to make C# code work (typo fix)

### DIFF
--- a/aspnetcore/migration/1x-to-2x/samples/AspNetCoreDotNetFx2.0App/AspNetCoreDotNetFx2.0App/Views/Account/AccessDenied.cshtml
+++ b/aspnetcore/migration/1x-to-2x/samples/AspNetCoreDotNetFx2.0App/AspNetCoreDotNetFx2.0App/Views/Account/AccessDenied.cshtml
@@ -3,6 +3,6 @@
 }
 
 <header>
-    <h2 class="text-danger">ViewData["Title"]</h2>
+    <h2 class="text-danger">@ViewData["Title"]</h2>
     <p class="text-danger">You do not have access to this resource.</p>
 </header>


### PR DESCRIPTION
In line 6 an @ symbol was forgotten. This made ViewData["Title"] render in HTML instead of being parsed as C#.