### PR TITLE
Fixed confusing but harmless code that had no effect on the Page() display

### DIFF
--- a/aspnetcore/data/ef-rp/concurrency.md
+++ b/aspnetcore/data/ef-rp/concurrency.md
@@ -192,7 +192,7 @@ Update *pages\departments\edit.cshtml.cs* with the following code:
 
 [!code-csharp[](intro/samples/cu/Pages/Departments/Edit.cshtml.cs?name=snippet)]
 
-To detect a concurrency issue, the [OriginalValue](https://docs.microsoft.com/dotnet/api/microsoft.entityframeworkcore.changetracking.propertyentry.originalvalue?view=efcore-2.0#Microsoft_EntityFrameworkCore_ChangeTracking_PropertyEntry_OriginalValue) is updated with the `rowVersion` value from the entity was it was fetched. EF Core generates a SQL UPDATE command with a WHERE clause containing the original `RowVersion` value. If no rows are affected by the UPDATE command (no rows have the original `RowVersion` value), a `DbUpdateConcurrencyException` exception is thrown.
+To detect a concurrency issue, the [OriginalValue](https://docs.microsoft.com/dotnet/api/microsoft.entityframeworkcore.changetracking.propertyentry.originalvalue?view=efcore-2.0#Microsoft_EntityFrameworkCore_ChangeTracking_PropertyEntry_OriginalValue) is updated with the `rowVersion` value from the entity it was fetched. EF Core generates a SQL UPDATE command with a WHERE clause containing the original `RowVersion` value. If no rows are affected by the UPDATE command (no rows have the original `RowVersion` value), a `DbUpdateConcurrencyException` exception is thrown.
 
 [!code-csharp[](intro/samples/cu/Pages/Departments/Edit.cshtml.cs?name=snippet_rv&highlight=24-)]
 

--- a/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part8/Pages/Departments/Edit.cshtml.cs
+++ b/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part8/Pages/Departments/Edit.cshtml.cs
@@ -112,25 +112,14 @@ namespace ContosoUniversity.Pages.Departments
         private async Task<IActionResult> HandleDeletedDepartment()
         {
             Department deletedDepartment = new Department();
-            // Fetch the posted data so we can display it with the error message.
-            await TryUpdateModelAsync(deletedDepartment);
-            CopyDepartment(deletedDepartment);
+            // ModelState contains the posted data because of the deletion error and will overide the Department instance values when displaying Page().
             ModelState.AddModelError(string.Empty,
                 "Unable to save. The department was deleted by another user.");
-            InstructorNameSL = new SelectList(_context.Instructors, "ID",
-                "FullName", Department.InstructorID);
+            InstructorNameSL = new SelectList(_context.Instructors, "ID", "FullName", Department.InstructorID); 
             return Page();
         }
 
-        private void CopyDepartment(Department deletedDepartment)
-        {
-            Department.Administrator = deletedDepartment.Administrator;
-            Department.Budget = deletedDepartment.Budget;
-            Department.StartDate = deletedDepartment.StartDate;
-            Department.InstructorID = deletedDepartment.InstructorID;
-        }
-
-        private async Task setDbErrorMessage(Department dbValues,
+         private async Task setDbErrorMessage(Department dbValues,
                 Department clientValues, SchoolContext context)
         {
 

--- a/aspnetcore/data/ef-rp/intro/samples/cu/Pages/Departments/Edit.cshtml.cs
+++ b/aspnetcore/data/ef-rp/intro/samples/cu/Pages/Departments/Edit.cshtml.cs
@@ -112,25 +112,14 @@ namespace ContosoUniversity.Pages.Departments
             return Page();
         }
 
-        private async Task<IActionResult> HandleDeletedDepartment()
+       private async Task<IActionResult> HandleDeletedDepartment()
         {
             Department deletedDepartment = new Department();
-            // Fetch the posted data so we can display it with the error message.
-            await TryUpdateModelAsync(deletedDepartment);
-            CopyDepartment(deletedDepartment);
+            // ModelState contains the posted data because of the deletion error and will overide the Department instance values when displaying Page().
             ModelState.AddModelError(string.Empty,
                 "Unable to save. The department was deleted by another user.");
-            InstructorNameSL = new SelectList(_context.Instructors, "ID",
-                "FullName", Department.InstructorID);
+            InstructorNameSL = new SelectList(_context.Instructors, "ID", "FullName", Department.InstructorID); 
             return Page();
-        }
-
-        private void CopyDepartment(Department deletedDepartment)
-        {
-            Department.Administrator = deletedDepartment.Administrator;
-            Department.Budget = deletedDepartment.Budget;
-            Department.StartDate = deletedDepartment.StartDate;
-            Department.InstructorID = deletedDepartment.InstructorID;
         }
 
         #region snippet_err


### PR DESCRIPTION
In the razorpages CU-8 there is misleading code that does not do anything in the handleDelete method. Deleted the method because the values displayed come from the ModelState not the Department instance. 
