### PR TITLE
Making use of the ValueProviderFactoryExtensions

### DIFF
--- a/aspnetcore/mvc/models/file-uploads/sample/FileUploadSample/Filters/DisableFormValueModelBindingAttribute.cs
+++ b/aspnetcore/mvc/models/file-uploads/sample/FileUploadSample/Filters/DisableFormValueModelBindingAttribute.cs
@@ -1,6 +1,6 @@
+using System;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using System;
 
 namespace FileUploadSample.Filters
 {

--- a/aspnetcore/mvc/models/file-uploads/sample/FileUploadSample/Filters/DisableFormValueModelBindingAttribute.cs
+++ b/aspnetcore/mvc/models/file-uploads/sample/FileUploadSample/Filters/DisableFormValueModelBindingAttribute.cs
@@ -1,36 +1,21 @@
-﻿using System;
-using System.Linq;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System;
 
 namespace FileUploadSample.Filters
 {
-    #region snippet1
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
     public class DisableFormValueModelBindingAttribute : Attribute, IResourceFilter
     {
         public void OnResourceExecuting(ResourceExecutingContext context)
         {
-            var formValueProviderFactory = context.ValueProviderFactories
-                .OfType<FormValueProviderFactory>()
-                .FirstOrDefault();
-            if (formValueProviderFactory != null)
-            {
-                context.ValueProviderFactories.Remove(formValueProviderFactory);
-            }
-
-            var jqueryFormValueProviderFactory = context.ValueProviderFactories
-                .OfType<JQueryFormValueProviderFactory>()
-                .FirstOrDefault();
-            if (jqueryFormValueProviderFactory != null)
-            {
-                context.ValueProviderFactories.Remove(jqueryFormValueProviderFactory);
-            }
+            var factories = context.ValueProviderFactories;
+            factories.RemoveType<FormValueProviderFactory>();
+            factories.RemoveType<JQueryFormValueProviderFactory>();
         }
 
         public void OnResourceExecuted(ResourceExecutedContext context)
         {
         }
     }
-    #endregion
 }

--- a/aspnetcore/mvc/models/file-uploads/sample/FileUploadSample/Filters/DisableFormValueModelBindingAttribute.cs
+++ b/aspnetcore/mvc/models/file-uploads/sample/FileUploadSample/Filters/DisableFormValueModelBindingAttribute.cs
@@ -4,6 +4,7 @@ using System;
 
 namespace FileUploadSample.Filters
 {
+    #region snippet1    
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
     public class DisableFormValueModelBindingAttribute : Attribute, IResourceFilter
     {
@@ -17,5 +18,6 @@ namespace FileUploadSample.Filters
         public void OnResourceExecuted(ResourceExecutedContext context)
         {
         }
-    }
+    }    
+    #endregion
 }


### PR DESCRIPTION
Why don't we use the [`ValueProviderFactoryExtensions`](https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNetCore.Mvc.Core/ModelBinding/ValueProviderFactoryExtensions.cs) to cut the chatter?

