### PR TITLE
Update guidance on creating the Logs folder

### DIFF
--- a/aspnetcore/hosting/directory-structure.md
+++ b/aspnetcore/hosting/directory-structure.md
@@ -37,6 +37,6 @@ The contents of the *publish* directory represents the *content root path*, also
 </Target>
 ```
 
-The `<MakeDir>` element creates an empty *Logs* folder in the published output. The element uses the `PublishDir` property to determine the target location for creating the folder. Several deployment methods, such as Web Deploy, skip empty folders during deployment. The `<WriteLinesToFile>` element generates a file in the *Logs* folder, which guarantees deployment of the folder to the server.
+The `<MakeDir>` element creates an empty *Logs* folder in the published output. The element uses the `PublishDir` property to determine the target location for creating the folder. Several deployment methods, such as Web Deploy, skip empty folders during deployment. The `<WriteLinesToFile>` element generates a file in the *Logs* folder, which guarantees deployment of the folder to the server. Note that folder creation may still fail if the worker process doesn't have write access to the target folder.
 
 The deployment directory requires Read/Execute permissions, while the *Logs* directory requires Read/Write permissions. Additional directories where assets will be written require Read/Write permissions.

--- a/aspnetcore/hosting/directory-structure.md
+++ b/aspnetcore/hosting/directory-structure.md
@@ -27,12 +27,16 @@ In ASP.NET Core, the application directory, *publish*, is comprised of applicati
 The contents of the *publish* directory represents the *content root path*, also called the *application base path*, of the deployment. Whatever name is given to the *publish* directory in the deployment, its location serves as the server's physical path to the hosted application. The *wwwroot* directory, if present, only contains static assets. The *logs* directory may be included in the deployment by creating it in the project and adding the `<Target>` element shown below to your *.csproj* file or by physically creating the directory on the server.
 
 ```xml
-<Target Name="CreateLogsFolder" AfterTargets="AfterPublish">
-  <MakeDir Directories="$(PublishDir)logs" Condition="!Exists('$(PublishDir)logs')" />
-  <MakeDir Directories="$(PublishUrl)logs" Condition="!Exists('$(PublishUrl)logs')" />
+<Target Name="CreateLogsFolder" AfterTargets="Publish">
+  <MakeDir Directories="$(PublishDir)Logs" 
+           Condition="!Exists('$(PublishDir)Logs')" />
+  <WriteLinesToFile File="$(PublishDir)Logs\.log" 
+                    Lines="Generated file" 
+                    Overwrite="True" 
+                    Condition="!Exists('$(PublishDir)Logs\.log')" />
 </Target>
 ```
 
-The first `<MakeDir>` element, which uses the `PublishDir` property, is used by the .NET Core CLI to determine the target location for the publish operation. The second `<MakeDir>` element, which uses the `PublishUrl` property, is used by Visual Studio to determine the target location. Visual Studio uses the `PublishUrl` property for compatibility with non-.NET Core projects.
+The `<MakeDir>` element creates an empty *Logs* folder in the published output. The element uses the `PublishDir` property to determine the target location for creating the folder. Several deployment methods, such as Web Deploy, skip empty folders during deployment. The `<WriteLinesToFile>` element generates a file in the *Logs* folder, which guarantees deployment of the folder to the server.
 
-The deployment directory requires Read/Execute permissions, while the *logs* directory requires Read/Write permissions. Additional directories where assets will be written require Read/Write permissions.
+The deployment directory requires Read/Execute permissions, while the *Logs* directory requires Read/Write permissions. Additional directories where assets will be written require Read/Write permissions.


### PR DESCRIPTION
Addresses https://github.com/aspnet/websdk/issues/152#issuecomment-348569871
Related: https://github.com/aspnet/AspNetCoreModule/issues/30

Based on the latest guidance for creating and deploying the *Logs* folder :sparkles: auto-magically :sparkles: that covers all manner of deployment strategies.

cc/ @vijayrkn @dasmulli

Thanks to @DaleMckeown and @gpcaretti.