### PR TITLE
add notice regarding undocumented methods notices and updated code

### DIFF
--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
@@ -223,7 +223,7 @@ See Visual Studio Code.
 
 ---
 
-* Remember that enabling XML comments will give a notice when debugging in case not all of your methods are documented: __Missing XML comment for publicly visible type or member__
+Enabling XML comments provides debug information for undocumented public methods: __Missing XML comment for publicly visible type or member__
 
 Configure Swagger to use the generated XML file. For Linux or non-Windows operating systems, file names and paths can be case sensitive. For example, a *ToDoApi.XML* file would be found on Windows but not CentOS.
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
@@ -223,8 +223,7 @@ See Visual Studio Code.
 
 ---
 
-Enabling XML comments provides debug information for undocumented public types and members.
-Undocumented types and members are indicated by the warning message: *Missing XML comment for publicly visible type or member*.
+Enabling XML comments provides debug information for undocumented public types and members. Undocumented types and members are indicated by the warning message: *Missing XML comment for publicly visible type or member*.
 
 Configure Swagger to use the generated XML file. For Linux or non-Windows operating systems, file names and paths can be case sensitive. For example, a *ToDoApi.XML* file would be found on Windows but not CentOS.
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
@@ -223,7 +223,8 @@ See Visual Studio Code.
 
 ---
 
-Enabling XML comments provides debug information for undocumented public methods: __Missing XML comment for publicly visible type or member__
+Enabling XML comments provides debug information for undocumented public types and members.
+Undocumented types and members are indicated by the warning message: *Missing XML comment for publicly visible type or member*.
 
 Configure Swagger to use the generated XML file. For Linux or non-Windows operating systems, file names and paths can be case sensitive. For example, a *ToDoApi.XML* file would be found on Windows but not CentOS.
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
@@ -223,6 +223,8 @@ See Visual Studio Code.
 
 ---
 
+* Remember that enabling XML comments will give a notice when debugging in case not all of your methods are documented: __Missing XML comment for publicly visible type or member__
+
 Configure Swagger to use the generated XML file. For Linux or non-Windows operating systems, file names and paths can be case sensitive. For example, a *ToDoApi.XML* file would be found on Windows but not CentOS.
 
 [!code-csharp[Main](../tutorials/web-api-help-pages-using-swagger/sample/TodoApi/Startup.cs?name=snippet_ConfigureServices&highlight=20-22)]

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/sample/TodoApi/Startup.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/sample/TodoApi/Startup.cs
@@ -30,8 +30,8 @@ namespace TodoApi
                 });
 
                 // Set the comments path for the Swagger JSON and UI.
-                var basePath = PlatformServices.Default.Application.ApplicationBasePath;
-                var xmlPath = Path.Combine(basePath, "TodoApi.xml"); 
+                var basePath = System.AppContext.BaseDirectory;
+                var xmlPath = System.IO.Path.Combine(basePath, "TodoApi.xml"); 
                 c.IncludeXmlComments(xmlPath);                
             });
         }

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/sample/TodoApi/Startup.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/sample/TodoApi/Startup.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,7 +10,7 @@ using TodoApi.Models;
 namespace TodoApi
 {
     public class Startup
-    {       
+    {
         #region snippet_ConfigureServices
         public void ConfigureServices(IServiceCollection services)
         {
@@ -30,9 +31,9 @@ namespace TodoApi
                 });
 
                 // Set the comments path for the Swagger JSON and UI.
-                var basePath = System.AppContext.BaseDirectory;
-                var xmlPath = System.IO.Path.Combine(basePath, "TodoApi.xml"); 
-                c.IncludeXmlComments(xmlPath);                
+                var basePath = AppContext.BaseDirectory;
+                var xmlPath = Path.Combine(basePath, "TodoApi.xml"); 
+                c.IncludeXmlComments(xmlPath);
             });
         }
         #endregion


### PR DESCRIPTION
Enabling the XML documentation will throw __Missing XML comment for publicly visible type or member__ so I thought it's important to give a heads up in the documentation regarding that. Not sure if referencing this [stack overflow thread](https://stackoverflow.com/questions/203863/missing-xml-comment-for-publicly-visible-type-or-member) is something that could be done in the documentation (or maybe create tab style information area on how to ignore them per editor?)

Also I've updated the reading code to be explicit regarding Path.Combine (so you can just copy paste the code) and also replaced the directory path code PlatformServices.Default.Application.ApplicationBasePath using System.AppContext.BaseDirectory since [according to](http://michaco.net/blog/EnvironmentVariablesAndConfigurationInASPNETCoreApps) that's legacy net 4 code and less future proof.