### PR TITLE
Fix startup.cs example to also show custom `ApplicationRole` class

### DIFF
--- a/aspnetcore/security/authentication/identity/sample/src/ASPNETv2-IdentityDemo-PrimaryKeysConfig/Startup.cs
+++ b/aspnetcore/security/authentication/identity/sample/src/ASPNETv2-IdentityDemo-PrimaryKeysConfig/Startup.cs
@@ -27,7 +27,7 @@ namespace webapptemplate
             services.AddDbContext<ApplicationDbContext>(options =>
                 options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
 
-            services.AddIdentity<ApplicationUser, IdentityRole>()
+            services.AddIdentity<ApplicationUser, ApplicationRole>()
                 .AddEntityFrameworkStores<ApplicationDbContext>()
                 .AddDefaultTokenProviders();
 


### PR DESCRIPTION

https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity-primary-key-configuration?tabs=aspnetcore2x

This documentation page is about creating and registering custom `ApplicationUser` and `ApplicationRole` Identity classes, this PR fixes the sample for `Startup.cs` registration.