### PR TITLE
Fixing sample code to use ASP.NET Core 2.x DefaultHostBuilder to setup a host

### DIFF
--- a/aspnetcore/hosting/windows-service/sample/Program.cs
+++ b/aspnetcore/hosting/windows-service/sample/Program.cs
@@ -16,14 +16,11 @@ namespace AspNetCoreService
             var pathToExe = Process.GetCurrentProcess().MainModule.FileName;
             var pathToContentRoot = Path.GetDirectoryName(pathToExe);
 
-            var host = new WebHostBuilder()
-            .UseKestrel()
-            .UseContentRoot(pathToContentRoot)
-            .UseIISIntegration()
-            .UseStartup<Startup>()
-            .UseApplicationInsights()
-            .Build();
-
+            var host = WebHost.CreateDefaultBuilder(args)
+                              .UseContentRoot(pathToContentRoot)
+                              .UseStartup<Startup>()
+                              .UseApplicationInsights()
+                              .Build();
             host.RunAsService();
         }
         #endregion
@@ -45,13 +42,11 @@ namespace AspNetCoreService
                 pathToContentRoot = Path.GetDirectoryName(pathToExe);
             }
 
-            var host = new WebHostBuilder()
-            .UseKestrel()
-            .UseContentRoot(pathToContentRoot)
-            .UseIISIntegration()
-            .UseStartup<Startup>()
-            .UseApplicationInsights()
-            .Build();
+           var host = WebHost.CreateDefaultBuilder(args)
+                              .UseContentRoot(pathToContentRoot)
+                              .UseStartup<Startup>()
+                              .UseApplicationInsights()
+                              .Build();
 
             if (isService)
             {


### PR DESCRIPTION
Though, creating a host from WebHostBuilder is supported approach, it sounds 1.x though. Took liberty to upgrade sample to use more compact static CreateDefaultBuilder method

