### PR TITLE
fix anchor link to handler registration

### DIFF
--- a/aspnetcore/security/authorization/dependencyinjection.md
+++ b/aspnetcore/security/authorization/dependencyinjection.md
@@ -16,7 +16,7 @@ uid: security/authorization/dependencyinjection
 
 <a name="security-authorization-di"></a>
 
-[Authorization handlers must be registered](policies.md#security-authorization-policies-based-handler-registration) in the service collection during configuration (using [dependency injection](../../fundamentals/dependency-injection.md#fundamentals-dependency-injection)).
+[Authorization handlers must be registered](policies.md#handler-registration) in the service collection during configuration (using [dependency injection](../../fundamentals/dependency-injection.md#fundamentals-dependency-injection)).
 
 Suppose you had a repository of rules you wanted to evaluate inside an authorization handler and that repository was registered in the service collection.  Authorization will resolve and inject that into your constructor.
 


### PR DESCRIPTION
Fixes one issue in #4649 

>Illegal link: `[Authorization handlers must be registered](policies.md#security-authorization-policies-based-handler-registration)` -- missing bookmark. The file security/authorization/policies.md doesn't contain a bookmark named security-authorization-policies-based-handler-registration.

Reference [Build Report](https://opbuildstorageprod.blob.core.windows.net/report/2017%5C10%5C13%5C6a0d29ae-bb37-09f1-c55a-4cfa862c6784%5CPullRequest%5C201710131248087361-4562%5Cworkflow_report.html?sv=2015-02-21&sr=b&sig=GbG0qgcJNtJMXYbbzHZqcp2BJNdAKtUYmbwoSscw5IY%3D&st=2017-10-13T12%3A50%3A41Z&se=2017-11-13T12%3A55%3A41Z&sp=r)
