### PR TITLE
Remove extra space from div tag

### DIFF
--- a/aspnetcore/mvc/views/view-components/sample/ViewCompFinal/Views/Todo/IndexFirst.cshtml
+++ b/aspnetcore/mvc/views/view-components/sample/ViewCompFinal/Views/Todo/IndexFirst.cshtml
@@ -32,6 +32,6 @@
             </tr>
     }
 </table>
-<div >
+<div>
     @await Component.InvokeAsync("PriorityList", new { maxPriority = 2, isDone = false })
 </div>


### PR DESCRIPTION
Remove an extra space from a div tag which appears in a code snippet in the View Components doc.