### PR TITLE
Missing  ContentPlaceHolder in master page

### DIFF
--- a/aspnet/web-api/overview/getting-started-with-aspnet-web-api/using-web-api-with-aspnet-web-forms.md
+++ b/aspnet/web-api/overview/getting-started-with-aspnet-web-api/using-web-api-with-aspnet-web-forms.md
@@ -92,7 +92,8 @@ Below the jQuery script tag, add the following script block:
 
 [!code-html[Main](using-web-api-with-aspnet-web-forms/samples/sample7.html)]
 
-Make sure, your maser pages (Ex: Site.Master), includes a ContentPlaceHolder with ID="HeadContent" similar to the following.
+Make sure your master page (for example, *Site.Master*), includes a `ContentPlaceHolder` with `ID="HeadContent"` similar to the following:
+
 [!code-html[Main](using-web-api-with-aspnet-web-forms/samples/sample8.html)]
 
 When the document loads, this script makes an AJAX request to &quot;api/products&quot;. The request returns a list of products in JSON format. The script adds the product information to the HTML table.

--- a/aspnet/web-api/overview/getting-started-with-aspnet-web-api/using-web-api-with-aspnet-web-forms.md
+++ b/aspnet/web-api/overview/getting-started-with-aspnet-web-api/using-web-api-with-aspnet-web-forms.md
@@ -76,7 +76,7 @@ For more information about routing tables, see [Routing in ASP.NET Web API](../w
 
 That's all you need to create a web API that clients can access. Now let's add an HTML page that uses jQuery to call the API.
 
-Make sure your master page (for example, *Site.Master*), includes a `ContentPlaceHolder` with `ID="HeadContent"` similar to the following:
+Make sure your master page (for example, *Site.Master*) includes a `ContentPlaceHolder` with `ID="HeadContent"`:
 
 [!code-html[Main](using-web-api-with-aspnet-web-forms/samples/sample8.html)]
 

--- a/aspnet/web-api/overview/getting-started-with-aspnet-web-api/using-web-api-with-aspnet-web-forms.md
+++ b/aspnet/web-api/overview/getting-started-with-aspnet-web-api/using-web-api-with-aspnet-web-forms.md
@@ -76,6 +76,10 @@ For more information about routing tables, see [Routing in ASP.NET Web API](../w
 
 That's all you need to create a web API that clients can access. Now let's add an HTML page that uses jQuery to call the API.
 
+Make sure your master page (for example, *Site.Master*), includes a `ContentPlaceHolder` with `ID="HeadContent"` similar to the following:
+
+[!code-html[Main](using-web-api-with-aspnet-web-forms/samples/sample8.html)]
+
 Open the file Default.aspx. Replace the boilerplate text that is in the main content section, as shown:
 
 [!code-aspx[Main](using-web-api-with-aspnet-web-forms/samples/sample5.aspx)]
@@ -91,10 +95,6 @@ Note: You can easily add the script reference by dragging and dropping the file 
 Below the jQuery script tag, add the following script block:
 
 [!code-html[Main](using-web-api-with-aspnet-web-forms/samples/sample7.html)]
-
-Make sure your master page (for example, *Site.Master*), includes a `ContentPlaceHolder` with `ID="HeadContent"` similar to the following:
-
-[!code-html[Main](using-web-api-with-aspnet-web-forms/samples/sample8.html)]
 
 When the document loads, this script makes an AJAX request to &quot;api/products&quot;. The request returns a list of products in JSON format. The script adds the product information to the HTML table.
 

--- a/aspnet/web-api/overview/getting-started-with-aspnet-web-api/using-web-api-with-aspnet-web-forms.md
+++ b/aspnet/web-api/overview/getting-started-with-aspnet-web-api/using-web-api-with-aspnet-web-forms.md
@@ -92,6 +92,9 @@ Below the jQuery script tag, add the following script block:
 
 [!code-html[Main](using-web-api-with-aspnet-web-forms/samples/sample7.html)]
 
+Make sure, your maser pages (Ex: Site.Master), includes a ContentPlaceHolder with ID="HeadContent" similar to the following.
+[!code-html[Main](using-web-api-with-aspnet-web-forms/samples/sample8.html)]
+
 When the document loads, this script makes an AJAX request to &quot;api/products&quot;. The request returns a list of products in JSON format. The script adds the product information to the HTML table.
 
 When you run the application, it should look like this:


### PR DESCRIPTION
When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.

[Internal Review Page](https://review.docs.microsoft.com/aspnet/web-api/overview/getting-started-with-aspnet-web-api/using-web-api-with-aspnet-web-forms?branch=pr-en-us-4899#add-client-side-ajax)