### PR TITLE
Edit "-PhysicalPath" paramater for "New-IISSite" command

### DIFF
--- a/aspnetcore/tutorials/nano-server.md
+++ b/aspnetcore/tutorials/nano-server.md
@@ -190,7 +190,7 @@ Run the following commands in the remote session to create a new site in IIS for
 
 ```PowerShell
 Import-module IISAdministration
-New-IISSite -Name "AspNetCore" -PhysicalPath c:\PublishedApps\AspNetCoreSampleForNano -BindingInformation "*:8000:"
+New-IISSite -Name "AspNetCore" -PhysicalPath c:\PublishedApps\AspNetCoreSampleForNano\wwwroot -BindingInformation "*:8000:"
 ```
 
 ## Known issue running .NET Core CLI on Nano Server and workaround


### PR DESCRIPTION
This was hanging me up until I compared all the steps to "[https://docs.microsoft.com/en-us/iis/get-started/whats-new-in-iis-10/running-aspnet-core-with-iis-on-nano-server](url)" and noticed "wwwroot" was included there and not here