### PR TITLE
Patch sample and add a note on handler name matching

### DIFF
--- a/aspnetcore/mvc/razor-pages/razor-pages-convention-features.md
+++ b/aspnetcore/mvc/razor-pages/razor-pages-convention-features.md
@@ -269,7 +269,9 @@ Note that `Async` is optional between `DeleteAllMessages` and `DeleteMessageAsyn
 
 Note the handler names provided in *Index.cshtml* match the `DeleteAllMessages` and `DeleteMessageAsync` handler methods:
 
-[!code-cshtml[Main](razor-pages-convention-features/sample/Pages/Index.cshtml?range=29-60&highlight=7-8,25-26)]
+[!code-cshtml[Main](razor-pages-convention-features/sample/Pages/Index.cshtml?range=29-60&highlight=7-8,24-25)]
+
+`Async` in the handler method name `DeleteMessageAsync` is factored out by the `TryParseHandlerMethod` for handler matching of POST request to method. The `asp-page-handler` name of `DeleteMessage` is matched to the handler method `DeleteMessageAsync`.
 
 ## MVC Filters and the Page filter (IPageFilter)
 

--- a/aspnetcore/mvc/razor-pages/razor-pages-convention-features/sample/Pages/Index.cshtml
+++ b/aspnetcore/mvc/razor-pages/razor-pages-convention-features/sample/Pages/Index.cshtml
@@ -48,11 +48,9 @@
                 @foreach (var message in Model.Messages)
                 {
                     <li>
-                        <td>@message.Text</td>
-                        <td>
-                            <button type="submit" asp-page-handler="DeleteMessage" 
-                                    asp-route-id="@message.Id">delete</button>
-                        </td>
+                        @message.Text
+                        <button type="submit" asp-page-handler="DeleteMessage" 
+                            asp-route-id="@message.Id">delete</button>
                     </li>
                 }
             </ol>


### PR DESCRIPTION
Moving from a table to an ordered list, I didn't 🥊 knock out the `<td>` elements. I also add a one line note there to confirm the matching of handler method to handler name from the POST request is correct in the example shown.