### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,3 @@ When creating a new PR, please do the following and delete this template text:
 
   > The "Fixes #nnn" syntax in the PR description causes
   > GitHub to automatically close the issue when this PR is merged.
-
-* Suggest reviewers if you know who should review the PR, using the GitHub **Reviewers** UI.


### PR DESCRIPTION
Remove suggest reviewers. For the few folks who read this, the suggest far too many people. We're in a much better position to suggest reviewers.

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.

* Suggest reviewers if you know who should review the PR, using the GitHub **Reviewers** UI.
