### PR TITLE
Added "Parent culture" to the list of terms on the Globalization and Localization article

### DIFF
--- a/aspnetcore/fundamentals/localization.md
+++ b/aspnetcore/fundamentals/localization.md
@@ -314,6 +314,7 @@ Terms:
 * Culture: It is a language and, optionally, a region.
 * Neutral culture: A culture that has a specified language, but not a region. (for example "en", "es")
 * Specific culture: A culture that has a specified language and region. (for example "en-US", "en-GB", "es-CL")
+* Parent culture: The neutral culture that contains a specific culture. (for example, "en" is the parent culture of "en-US" and "en-GB")
 * Locale: A locale is the same as a culture.
 
 ## Additional resources


### PR DESCRIPTION
Given the presence of APIs like [`RequestLocalizationOptions.FallBackToParentCultures`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.requestlocalizationoptions.fallbacktoparentcultures?view=aspnetcore-2.0), it seemed appropriate to mention that specific cultures have "parent" neutral cultures.

Suggested reviewers:
* @Rick-Anderson 
* @damienbod 
* @hishamco 
