### PR TITLE
Updated example kestrel-hellomvc.service

### DIFF
--- a/aspnetcore/publishing/linuxproduction.md
+++ b/aspnetcore/publishing/linuxproduction.md
@@ -153,7 +153,8 @@ Restart=always
 RestartSec=10  # Restart service after 10 seconds if dotnet service crashes
 SyslogIdentifier=dotnet-example
 User=www-data
-Environment=ASPNETCORE_ENVIRONMENT=Production 
+Environment=ASPNETCORE_ENVIRONMENT=Production
+Environment=DOTNET_PRINT_TELEMETRY_MESSAGE=false
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I followed the [Host on Linux with Nginx](https://docs.microsoft.com/en-us/aspnet/core/publishing/linuxproduction?tabs=aspnetcore2x) guide and the service did not start due to a permission error similar to one described [here](https://stackoverflow.com/q/47082358/280778
).

I looked into the source code and found that the problem can be avoided by not displaying the telemetry message. So I added the corresponding environment variable to the example to make the service work on a default nginx installation.