### PR TITLE
Allow lib folder contents for samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,8 +206,6 @@ FakesAssemblies/
 *.opt
 
 project.lock.json
-**/sample/**/wwwroot/lib/
-**/samples/**/wwwroot/lib/
 __pycache__/
 
 #Mac OSX 


### PR DESCRIPTION
Due to the changes coming along for https://github.com/aspnet/templating/issues/48, samples will get *lib* folder static assets that Bower would have normally provided when the app is built/published.

Side Note: We'll also include bundled+minified styles and scripts that `BundlerMinifier.Core` would have produced for the app.

Therefore, new samples and existing sample updates should contain all of the static assets they need to run (*lib* folder and *.min.* CSS and JS files) and Bower+`BunderMinifier.Core` shouldn't be part of the app (no configuration files for these features and no targets and package+tooling references in the project file for these features).

cc/ @Rick-Anderson