### PR TITLE
2fa twilio sample

### DIFF
--- a/aspnetcore/security/authentication/2fa/sample/Web2FA/Services/MessageServices_twilio.cs
+++ b/aspnetcore/security/authentication/2fa/sample/Web2FA/Services/MessageServices_twilio.cs
@@ -34,11 +34,10 @@ namespace Web2FA.Services
 
             TwilioClient.Init(accountSid, authToken);
 
-            var msg = MessageResource.Create(
+            return MessageResource.CreateAsync(
               to: new PhoneNumber(number),
               from: new PhoneNumber(Options.SMSAccountFrom),
               body: message);
-            return Task.FromResult(0);
         }
     }
 }

--- a/aspnetcore/security/authentication/2fa/sample/Web2FA/Services/MessageServices_twilio.cs
+++ b/aspnetcore/security/authentication/2fa/sample/Web2FA/Services/MessageServices_twilio.cs
@@ -31,7 +31,6 @@ namespace Web2FA.Services
             var accountSid = Options.SMSAccountIdentification;
             // Your Auth Token from twilio.com/console
             var authToken = Options.SMSAccountPassword;
-            var 
 
             TwilioClient.Init(accountSid, authToken);
 


### PR DESCRIPTION
Removes a `var` declaration that would not compile.
Also changes the call to Twilio to use the async version and return the resulting Task.