### PR TITLE
Catch a more general exception and report it

### DIFF
--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/Utilities/FileHelpers.cs
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/Utilities/FileHelpers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Net;
@@ -76,9 +77,9 @@ namespace RazorPagesMovie.Utilities
                         }
                     }
                 }
-                catch (IOException ex)
+                catch (Exception ex)
                 {
-                    modelState.AddModelError(formFile.Name, $"The {fieldDisplayName}file ({fileName}) upload failed. Please contact the Help Desk for support.");
+                    modelState.AddModelError(formFile.Name, $"The {fieldDisplayName}file ({fileName}) upload failed. Please contact the Help Desk for support. Error: {ex.Message}");
                     // Log the exception
                 }
             }


### PR DESCRIPTION
RE: File Uploads section of RP tutorial (*FileHelper.cs*)

When the `StreamReader` chokes on bytes for a Unicode conversion, it throws a `DecoderFallbackException`:

> DecoderFallbackException: Unable to translate bytes \[97] at index 301 from specified code page to Unicode.

I recommend we catch a more general exception and then just report the error `Message` back to the user.

The result of this will look like this in the UI ...

![capture](https://user-images.githubusercontent.com/1622880/33401681-b5615588-d51f-11e7-87a3-4e49410ccd71.PNG)