### PR TITLE
Updated facebook-logins.md with exact instructions to store Facebook …

### DIFF
--- a/aspnetcore/security/authentication/social/facebook-logins.md
+++ b/aspnetcore/security/authentication/social/facebook-logins.md
@@ -58,11 +58,12 @@ This tutorial shows you how to enable your users to sign in with their Facebook 
 
 Link sensitive settings like Facebook `App ID` and `App Secret` to your application configuration using the [Secret Manager](xref:security/app-secrets). For the purposes of this tutorial, name the tokens `Authentication:Facebook:AppId` and `Authentication:Facebook:AppSecret`.
 
-* To store Facebook `App ID` and `App Secret` in your `Secret Manager` execute the following.
+Execute the following commands to securely store `App ID` and `App Secret` using Secret Manager:
 
-   `dotnet user-secrets set Authentication:Google:AppId <app-Id>`
-
-   `dotnet user-secrets set Authentication:Google:AppSecret <app-secret>`
+```console
+dotnet user-secrets set Authentication:Facebook:AppId <app-id>
+dotnet user-secrets set Authentication:Facebook:AppSecret <app-secret>
+```
 
 ## Configure Facebook Authentication
 

--- a/aspnetcore/security/authentication/social/facebook-logins.md
+++ b/aspnetcore/security/authentication/social/facebook-logins.md
@@ -58,6 +58,12 @@ This tutorial shows you how to enable your users to sign in with their Facebook 
 
 Link sensitive settings like Facebook `App ID` and `App Secret` to your application configuration using the [Secret Manager](xref:security/app-secrets). For the purposes of this tutorial, name the tokens `Authentication:Facebook:AppId` and `Authentication:Facebook:AppSecret`.
 
+* To store Facebook `App ID` and `App Secret` in your `Secret Manager` execute the following.
+
+   `dotnet user-secrets set Authentication:Google:AppId <app-Id>`
+
+   `dotnet user-secrets set Authentication:Google:AppSecret <app-secret>`
+
 ## Configure Facebook Authentication
 
 The project template used in this tutorial ensures that [Microsoft.AspNetCore.Authentication.Facebook](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Facebook) package is already installed.


### PR DESCRIPTION
[Internal Review Page](https://review.docs.microsoft.com/aspnet/core/security/authentication/social/facebook-logins?branch=pr-en-us-4709)

The documentation is updated with exact instructions to store Facebook app Id and secret in secret store. The issue is really small to create an issue. 