### PR TITLE
Add BuildBundlerMinifier to drop the Target

### DIFF
--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/RazorPagesMovie.csproj
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/RazorPagesMovie.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
+    <PackageReference Include="BuildBundlerMinifier" Version="2.5.357" />
   </ItemGroup>
 
   <ItemGroup>
@@ -16,10 +17,6 @@
 
   <Target Name="PreBuildScript" BeforeTargets="PrepareForBuild">
     <Exec Command="bower install" />
-  </Target>
-
-  <Target Name="PrePublishScript" BeforeTargets="PrepareForPublish">
-    <Exec Command="dotnet bundle" />
   </Target>
 
 </Project>

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/RazorPagesMovie.csproj
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/RazorPagesMovie.csproj
@@ -15,7 +15,7 @@
     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.5.357" />
   </ItemGroup>
 
-  <!-- For information on Bower, see https://bower.io/ and https://docs.microsoft.com/aspnet/core/client-side/bower
+  <!-- For information on Bower, see https://bower.io/ and https://docs.microsoft.com/aspnet/core/client-side/bower -->
   <Target Name="PreBuildScript" BeforeTargets="PrepareForBuild">
     <Exec Command="bower install" />
   </Target>

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/RazorPagesMovie.csproj
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/RazorPagesMovie.csproj
@@ -15,6 +15,7 @@
     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.5.357" />
   </ItemGroup>
 
+  <!-- For information on Bower, see https://bower.io/ and https://docs.microsoft.com/aspnet/core/client-side/bower
   <Target Name="PreBuildScript" BeforeTargets="PrepareForBuild">
     <Exec Command="bower install" />
   </Target>


### PR DESCRIPTION
Due to being an old skool Gulp dude, I wasn't aware that the light-up feature for `BundlerMinifier.Core` with `dotnet build` is to include the `BuildBundlerMinifier` package. This composes the project file better.

@Rick-Anderson @scottaddie In my spare time (i.e., not working on contract items), I'd like to run thru existing 2.0 samps and make sure that the ones with Bower and BundlerMinifier configuration (*bower.json*, *bundleconfig.json*) have the right bits to work properly x-tooling if that's ok with you. I'd propose to look at it this weekend, since some of the samples are broken for these features when not using VS, especially if you consider that the *.gitignore* locks out *lib* folders from samples.

[EDIT] ... and I'm a bit concerned that topics/samples don't call out the prereqs for the Bower install command to work. This PR includes a line that should cover it.