### PR TITLE
Changes to resourcebased.md to match Core 2.0

### DIFF
--- a/aspnetcore/security/authorization/resourcebased.md
+++ b/aspnetcore/security/authorization/resourcebased.md
@@ -36,6 +36,8 @@ public class DocumentController : Controller
 
 `IAuthorizationService` has two methods, one where you pass the resource and the policy name and the other where you pass the resource and a list of requirements to evaluate.
 
+# [ASP.NET Core 2.x](#tab/aspnetcore2x)
+
 ```csharp
 Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user,
                           object resource,
@@ -44,6 +46,19 @@ Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user,
                           object resource,
                           string policyName);
 ```
+
+# [ASP.NET Core 1.x](#tab/aspnetcore1x)
+
+```csharp
+Task<bool> AuthorizeAsync(ClaimsPrincipal user,
+                          object resource,
+                          IEnumerable<IAuthorizationRequirement> requirements);
+Task<bool> AuthorizeAsync(ClaimsPrincipal user,
+                          object resource,
+                          string policyName);
+```
+
+---
 
 <a name="security-authorization-resource-based-imperative"></a>
 

--- a/aspnetcore/security/authorization/resourcebased.md
+++ b/aspnetcore/security/authorization/resourcebased.md
@@ -37,10 +37,10 @@ public class DocumentController : Controller
 `IAuthorizationService` has two methods, one where you pass the resource and the policy name and the other where you pass the resource and a list of requirements to evaluate.
 
 ```csharp
-Task<bool> AuthorizeAsync(ClaimsPrincipal user,
+Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user,
                           object resource,
                           IEnumerable<IAuthorizationRequirement> requirements);
-Task<bool> AuthorizeAsync(ClaimsPrincipal user,
+Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user,
                           object resource,
                           string policyName);
 ```
@@ -59,7 +59,7 @@ public async Task<IActionResult> Edit(Guid documentId)
         return new HttpNotFoundResult();
     }
 
-    if (await _authorizationService.AuthorizeAsync(User, document, "EditPolicy"))
+    if ((await _authorizationService.AuthorizeAsync(User, document, "EditPolicy")).Succeeded)
     {
         return View(document);
     }


### PR DESCRIPTION
[Internal Review Page](https://review.docs.microsoft.com/aspnet/core/security/authorization/resourcebased?branch=pr-en-us-4712)

`AuthorizeAsync` method returns `Task<AuthorizationResult>` instead of `Task<bool>` in 2.0.