### PR TITLE
Move FileUpload step to the top

### DIFF
--- a/aspnetcore/tutorials/razor-pages/uploading-files.md
+++ b/aspnetcore/tutorials/razor-pages/uploading-files.md
@@ -21,6 +21,14 @@ The [Razor Pages Movie sample app](https://github.com/aspnet/Docs/tree/master/as
 
 In the steps below, you add a movie schedule file upload feature to the sample app. A movie schedule is represented by a `Schedule` class. The class includes two versions of the schedule. One version is provided to customers, `PublicSchedule`. The other version is used for company employees, `PrivateSchedule`. Each version is uploaded as a separate file. The tutorial demonstrates how to perform two file uploads from a page with a single POST to the server.
 
+## Add a FileUpload class
+
+Below, you create a Razor page to handle a pair of file uploads. Add a `FileUpload` class, which is bound to the page to obtain the schedule data. Right click the *Models* folder. Select **Add** > **Class**. Name the class **FileUpload** and add the following properties:
+
+[!code-csharp[Main](razor-pages-start/sample/RazorPagesMovie/Models/FileUpload.cs)]
+
+The class has a property for the schedule's title and a property for each of the two versions of the schedule. All three properties are required, and the title must be 3-60 characters long.
+
 ## Add a helper method to upload files
 
 To avoid code duplication for processing uploaded schedule files, add a static helper method first. Create a *Utilities* folder in the app and add a *FileHelpers.cs* file with the following content. The helper method, `ProcessFormFile`, takes an [IFormFile](/dotnet/api/microsoft.aspnetcore.http.iformfile) and [ModelStateDictionary](/api/microsoft.aspnetcore.mvc.modelbinding.modelstatedictionary) and returns a string containing the file's size and content. The content type and length are checked. If the file doesn't pass a validation check, an error is added to the `ModelState`.
@@ -53,14 +61,6 @@ In the PMC, execute the following commands. These commands add a `Schedule` tabl
 Add-Migration AddScheduleTable
 Update-Database
 ```
-
-## Add a FileUpload class
-
-Next, add a `FileUpload` class, which is bound to the page to obtain the schedule data. Right click the *Models* folder. Select **Add** > **Class**. Name the class **FileUpload** and add the following properties:
-
-[!code-csharp[Main](razor-pages-start/sample/RazorPagesMovie/Models/FileUpload.cs)]
-
-The class has a property for the schedule's title and a property for each of the two versions of the schedule. All three properties are required, and the title must be 3-60 characters long.
 
 ## Add a file upload Razor Page
 


### PR DESCRIPTION
`FileUpload` is needed prior to running the migration, so this moves it to the top. Thanks to @jd_kimber and @sevdanski for suggesting this change.