### PR TITLE
Fix link: dependency-injection.md

### DIFF
--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -291,7 +291,7 @@ When working with dependency injection, keep the following recommendations in mi
 
 * DI is for objects that have complex dependencies. Controllers, services, adapters, and repositories are all examples of objects that might be added to DI.
 
-* Avoid storing data and configuration directly in DI. For example, a user's shopping cart shouldn't typically be added to the services container. Configuration should use the [Options Model](configuration.md#options-config-objects). Similarly, avoid "data holder" objects that only exist to allow access to some other object. It's better to request the actual item needed via DI, if possible.
+* Avoid storing data and configuration directly in DI. For example, a user's shopping cart shouldn't typically be added to the services container. Configuration should use the [Options Model](configuration.md#using-options-and-configuration-objects). Similarly, avoid "data holder" objects that only exist to allow access to some other object. It's better to request the actual item needed via DI, if possible.
 
 * Avoid static access to services.
 


### PR DESCRIPTION
Fixes 

Illegal link: `[Options Model](configuration.md#options-config-objects)` -- missing bookmark. The file fundamentals/configuration.md doesn't contain a bookmark named options-config-objects.
--


