### PR TITLE
Added info about calling generic methods to the Razor syntax topic

### DIFF
--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -19,7 +19,7 @@ Razor is a markup syntax for embedding server-based code into webpages. The Razo
 
 ## Rendering HTML
 
-The default Razor language is HTML. Rendering HTML from Razor markup is no different than rendering HTML from an HTML file. If you place HTML markup into a *.cshtml* Razor file, it's rendered by the server unchanged.
+The default Razor language is HTML. Rendering HTML from Razor markup is no different than rendering HTML from an HTML file.  HTML markup in *.cshtml* Razor file is rendered by the server unchanged.
 
 ## Razor syntax
 
@@ -54,7 +54,7 @@ Implicit Razor expressions start with `@` followed by C# code:
 <p>@DateTime.IsLeapYear(2016)</p>
 ```
 
-With the exception of the C# `await` keyword, implicit expressions must not contain spaces. If the C# statement has a clear ending, you can intermingle spaces:
+With the exception of the C# `await` keyword, implicit expressions must not contain spaces. If the C# statement has a clear ending, spaces can be intermingled:
 
 ```cshtml
 <p>@await DoSomething("hello", "world")</p>
@@ -185,7 +185,7 @@ The code renders the following HTML:
 
 ### Implicit transitions
 
-The default language in a code block is C#, but you can transition back to HTML:
+The default language in a code block is C#, but the Razor Page can transition back to HTML:
 
 ```cshtml
 @{
@@ -225,7 +225,7 @@ To render the rest of an entire line as HTML inside a code block, use the `@:` s
 }
 ```
 
-Without the `@:` in the code, you receive a Razor runtime error.
+Without the `@:` in the code,  a Razor runtime error is generated.
 
 Warning: Extra `@` characters in a Razor file can cause  cause compiler errors at statements later in the block. These compiler errors can be difficult to understand because the actual error occurs before the reported error.  This error is common after combining multiple implicit/explicit expressions into a single code block.
 
@@ -261,7 +261,7 @@ else
 }
 ```
 
-You can use a switch statement like the following code:
+The following markup shows how to use a switch statement:
 
 ```cshtml
 @switch (value)
@@ -280,7 +280,7 @@ You can use a switch statement like the following code:
 
 ### Looping @for, @foreach, @while, and @do while
 
-You can render templated HTML with looping control statements. To render a list of people:
+Templated HTML can be rendered with looping control statements.  To render a list of people:
 
 ```cshtml
 @{
@@ -293,7 +293,7 @@ You can render templated HTML with looping control statements. To render a list 
 }
 ```
 
-You can use any of the following looping statements:
+The following looping statements are supported:
 
 `@for`
 
@@ -346,7 +346,8 @@ You can use any of the following looping statements:
 
 ### Compound @using
 
-In C#, a `using` statement is used to ensure an object is disposed. In Razor, the same mechanism is used to create HTML Helpers that contain additional content. For instance, you can utilize HTML Helpers to render a form tag with the `@using` statement:
+In C#, a `using` statement is used to ensure an object is disposed. In Razor, the same mechanism is used to create HTML Helpers that contain additional content.  In the following code, HTML Helpers render a form tag with the `@using` statement:
+
 
 ```cshtml
 @using (Html.BeginForm())
@@ -359,7 +360,7 @@ In C#, a `using` statement is used to ensure an object is disposed. In Razor, th
 }
 ```
 
-You can also perform scope-level actions with [Tag Helpers](xref:mvc/views/tag-helpers/intro).
+Scope-level actions can be performed with [Tag Helpers](xref:mvc/views/tag-helpers/intro).
 
 ### @try, catch, finally
 
@@ -448,7 +449,7 @@ The `@model` directive specifies the type of the model passed to a view:
 @model TypeNameOfModel
 ```
 
-If you create an ASP.NET Core MVC app with individual user accounts, the *Views/Account/Login.cshtml* view contains the following model declaration:
+In an ASP.NET Core MVC app created with individual user accounts, the *Views/Account/Login.cshtml* view contains the following model declaration:
 
 ```cshtml
 @model LoginViewModel
