### PR TITLE
Broken link fixed.

### DIFF
--- a/aspnetcore/security/authentication/index.md
+++ b/aspnetcore/security/authentication/index.md
@@ -38,6 +38,6 @@ uid: security/authentication/index
 
   * [Calling a Web API in an ASP.NET Core Web Application Using Azure AD](https://azure.microsoft.com/documentation/samples/active-directory-dotnet-webapp-webapi-openidconnect-aspnetcore/)
 
-* [Securing ASP.NET Core apps with IdentityServer4](https://identityserver4.readthedocs.io/release/)
+* [Securing ASP.NET Core apps with IdentityServer4](http://docs.identityserver.io/en/release/)
 
 * [Securing ASP.NET Core apps with Azure App Service Authentication (Easy Auth)](https://docs.microsoft.com/azure/app-service/app-service-authentication-overview)

--- a/aspnetcore/security/authentication/index.md
+++ b/aspnetcore/security/authentication/index.md
@@ -38,6 +38,6 @@ uid: security/authentication/index
 
   * [Calling a Web API in an ASP.NET Core Web Application Using Azure AD](https://azure.microsoft.com/documentation/samples/active-directory-dotnet-webapp-webapi-openidconnect-aspnetcore/)
 
-* [Securing ASP.NET Core apps with IdentityServer4](http://docs.identityserver.io/en/release/)
+* [Securing ASP.NET Core apps with IdentityServer4](http://docs.identityserver.io/release/)
 
 * [Securing ASP.NET Core apps with Azure App Service Authentication (Easy Auth)](https://docs.microsoft.com/azure/app-service/app-service-authentication-overview)

--- a/aspnetcore/security/authentication/index.md
+++ b/aspnetcore/security/authentication/index.md
@@ -38,6 +38,6 @@ uid: security/authentication/index
 
   * [Calling a Web API in an ASP.NET Core Web Application Using Azure AD](https://azure.microsoft.com/documentation/samples/active-directory-dotnet-webapp-webapi-openidconnect-aspnetcore/)
 
-* [Securing ASP.NET Core apps with IdentityServer4](http://docs.identityserver.io/release/)
+* [Securing ASP.NET Core apps with IdentityServer4](http://docs.identityserver.io/en/release/)
 
 * [Securing ASP.NET Core apps with Azure App Service Authentication (Easy Auth)](https://docs.microsoft.com/azure/app-service/app-service-authentication-overview)


### PR DESCRIPTION
The the link to "Securing ASP.NET Core apps with IdentityServer4" was broken. The link was replaced with a working one.