### PR TITLE
Add missing using statement

### DIFF
--- a/aspnetcore/fundamentals/configuration/sample/ConfigJson/Program.cs
+++ b/aspnetcore/fundamentals/configuration/sample/ConfigJson/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
 
 public class Program
 {


### PR DESCRIPTION
Missing using statement associated with example.
