### PR TITLE
fix bad anchor link

### DIFF
--- a/aspnetcore/security/authorization/limitingidentitybyscheme.md
+++ b/aspnetcore/security/authorization/limitingidentitybyscheme.md
@@ -131,7 +131,7 @@ In the preceding code, only the handler with the "Bearer" scheme runs. Any cooki
 
 ## Selecting the scheme with policies
 
-If you prefer to specify the desired schemes in [policy](xref:security/authorization/policies#security-authorization-policies-based), you can set the `AuthenticationSchemes` collection when adding your policy:
+If you prefer to specify the desired schemes in [policy](xref:security/authorization/policies), you can set the `AuthenticationSchemes` collection when adding your policy:
 
 ```csharp
 services.AddAuthorization(options =>


### PR DESCRIPTION
reference: [build report](https://opbuildstorageprod.blob.core.windows.net/report/2017%5C10%5C13%5C6a0d29ae-bb37-09f1-c55a-4cfa862c6784%5CPullRequest%5C201710131248087361-4562%5Cworkflow_report.html?sv=2015-02-21&sr=b&sig=GbG0qgcJNtJMXYbbzHZqcp2BJNdAKtUYmbwoSscw5IY%3D&st=2017-10-13T12%3A50%3A41Z&se=2017-11-13T12%3A55%3A41Z&sp=r)

When creating a new PR, please do the following and delete this template text:

Fixes one issue in #4649
