### PR TITLE
PrimeWeb sample fix

### DIFF
--- a/aspnetcore/testing/integration-testing/sample/test/PrimeWeb.IntegrationTests/PrimeWeb.IntegrationTests.csproj
+++ b/aspnetcore/testing/integration-testing/sample/test/PrimeWeb.IntegrationTests/PrimeWeb.IntegrationTests.csproj
@@ -5,6 +5,22 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+   
+  <!-- https://github.com/NuGet/Home/issues/4412 -->
+  <Target Name="CopyDepsFiles" AfterTargets="Build" Condition="'$(TargetFramework)'!=''">
+    <ItemGroup>
+      <DepsFilePaths Include="$([System.IO.Path]::ChangeExtension('%(_ResolvedProjectReferencePaths.FullPath)', '.deps.json'))" />
+    </ItemGroup>
+
+    <Copy SourceFiles="%(DepsFilePaths.FullPath)" DestinationFolder="$(OutputPath)" Condition="Exists('%(DepsFilePaths.FullPath)')" />
+  </Target>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\PrimeWeb\PrimeWeb.csproj" />
   </ItemGroup>
 

--- a/aspnetcore/testing/integration-testing/sample/test/PrimeWeb.IntegrationTests/xunit.runner.json
+++ b/aspnetcore/testing/integration-testing/sample/test/PrimeWeb.IntegrationTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}

--- a/aspnetcore/testing/integration-testing/sample/test/PrimeWeb.UnitTests/PrimeWeb.UnitTests.csproj
+++ b/aspnetcore/testing/integration-testing/sample/test/PrimeWeb.UnitTests/PrimeWeb.UnitTests.csproj
@@ -5,6 +5,22 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+   
+  <!-- https://github.com/NuGet/Home/issues/4412 -->
+  <Target Name="CopyDepsFiles" AfterTargets="Build" Condition="'$(TargetFramework)'!=''">
+    <ItemGroup>
+      <DepsFilePaths Include="$([System.IO.Path]::ChangeExtension('%(_ResolvedProjectReferencePaths.FullPath)', '.deps.json'))" />
+    </ItemGroup>
+
+    <Copy SourceFiles="%(DepsFilePaths.FullPath)" DestinationFolder="$(OutputPath)" Condition="Exists('%(DepsFilePaths.FullPath)')" />
+  </Target>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\PrimeWeb\PrimeWeb.csproj" />
   </ItemGroup>
 

--- a/aspnetcore/testing/integration-testing/sample/test/PrimeWeb.UnitTests/xunit.runner.json
+++ b/aspnetcore/testing/integration-testing/sample/test/PrimeWeb.UnitTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}


### PR DESCRIPTION
Addresses #4943 

This fixes up the project files in the tests projects of the PrimeWeb sample:
* Provide for `shadowCopy: false`
* Copy the deps file per https://github.com/NuGet/Home/issues/4412.