### PR TITLE
Removed a link from the Working With Multiple Environments Article

### DIFF
--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -22,7 +22,7 @@ ASP.NET Core provides support for controlling app behavior across multiple envir
 
 ## Development, Staging, Production
 
-ASP.NET Core references a particular [environment variable](https://github.com/aspnet/Home/wiki), `ASPNETCORE_ENVIRONMENT` to describe the environment the application is currently running in. This variable can be set to any value you like, but three values are used by convention: `Development`, `Staging`, and `Production`. You will find these values used in the samples and templates provided with ASP.NET Core.
+ASP.NET Core references a particular environment variable, `ASPNETCORE_ENVIRONMENT` to describe the environment the application is currently running in. This variable can be set to any value you like, but three values are used by convention: `Development`, `Staging`, and `Production`. You will find these values used in the samples and templates provided with ASP.NET Core.
 
 The current environment setting can be detected programmatically from within your application. In addition, you can use the Environment [tag helper](../mvc/views/tag-helpers/index.md) to include certain sections in your [view](../mvc/views/index.md) based on the current application environment.
 


### PR DESCRIPTION
As already noted by users IhorShnaider and Mike_DePouw_CEI in the comments on the actual Microsoft Docs page, this link just goes back to the wiki homepage, which isn't very helpful.  The proper fix would probably be to link to an article somewhere about environment variables, such as [Wikipedia's](https://en.wikipedia.org/wiki/Environment_variable), but I wasn't sure if there was some Microsoft-specific article that the author had in mind, so I just deleted the link.

Suggested reviewers:
@ardalis 