### PR TITLE
Fix @DateTime.Now reference not resolving

### DIFF
--- a/aspnetcore/getting-started.md
+++ b/aspnetcore/getting-started.md
@@ -38,7 +38,7 @@ uid: getting-started
 
 5. Browse to [http://localhost:5000](http://localhost:5000)
 
-6. Open *Pages/About.cshtml* and modify the page to display the message "Hello, world! The time on the server is @DateTime.Now":
+6. Open *Pages/About.cshtml* and modify the page to display the message "Hello, world! The time on the server is @DateTime.Now ":
 
     [!code-html[Main](getting-started/sample/getting-started/about.cshtml?highlight=9&range=1-9)]
 


### PR DESCRIPTION
xref resolution should end with a white space. 

This fix also fixed the broken localized content [here](https://docs.microsoft.com/zh-cn/aspnet/core/getting-started) due to bad xref resolution.