@@ -466,11 +467,11 @@ Razor exposes a `Model` property for accessing the model passed to the view:
 <div>The Login Email: @Model.Email</div>
 ```
 
-The `@model` directive specifies the type of this property. The directive specifies the `T` in `RazorPage<T>` that the generated class that your view derives from. If you don't specify the `@model` directive, the `Model` property is of type `dynamic`. The value of the model is passed from the controller to the view. For more information, see [Strongly typed models and the @model keyword.
+The `@model` directive specifies the type of this property. The directive specifies the `T` in `RazorPage<T>` that the generated class that the view derives from. If  the `@model` directive is not specified, the `Model` property is of type `dynamic`. The value of the model is passed from the controller to the view. For more information, see [Strongly typed models and the @model keyword.
 
 ### @inherits
 
-The `@inherits` directive gives you full control of the class your view inherits:
+The `@inherits` directive provides  full control of the class the view inherits:
 
 ```cshtml
 @inherits TypeNameOfClassToInheritFrom
@@ -490,7 +491,7 @@ The code renders the following HTML:
 <div>Custom text: Gardyloo! - A Scottish warning yelled from a window before dumping a slop bucket on the street below.</div>
 ```
 
-You can't use `@model` and `@inherits` in the same view. You can have `@inherits` in a *_ViewImports.cshtml* file that the view imports:
+ `@model` and `@inherits` can be used in the same view.  `@inherits` can be in a *_ViewImports.cshtml* file that the view imports:
 
 [!code-cshtml[Main](razor/sample/Views/_ViewImportsModel.cshtml)]
 
@@ -507,11 +508,12 @@ If "rick@contoso.com" is passed in the model, the view generates the following H
 
 ### @inject
 
-The `@inject` directive enables you to inject a service from your [service container](xref:fundamentals/dependency-injection) into your view. For more information, see [Dependency injection into views](xref:mvc/views/dependency-injection).
+
+The `@inject` directive enables the Razor Page to inject a service from the [service container](xref:fundamentals/dependency-injection) into a view. For more information, see [Dependency injection into views](xref:mvc/views/dependency-injection).
 
 ### @functions
 
-The `@functions` directive enables you to add function-level content to a view:
+The `@functions` directive enables a Razor Page to add function-level content to a view:
 
 ```cshtml
 @functions { // C# Code }
@@ -584,7 +586,7 @@ C# Razor keywords must be double-escaped with `@(@C# Razor Keyword)` (for exampl
 
 ## Viewing the Razor C# class generated for a view
 
-Add the following class to your ASP.NET Core MVC project:
+Add the following class to the ASP.NET Core MVC project:
 
 [!code-csharp[Main](razor/sample/Utilities/CustomTemplateEngine.cs)]
 
@@ -610,4 +612,4 @@ Developers are encouraged to match the casing of file and directory names to the
     * Area, controller, and action names. 
     * Razor Pages.
     
-Matching case ensures your deployments find their views regardless of the underlying file system.
+Matching case ensures the deployments find their views regardless of the underlying file system.

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -60,13 +60,13 @@ With the exception of the C# `await` keyword, implicit expressions must not cont
 <p>@await DoSomething("hello", "world")</p>
 ```
 
-Implicit expressions may not contain C# generics, as the characters inside the brackets (`<>`) would be interpreted as an HTML tag:
+Implicit expressions can't contain C# generics, as the characters inside the brackets (`<>`) are interpreted as an HTML tag:
 
 ```cshtml
 <p>@GenericMethod<int>()</p>
 ```
 
-The code generates a compiler error like `The "int" element was not closed.  All elements must be either self-closing or have a matching end tag` or `Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?`  Instead, generic method calls must be wrapped in an [explicit Razor expression](#explicit-razor-expressions) or a [Razor code block](#razor-code-blocks).  Note that this restriction does not apply to _.vbhtml_ Razor files, because Visual Basic syntax places parentheses around generic type parameters instead of brackets.
+The code generates a compiler error like `The "int" element was not closed.  All elements must be either self-closing or have a matching end tag` or `Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?` Instead, generic method calls must be wrapped in an [explicit Razor expression](#explicit-razor-expressions) or a [Razor code block](#razor-code-blocks). Note that this restriction doesn't apply to *.vbhtml* Razor files because Visual Basic syntax places parentheses around generic type parameters instead of brackets.
 
 ## Explicit Razor expressions
 
@@ -100,19 +100,19 @@ You can use an explicit expression to concatenate text with an expression result
 
 Without the explicit expression, `<p>Age@joe.Age</p>` is treated as an email address, and `<p>Age@joe.Age</p>` is rendered. When written as an explicit expression, `<p>Age33</p>` is rendered.
 
-You can also use explicit expressions to render output from generic methods in _.cshtml_ files.  In an implicit expression, the characters inside the brackets (`<>`) would be interpreted as an HTML tag:
+You can also use explicit expressions to render output from generic methods in *.cshtml* files. In an implicit expression, the characters inside the brackets (`<>`) are interpreted as an HTML tag:
 
 ```cshtml
 <p>@GenericMethod<int>()</p>
 ```
 
-The code generates a compiler error like `The "int" element was not closed.  All elements must be either self-closing or have a matching end tag` or `Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?`  However, when written as an explicit expression, the generic method's output will compile correctly.  
+The code generates a compiler error like `The "int" element was not closed.  All elements must be either self-closing or have a matching end tag` or `Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?` When written as an explicit expression, the generic method's output compiles correctly.
 
 ```cshtml
 <p>@(GenericMethod<int>())</p>
 ```
 
-Note that this restriction does not apply to _.vbhtml_ Razor files, because Visual Basic syntax places parentheses around generic type parameters instead of brackets.
+Note that this restriction doesn't apply to *.vbhtml* Razor files because Visual Basic syntax places parentheses around generic type parameters instead of brackets.
 
 ## Expression encoding
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -19,7 +19,7 @@ Razor is a markup syntax for embedding server-based code into webpages. The Razo
 
 ## Rendering HTML
 
-The default Razor language is HTML. Rendering HTML from Razor markup is no different than rendering HTML from an HTML file.  HTML markup in *.cshtml* Razor file is rendered by the server unchanged.
+The default Razor language is HTML. Rendering HTML from Razor markup is no different than rendering HTML from an HTML file.  HTML markup in *.cshtml* Razor files is rendered by the server unchanged.
 
 ## Razor syntax
 
@@ -66,9 +66,10 @@ Implicit expressions **cannot** contain C# generics, as the characters inside th
 <p>@GenericMethod<int>()</p>
 ```
 
-The preceding code generates a compiler error similar to the following:
+The preceding code generates a compiler error similar to one of the following:
 
-* The "int" element was not closed.  All elements must be either self-closing or have a matching end tag or Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?
+ * The "int" element was not closed.  All elements must be either self-closing or have a matching end tag.
+ *  Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?` 
  
 Generic method calls must be wrapped in an [explicit Razor expression](#explicit-razor-expressions) or a [Razor code block](#razor-code-blocks). This restriction doesn't apply to *.vbhtml* Razor files because Visual Basic syntax places parentheses around generic type parameters instead of brackets.
 
@@ -111,9 +112,10 @@ Explicit expressions can be used to render output from generic methods in *.csht
 <p>@GenericMethod<int>()</p>
 ```
 
-The preceding code generates a compiler error similar to the following:
+The preceding code generates a compiler error similar to one of the following:
 
- The "int" element was not closed.  All elements must be either self-closing or have a matching end tag or Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?` 
+ * The "int" element was not closed.  All elements must be either self-closing or have a matching end tag.
+ *  Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?` 
  
  The following markup shows the correct way write this code.  The code is written as an explicit expression:
 
@@ -346,7 +348,7 @@ The following looping statements are supported:
 
 ### Compound @using
 
-In C#, a `using` statement is used to ensure an object is disposed. In Razor, the same mechanism is used to create HTML Helpers that contain additional content.  In the following code, HTML Helpers render a form tag with the `@using` statement:
+In C#, a `using` statement is used to ensure an object is disposed. In Razor, the same mechanism is used to create HTML Helpers that contain additional content. In the following code, HTML Helpers render a form tag with the `@using` statement:
 
 
 ```cshtml
@@ -467,7 +469,7 @@ Razor exposes a `Model` property for accessing the model passed to the view:
 <div>The Login Email: @Model.Email</div>
 ```
 
-The `@model` directive specifies the type of this property. The directive specifies the `T` in `RazorPage<T>` that the generated class that the view derives from. If  the `@model` directive is not specified, the `Model` property is of type `dynamic`. The value of the model is passed from the controller to the view. For more information, see [Strongly typed models and the @model keyword.
+The `@model` directive specifies the type of this property. The directive specifies the `T` in `RazorPage<T>` that the generated class that the view derives from. If  the `@model` directive iisn't specified, the `Model` property is of type `dynamic`. The value of the model is passed from the controller to the view. For more information, see [Strongly typed models and the @model keyword.
 
 ### @inherits
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -60,6 +60,14 @@ With the exception of the C# `await` keyword, implicit expressions must not cont
 <p>@await DoSomething("hello", "world")</p>
 ```
 
+Implicit expressions may not contain C# generics, as the characters inside the brackets (`<>`) would be interpreted as an HTML tag:
+
+```cshtml
+<p>@GenericMethod<int>()</p>
+```
+
+The code generates a compiler error like `The "int" element was not closed.  All elements must be either self-closing or have a matching end tag` or `Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?`  Instead, generic method calls must be wrapped in an [explicit Razor expression](#explicit-razor-expressions) or a [Razor code block](#razor-code-blocks).  Note that this restriction does not apply to _.vbhtml_ Razor files, because Visual Basic syntax places parentheses around generic type parameters instead of brackets.
+
 ## Explicit Razor expressions
 
 Explicit Razor expressions consist of an `@` symbol with balanced parenthesis. To render last week's time, the following Razor markup is used:
@@ -91,6 +99,20 @@ You can use an explicit expression to concatenate text with an expression result
 ```
 
 Without the explicit expression, `<p>Age@joe.Age</p>` is treated as an email address, and `<p>Age@joe.Age</p>` is rendered. When written as an explicit expression, `<p>Age33</p>` is rendered.
+
+You can also use explicit expressions to render output from generic methods in _.cshtml_ files.  In an implicit expression, the characters inside the brackets (`<>`) would be interpreted as an HTML tag:
+
+```cshtml
+<p>@GenericMethod<int>()</p>
+```
+
+The code generates a compiler error like `The "int" element was not closed.  All elements must be either self-closing or have a matching end tag` or `Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?`  However, when written as an explicit expression, the generic method's output will compile correctly.  
+
+```cshtml
+<p>@(GenericMethod<int>())</p>
+```
+
+Note that this restriction does not apply to _.vbhtml_ Razor files, because Visual Basic syntax places parentheses around generic type parameters instead of brackets.
 
 ## Expression encoding
 
@@ -192,6 +214,9 @@ To render the rest of an entire line as HTML inside a code block, use the `@:` s
 ```
 
 Without the `@:` in the code, you recieve a Razor runtime error.
+
+> [!WARNING]
+> Be sure to remove superfluous `@` characters from code blocks, as they can cause compiler errors at statements later in the block (such as generic method calls in _.cshtml_ files).  This error is common after combining multiple implicit/explicit expressions into a single code block.
 
 ## Control Structures
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -1,11 +1,11 @@
 ---
 title: Razor syntax reference for ASP.NET Core
-author: guardrex
+author: rick-anderson
 description: Learn about Razor markup syntax for embedding server-based code into webpages.
 keywords: ASP.NET Core,Razor,Razor directives
 ms.author: riande
 manager: wpickett
-ms.date: 09/29/2017
+ms.date: 10/18/2017
 ms.topic: article
 ms.technology: aspnet
 ms.prod: asp.net-core
@@ -13,7 +13,7 @@ uid: mvc/views/razor
 ---
 # Razor syntax for ASP.NET Core
 
-By [Rick Anderson](https://twitter.com/RickAndMSFT), [Luke Latham](https://github.com/guardrex), and [Taylor Mullen](https://twitter.com/ntaylormullen)
+By [Rick Anderson](https://twitter.com/RickAndMSFT), [Luke Latham](https://github.com/guardrex),  [Taylor Mullen](https://twitter.com/ntaylormullen), and [Dan Vicarel](https://github.com/Rabadash8820)
 
 Razor is a markup syntax for embedding server-based code into webpages. The Razor syntax consists of Razor markup, C#, and HTML. Files containing Razor generally have a *.cshtml* file extension.
 
@@ -54,19 +54,23 @@ Implicit Razor expressions start with `@` followed by C# code:
 <p>@DateTime.IsLeapYear(2016)</p>
 ```
 
-With the exception of the C# `await` keyword, implicit expressions must not contain spaces. You can intermingle spaces if the C# statement has a clear ending:
+With the exception of the C# `await` keyword, implicit expressions must not contain spaces. If the C# statement has a clear ending, you can intermingle spaces:
 
 ```cshtml
 <p>@await DoSomething("hello", "world")</p>
 ```
 
-Implicit expressions can't contain C# generics, as the characters inside the brackets (`<>`) are interpreted as an HTML tag:
+Implicit expressions **cannot** contain C# generics, as the characters inside the brackets (`<>`) are interpreted as an HTML tag. The following code is **not** valid:
 
 ```cshtml
 <p>@GenericMethod<int>()</p>
 ```
 
-The code generates a compiler error like `The "int" element was not closed.  All elements must be either self-closing or have a matching end tag` or `Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?` Instead, generic method calls must be wrapped in an [explicit Razor expression](#explicit-razor-expressions) or a [Razor code block](#razor-code-blocks). Note that this restriction doesn't apply to *.vbhtml* Razor files because Visual Basic syntax places parentheses around generic type parameters instead of brackets.
+The preceding code generates a compiler error similar to the following:
+
+* The "int" element was not closed.  All elements must be either self-closing or have a matching end tag or Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?
+ 
+Generic method calls must be wrapped in an [explicit Razor expression](#explicit-razor-expressions) or a [Razor code block](#razor-code-blocks). This restriction doesn't apply to *.vbhtml* Razor files because Visual Basic syntax places parentheses around generic type parameters instead of brackets.
 
 ## Explicit Razor expressions
 
@@ -88,7 +92,7 @@ The code renders the following HTML:
 <p>Last week: 7/7/2016 4:39:52 PM - TimeSpan.FromDays(7)</p>
 ```
 
-You can use an explicit expression to concatenate text with an expression result:
+Explicit expressions can be used to concatenate text with an expression result:
 
 ```cshtml
 @{
@@ -100,19 +104,24 @@ You can use an explicit expression to concatenate text with an expression result
 
 Without the explicit expression, `<p>Age@joe.Age</p>` is treated as an email address, and `<p>Age@joe.Age</p>` is rendered. When written as an explicit expression, `<p>Age33</p>` is rendered.
 
-You can also use explicit expressions to render output from generic methods in *.cshtml* files. In an implicit expression, the characters inside the brackets (`<>`) are interpreted as an HTML tag:
+
+Explicit expressions can be used to render output from generic methods in *.cshtml* files. In an implicit expression, the characters inside the brackets (`<>`) are interpreted as an HTML tag. The following markup is **not** valid Razor:
 
 ```cshtml
 <p>@GenericMethod<int>()</p>
 ```
 
-The code generates a compiler error like `The "int" element was not closed.  All elements must be either self-closing or have a matching end tag` or `Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?` When written as an explicit expression, the generic method's output compiles correctly.
+The preceding code generates a compiler error similar to the following:
+
+ The "int" element was not closed.  All elements must be either self-closing or have a matching end tag or Cannot convert method group 'GenericMethod' to non-delegate type 'object'. Did you intend to invoke the method?` 
+ 
+ The following markup shows the correct way write this code.  The code is written as an explicit expression:
 
 ```cshtml
 <p>@(GenericMethod<int>())</p>
 ```
 
-Note that this restriction doesn't apply to *.vbhtml* Razor files because Visual Basic syntax places parentheses around generic type parameters instead of brackets.
+Note: this restriction doesn't apply to *.vbhtml* Razor files.  With *.vbhtml* Razor files, Visual Basic syntax places parentheses around generic type parameters instead of brackets.
 
 ## Expression encoding
 
@@ -187,7 +196,7 @@ The default language in a code block is C#, but you can transition back to HTML:
 
 ### Explicit delimited transition
 
-To define a sub-section of a code block that should render HTML, surround the characters for rendering with the Razor **\<text>** tag:
+To define a subsection of a code block that should render HTML, surround the characters for rendering with the Razor **\<text>** tag:
 
 ```cshtml
 @for (var i = 0; i < people.Length; i++)
@@ -197,9 +206,12 @@ To define a sub-section of a code block that should render HTML, surround the ch
 }
 ```
 
-Use this approach when you want to render HTML that isn't surrounded by an HTML tag. Without an HTML or Razor tag, you receive a Razor runtime error.
+Use this approach to render HTML that isn't surrounded by an HTML tag. Without an HTML or Razor tag, a Razor runtime error occurs.
 
-The **\<text>** tag is also useful to control whitespace when rendering content. Only the content between the **\<text>** tags is rendered, and no whitespace before or after the **\<text>** tags appears in the HTML output.
+The **\<text>** tag is useful to control whitespace when rendering content:
+
+* Only the content between the **\<text>** tag is rendered. 
+* No whitespace before or after the **\<text>** tag appears in the HTML output.
 
 ### Explicit Line Transition with @:
 
@@ -213,14 +225,13 @@ To render the rest of an entire line as HTML inside a code block, use the `@:` s
 }
 ```
 
-Without the `@:` in the code, you recieve a Razor runtime error.
+Without the `@:` in the code, you receive a Razor runtime error.
 
-> [!WARNING]
-> Be sure to remove superfluous `@` characters from code blocks, as they can cause compiler errors at statements later in the block (such as generic method calls in _.cshtml_ files).  This error is common after combining multiple implicit/explicit expressions into a single code block.
+Warning: Extra `@` characters in a Razor file can cause  cause compiler errors at statements later in the block. These compiler errors can be difficult to understand because the actual error occurs before the reported error.  This error is common after combining multiple implicit/explicit expressions into a single code block.
 
 ## Control Structures
 
-Control structures are an extension of code blocks. All aspects of code blocks (transitioning to markup, inline C#) also apply to the following structures.
+Control structures are an extension of code blocks. All aspects of code blocks (transitioning to markup, inline C#) also apply to the following structures:
 
 ### Conditionals @if, else if, else, and @switch
 
@@ -250,7 +261,7 @@ else
 }
 ```
 
-You can use a switch statement like this:
+You can use a switch statement like the following code:
 
 ```cshtml
 @switch (value)
@@ -455,7 +466,7 @@ Razor exposes a `Model` property for accessing the model passed to the view:
 <div>The Login Email: @Model.Email</div>
 ```
 
-The `@model` directive specifies the type of this property. The directive specifies the `T` in `RazorPage<T>` that the generated class that your view derives from. If you don't specify the `@model` directive, the `Model` property is of type `dynamic`. The value of the model is passed from the controller to the view. See [Strongly typed models and the @model keyword](xref:tutorials/first-mvc-app/adding-model#strongly-typed-models-keyword-label) for more information.
+The `@model` directive specifies the type of this property. The directive specifies the `T` in `RazorPage<T>` that the generated class that your view derives from. If you don't specify the `@model` directive, the `Model` property is of type `dynamic`. The value of the model is passed from the controller to the view. For more information, see [Strongly typed models and the @model keyword.
 
 ### @inherits
 
@@ -465,7 +476,7 @@ The `@inherits` directive gives you full control of the class your view inherits
 @inherits TypeNameOfClassToInheritFrom
 ```
 
-The following is a custom Razor page type:
+The following code is a custom Razor page type:
 
 [!code-csharp[Main](razor/sample/Classes/CustomRazorPage.cs)]
 
@@ -483,7 +494,7 @@ You can't use `@model` and `@inherits` in the same view. You can have `@inherits
 
 [!code-cshtml[Main](razor/sample/Views/_ViewImportsModel.cshtml)]
 
-The following is an example of a strongly-typed view:
+The following code is an example of a strongly-typed view:
 
 [!code-cshtml[Main](razor/sample/Views/Home/Login1.cshtml)]
 
@@ -496,7 +507,7 @@ If "rick@contoso.com" is passed in the model, the view generates the following H
 
 ### @inject
 
-The `@inject` directive enables you to inject a service from your [service container](xref:fundamentals/dependency-injection) into your view. See [Dependency injection into views](xref:mvc/views/dependency-injection) for more information.
+The `@inject` directive enables you to inject a service from your [service container](xref:fundamentals/dependency-injection) into your view. For more information, see [Dependency injection into views](xref:mvc/views/dependency-injection).
 
 ### @functions
 
@@ -522,7 +533,7 @@ The following code is the generated Razor C# class:
 
 ### @section
 
-The `@section` directive is used in conjunction with the [layout](xref:mvc/views/layout) to enable views to render content in different parts of the HTML page. See [Sections](xref:mvc/views/layout#layout-sections-label) for more information.
+The `@section` directive is used in conjunction with the [layout](xref:mvc/views/layout) to enable views to render content in different parts of the HTML page. For more information, see [Sections](xref:mvc/views/layout#layout-sections-label).
 
 ## Tag Helpers
 
@@ -591,7 +602,12 @@ The Razor view engine performs case-sensitive lookups for views. However, the ac
 
 * File based source: 
   * On operating systems with case insensitive file systems (for example, Windows), physical file provider lookups are case insensitive. For example, `return View("Test")` results in matches for */Views/Home/Test.cshtml*, */Views/home/test.cshtml*, and any other casing variant.
-  * On case sensitive file systems (for example, Linux, OSX, and with `EmbeddedFileProvider`), lookups are case sensitive. For example, `return View("Test")` specifically matches */Views/Home/Test.cshtml*.
+  * On case-sensitive file systems (for example, Linux, OSX, and with `EmbeddedFileProvider`), lookups are case-sensitive. For example, `return View("Test")` specifically matches */Views/Home/Test.cshtml*.
 * Precompiled views: With ASP.Net Core 2.0 and later, looking up precompiled views is case insensitive on all operating systems. The behavior is identical to physical file provider's behavior on Windows. If two precompiled views differ only in case, the result of lookup is non-deterministic.
 
-Developers are encouraged to match the casing of file and directory names to the casing of area, controller, and action names. This ensures your deployments will find their views regardless of the underlying file system.
+Developers are encouraged to match the casing of file and directory names to the casing of:
+
+    * Area, controller, and action names. 
+    * Razor Pages.
+    
+Matching case ensures your deployments find their views regardless of the underlying file system.


### PR DESCRIPTION
Most of the necessary background on this PR is provided in an Issue that I created, linked below:

Fixes #4575

I wasn't quite sure on the syntax for relative links to sections within the same topic, so someone will want to review those.

## Suggested Reviewers
- @Rick-Anderson 
- @guardrex 
- @NTaylorMullen 
