### PR TITLE
Correct highlighted new code that needs to be added

### DIFF
--- a/aspnetcore/data/ef-rp/crud.md
+++ b/aspnetcore/data/ef-rp/crud.md
@@ -98,7 +98,7 @@ The `AsNoTracking` method improves performance in scenarios when the entities re
 Open *Pages/Students/Details.cshtml*. Add the following highlighted code to display a list of enrollments:
 
  <!--2do ricka. if doesn't change, remove dup -->
-[!code-cshtml[Main](intro/samples/cu/Pages/Students/Details1.cshtml?highlight=35-53)]
+[!code-cshtml[Main](intro/samples/cu/Pages/Students/Details1.cshtml?highlight=32-53)]
 
 If code indentation is wrong after the code is pasted, press CTRL-K-D to correct it.
 


### PR DESCRIPTION
In the highlighted portion of new code to be added for the section "Display related enrollments on the Details page", the previous 3 lines (32-34) are not highlighted but they are new lines of code that the user should add.
