### PR TITLE
fix illegal links

### DIFF
--- a/aspnetcore/security/authorization/policies.md
+++ b/aspnetcore/security/authorization/policies.md
@@ -16,7 +16,7 @@ uid: security/authorization/policies
 
 <a name=security-authorization-policies-based></a>
 
-Underneath the covers the [role authorization](roles.md#security-authorization-role-based) and [claims authorization](claims.md#security-authorization-claims-based) make use of a requirement, a handler for the requirement and a pre-configured policy. These building blocks allow you to express authorization evaluations in code, allowing for a richer, reusable, and easily testable authorization structure.
+Underneath the covers the [role authorization](roles.md) and [claims authorization](claims.md) make use of a requirement, a handler for the requirement and a pre-configured policy. These building blocks allow you to express authorization evaluations in code, allowing for a richer, reusable, and easily testable authorization structure.
 
 An authorization policy is made up of one or more requirements and registered at application startup as part of the Authorization service configuration, in `ConfigureServices` in the *Startup.cs* file.
 


### PR DESCRIPTION
[From build report](https://opbuildstorageprod.blob.core.windows.net/report/2017%5C10%5C13%5C6a0d29ae-bb37-09f1-c55a-4cfa862c6784%5CPullRequest%5C201710131248087361-4562%5Cworkflow_report.html?sv=2015-02-21&sr=b&sig=GbG0qgcJNtJMXYbbzHZqcp2BJNdAKtUYmbwoSscw5IY%3D&st=2017-10-13T12%3A50%3A41Z&se=2017-11-13T12%3A55%3A41Z&sp=r):

aspnetcore/security/authorization/policies.md
•	Line 19: [Warning] Illegal link: `[role authorization](roles.md#security-authorization-role-based)` -- missing bookmark. The file security/authorization/roles.md doesn't contain a bookmark named security-authorization-role-based. 
•	Line 19: [Warning] Illegal link: `[claims authorization](claims.md#security-authorization-claims-based)` -- missing bookmark. The file security/authorization/claims.md doesn't contain a bookmark named security-authorization-claims-based.

