### PR TITLE
Add port to to the header in Nginx config

### DIFF
--- a/aspnetcore/publishing/linuxproduction.md
+++ b/aspnetcore/publishing/linuxproduction.md
@@ -116,7 +116,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection keep-alive;
-        proxy_set_header Host $host:$server_port;
+        proxy_set_header Host $http_host;
         proxy_cache_bypass $http_upgrade;
     }
 }

--- a/aspnetcore/publishing/linuxproduction.md
+++ b/aspnetcore/publishing/linuxproduction.md
@@ -116,7 +116,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection keep-alive;
-        proxy_set_header Host $host;
+        proxy_set_header Host $host:$server_port;
         proxy_cache_bypass $http_upgrade;
     }
 }


### PR DESCRIPTION
Using `$host` only in HTTP header in Nginx config causes that Kestrel only knows that the host name is *hostname.com* **without any port**. That causes a problem in **redirecting** (e.g. to login page). The user will be directed to the hostname without any port (i.e. to 80 or 443 according to the schema HTTP or HTTPS respectively).

I added `$server_port` to HTTP request header in Nginx config, so the host name will become *hostname.com:8080*. That solves any related redirecting problems.
  
I am not sure if this is related to any opened issue.