### PR TITLE
Remove period from TOC link title

### DIFF
--- a/aspnetcore/security/data-protection/implementation/index.md
+++ b/aspnetcore/security/data-protection/implementation/index.md
@@ -14,7 +14,7 @@ uid: security/data-protection/implementation/index
 ---
 # Implementation
 
-* [Authenticated encryption details.](authenticated-encryption-details.md)
+* [Authenticated encryption details](authenticated-encryption-details.md)
 
 * [Subkey Derivation and Authenticated Encryption](subkeyderivation.md)
 

--- a/aspnetcore/security/data-protection/index.md
+++ b/aspnetcore/security/data-protection/index.md
@@ -52,7 +52,7 @@ uid: security/data-protection/index
 
 * [Implementation](implementation/index.md)
 
-  * [Authenticated encryption details.](implementation/authenticated-encryption-details.md)
+  * [Authenticated encryption details](implementation/authenticated-encryption-details.md)
 
   * [Subkey Derivation and Authenticated Encryption](implementation/subkeyderivation.md)
 

--- a/aspnetcore/security/index.md
+++ b/aspnetcore/security/index.md
@@ -58,7 +58,7 @@ uid: security/index
         *   [Key management extensibility](data-protection/extensibility/key-management.md)
         *   [Miscellaneous APIs](data-protection/extensibility/misc-apis.md)
     *   [Implementation](data-protection/implementation/index.md)
-        *   [Authenticated encryption details.](data-protection/implementation/authenticated-encryption-details.md)
+        *   [Authenticated encryption details](data-protection/implementation/authenticated-encryption-details.md)
         *   [Subkey Derivation and Authenticated Encryption](data-protection/implementation/subkeyderivation.md)
         *   [Context headers](data-protection/implementation/context-headers.md)
         *   [Key Management](data-protection/implementation/key-management.md)

--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -256,7 +256,7 @@
 ####[Key management extensibility](xref:security/data-protection/extensibility/key-management)
 ####[Miscellaneous APIs](xref:security/data-protection/extensibility/misc-apis)
 ###[Implementation](xref:security/data-protection/implementation/index)
-####[Authenticated encryption details.](xref:security/data-protection/implementation/authenticated-encryption-details)
+####[Authenticated encryption details](xref:security/data-protection/implementation/authenticated-encryption-details)
 ####[Subkey Derivation and Authenticated Encryption](xref:security/data-protection/implementation/subkeyderivation)
 ####[Context headers](xref:security/data-protection/implementation/context-headers)
 ####[Key Management](xref:security/data-protection/implementation/key-management)


### PR DESCRIPTION
Remove the period from the "Authenticated encryption details" doc's TOC links.