### PR TITLE
fix typo

### DIFF
--- a/aspnetcore/mvc/controllers/routing.md
+++ b/aspnetcore/mvc/controllers/routing.md
@@ -201,7 +201,7 @@ app.UseMvc(routes =>
 });
 ```
 
-The route names give the route a logical name so that the named route can be used for URL generation. This greatly simplifies URL creation when the ordering of routes could make URL generation complicated. Routes names must be unique application-wide.
+The route names give the route a logical name so that the named route can be used for URL generation. This greatly simplifies URL creation when the ordering of routes could make URL generation complicated. Route names must be unique application-wide.
 
 Route names have no impact on URL matching or handling of requests; they are used only for URL generation. [Routing](xref:fundamentals/routing) has more detailed information on URL generation including URL generation in MVC-specific helpers.
 


### PR DESCRIPTION
fixing a minor typo: "Routes names must be unique" => "Route names must be unique"
