### PR TITLE
Add 2.0 App Insights migration instructions for .NET Framework

### DIFF
--- a/aspnetcore/migration/1x-to-2x/index.md
+++ b/aspnetcore/migration/1x-to-2x/index.md
@@ -158,11 +158,11 @@ Effortless setup of application performance instrumentation is important. You ca
 
 ASP.NET Core 1.1 projects created in Visual Studio 2017 added Application Insights by default. If you're not using the Application Insights SDK directly, outside of *Program.cs* and *Startup.cs*, follow these steps:
 
-1. Remove the following `<PackageReference />` node from the *.csproj* file:
+1. If targeting .NET Core, remove the following `<PackageReference />` node from the *.csproj* file:
     
     [!code-xml[Main](../1x-to-2x/samples/AspNetCoreDotNetCore1App/AspNetCoreDotNetCore1App/AspNetCoreDotNetCore1App.csproj?range=10)]
 
-2. Remove the `UseApplicationInsights` extension method invocation from *Program.cs*:
+2. If targeting .NET Core, remove the `UseApplicationInsights` extension method invocation from *Program.cs*:
 
     [!code-csharp[Main](../1x-to-2x/samples/AspNetCoreDotNetCore1App/AspNetCoreDotNetCore1App/Program.cs?name=snippet_ProgramCsMain&highlight=8)]
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/Docs/issues/4493

[Internal Review Page](https://review.docs.microsoft.com/aspnet/core/migration/1x-to-2x/index?branch=pr-en-us-4494#rely-on-application-insights-light-up-features)

/cc: @mrbullwinkle