### PR TITLE
Explicitly state .NET Core 2.x is a metapackage requirement

### DIFF
--- a/aspnetcore/fundamentals/metapackage.md
+++ b/aspnetcore/fundamentals/metapackage.md
@@ -14,7 +14,7 @@ uid: fundamentals/metapackage
 
 #Microsoft.AspNetCore.All metapackage for ASP.NET Core 2.x
 
-This feature requires ASP.NET Core 2.x.
+This feature requires ASP.NET Core 2.x targeting .NET Core 2.x.
 
 The [Microsoft.AspNetCore.All](https://www.nuget.org/packages/Microsoft.AspNetCore.All) metapackage for ASP.NET Core includes:
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/Docs/issues/4486