### PR TITLE
fix publish config due to overlapping output path

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -44,7 +44,7 @@
     {
       "docset_name": "aspnet-core-conceptual",
       "build_source_folder": "aspnetcore",
-      "build_output_subfolder": "aspnet/core",
+      "build_output_subfolder": "aspnetcore",
       "locale": "en-us",
       "version": 0,
       "open_to_public_contributors": true,


### PR DESCRIPTION
@Rick-Anderson 
This is to fix the build error due to overlapping output path.