### PR TITLE
add heading for handler registration

### DIFF
--- a/aspnetcore/security/authorization/policies.md
+++ b/aspnetcore/security/authorization/policies.md
@@ -113,6 +113,7 @@ In the code above we first look to see if the current user principal has a date 
 
 <a name="security-authorization-policies-based-handler-registration"></a>
 
+### Handler Registration
 Handlers must be registered in the services collection during configuration, for example;
 
 ```csharp

--- a/aspnetcore/security/authorization/policies.md
+++ b/aspnetcore/security/authorization/policies.md
@@ -1,5 +1,5 @@
 ---
-title: Custom Policy-Based Authorization
+title: Custom policy-based authorization
 author: rick-anderson
 description: 
 keywords: ASP.NET Core,
@@ -12,7 +12,7 @@ ms.technology: aspnet
 ms.prod: asp.net-core
 uid: security/authorization/policies
 ---
-# Custom Policy-Based Authorization
+# Custom policy-based authorization
 
 <a name="security-authorization-policies-based"></a>
 

--- a/aspnetcore/security/authorization/policies.md
+++ b/aspnetcore/security/authorization/policies.md
@@ -71,7 +71,7 @@ A requirement doesn't need to have data or properties.
 
 <a name="security-authorization-policies-based-authorization-handler"></a>
 
-## Authorization Handlers
+## Authorization handlers
 
 An authorization handler is responsible for the evaluation of any properties of a requirement. The  authorization handler must evaluate them against a provided `AuthorizationHandlerContext` to decide if authorization is allowed. A requirement can have [multiple handlers](policies.md#security-authorization-policies-based-multiple-handlers). Handlers must inherit `AuthorizationHandler<T>` where T is the requirement it handles.
 
@@ -113,7 +113,7 @@ In the code above we first look to see if the current user principal has a date 
 
 <a name="security-authorization-policies-based-handler-registration"></a>
 
-### Handler Registration
+### Handler registration
 Handlers must be registered in the services collection during configuration, for example;
 
 ```csharp
@@ -207,7 +207,7 @@ services.AddAuthorization(options =>
  }
 ```
 
-## Accessing MVC Request Context In Handlers
+## Accessing MVC request context in handlers
 
 The `Handle` method you must implement in an authorization handler has two parameters, an `AuthorizationContext` and the `Requirement` you are handling. Frameworks such as MVC or Jabbr are free to add any object to the `Resource` property on the `AuthorizationContext` to pass through extra information.
 


### PR DESCRIPTION
This will allow for an anchor link (I think, I know ## does, hoping ### does too).  This will help to fix "Illegal link: `[Authorization handlers must be registered](policies.md#security-authorization-policies-based-handler-registration)` -- missing bookmark." on `aspnetcore/security/authorization/dependencyinjection.md`

Reference: [build report](https://opbuildstorageprod.blob.core.windows.net/report/2017%5C10%5C13%5C6a0d29ae-bb37-09f1-c55a-4cfa862c6784%5CPullRequest%5C201710131248087361-4562%5Cworkflow_report.html?sv=2015-02-21&sr=b&sig=GbG0qgcJNtJMXYbbzHZqcp2BJNdAKtUYmbwoSscw5IY%3D&st=2017-10-13T12%3A50%3A41Z&se=2017-11-13T12%3A55%3A41Z&sp=r)

Reference: #4649 
