### PR TITLE
Update SPA templates references to 2.0.0-rc1-final

### DIFF
--- a/aspnetcore/client-side/index.md
+++ b/aspnetcore/client-side/index.md
@@ -23,7 +23,7 @@ uid: client-side/index
 - [TypeScript](https://www.typescriptlang.org/docs/handbook/asp-net-core.html)
 - [Using Browser Link](xref:client-side/using-browserlink)
 - [Using JavaScriptServices for SPAs](xref:client-side/spa-services)
-- [Using the SPA project templates (preview)](xref:spa/index)
+- [Using the SPA project templates (RC)](xref:spa/index)
     - [Angular project template](xref:spa/angular)
     - [React project template](xref:spa/react)
     - [React with Redux project template](xref:spa/react-with-redux)

--- a/aspnetcore/spa/angular.md
+++ b/aspnetcore/spa/angular.md
@@ -1,7 +1,7 @@
 ---
 title: Use the Angular project template
 author: SteveSandersonMS
-description: Learn how to get started with the ASP.NET Core Single-Page Application (SPA) preview project template for Angular and the Angular CLI.
+description: Learn how to get started with the ASP.NET Core Single-Page Application (SPA) release candidate project template for Angular and the Angular CLI.
 manager: wpickett
 ms.author: scaddie
 ms.custom: mvc
@@ -12,10 +12,10 @@ ms.technology: aspnet
 ms.topic: article
 uid: spa/angular
 ---
-# Use the Angular project template (preview)
+# Use the Angular project template (release candidate)
 
 > [!NOTE]
-> This documentation is not about the released Angular project template. **This documentation is about the preview version of the Angular template.** We hope to ship the released version in early 2018.
+> This documentation is not about the released Angular project template. **This documentation is about the release candidate of the Angular template.** We hope to ship the released version in early 2018.
 
 The updated Angular project template provides a convenient starting point for ASP.NET Core apps using Angular 5 and the Angular CLI to implement a rich, client-side user interface (UI).
 

--- a/aspnetcore/spa/index.md
+++ b/aspnetcore/spa/index.md
@@ -24,10 +24,10 @@ uid: spa/index
 
 ## Installation
 
-Run the following command to install the **preview** release of the ASP.NET Core templates for Angular, React, and React with Redux:
+Run the following command to install the **release candidate** of the ASP.NET Core templates for Angular, React, and React with Redux:
 
 ```console
-dotnet new --install Microsoft.DotNet.Web.Spa.ProjectTemplates::2.0.0-preview1-final
+dotnet new --install Microsoft.DotNet.Web.Spa.ProjectTemplates::2.0.0-rc1-final
 ```
 
 ## Use the templates

--- a/aspnetcore/spa/index.md
+++ b/aspnetcore/spa/index.md
@@ -1,7 +1,7 @@
 ---
 title: Use the Single-Page Application templates
 author: SteveSandersonMS
-description: Learn how to install and get started with the ASP.NET Core Single-Page Application (SPA) preview project templates.
+description: Learn how to install and get started with the ASP.NET Core Single-Page Application (SPA) release candidate project templates.
 manager: wpickett
 ms.author: scaddie
 ms.custom: mvc
@@ -12,7 +12,7 @@ ms.technology: aspnet
 ms.topic: article
 uid: spa/index
 ---
-# Use the Single-Page Application templates (preview)
+# Use the Single-Page Application templates (release candidate)
 
 > [!NOTE]
 > The released .NET Core 2.0.x SDK includes project templates for Angular, React, and React with Redux. **This documentation is not about those released project templates.** This documentation is for the next version of the Angular, React, and React with Redux templates, which we hope to ship in early 2018.

--- a/aspnetcore/spa/react-with-redux.md
+++ b/aspnetcore/spa/react-with-redux.md
@@ -1,7 +1,7 @@
 ---
 title: Use the React-with-Redux project template
 author: SteveSandersonMS
-description: Learn how to get started with the ASP.NET Core Single-Page Application (SPA) preview project template for React with Redux and create-react-app.
+description: Learn how to get started with the ASP.NET Core Single-Page Application (SPA) release candidate project template for React with Redux and create-react-app.
 manager: wpickett
 ms.author: scaddie
 ms.custom: mvc
@@ -12,10 +12,10 @@ ms.technology: aspnet
 ms.topic: article
 uid: spa/react-with-redux
 ---
-# Use the React-with-Redux project template (preview)
+# Use the React-with-Redux project template (release candidate)
 
 > [!NOTE]
-> This documentation is not about the released React-with-Redux project template. **This documentation is about the preview version of the React-with-Redux template.** We hope to ship the released version in early 2018.
+> This documentation is not about the released React-with-Redux project template. **This documentation is about the release candidate of the React-with-Redux template.** We hope to ship the released version in early 2018.
 
 The updated React-with-Redux project template provides a convenient starting point for ASP.NET Core apps using React, Redux, and [create-react-app](https://github.com/facebookincubator/create-react-app) (CRA) conventions to implement a rich, client-side user interface (UI).
 

--- a/aspnetcore/spa/react.md
+++ b/aspnetcore/spa/react.md
@@ -1,7 +1,7 @@
 ---
 title: Use the React project template
 author: SteveSandersonMS
-description: Learn how to get started with the ASP.NET Core Single-Page Application (SPA) preview project template for React and create-react-app.
+description: Learn how to get started with the ASP.NET Core Single-Page Application (SPA) release candidate project template for React and create-react-app.
 manager: wpickett
 ms.author: scaddie
 ms.custom: mvc
@@ -12,10 +12,10 @@ ms.technology: aspnet
 ms.topic: article
 uid: spa/react
 ---
-# Use the React project template (preview)
+# Use the React project template (release candidate)
 
 > [!NOTE]
-> This documentation is not about the released React project template. **This documentation is about the preview version of the React template.** We hope to ship the released version in early 2018.
+> This documentation is not about the released React project template. **This documentation is about the release candidate of the React template.** We hope to ship the released version in early 2018.
 
 The updated React project template provides a convenient starting point for ASP.NET Core apps using React and [create-react-app](https://github.com/facebookincubator/create-react-app) (CRA) conventions to implement a rich, client-side user interface (UI).
 

--- a/aspnetcore/spa/sample/AngularServerSideRendering/AngularServerSideRendering.csproj
+++ b/aspnetcore/spa/sample/AngularServerSideRendering/AngularServerSideRendering.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="2.0.0-rc1-final" />
   </ItemGroup>
 
   <ItemGroup>

--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -153,7 +153,7 @@
 ## [Bundling and minification](xref:client-side/bundling-and-minification)
 ## [Using Browser Link](xref:client-side/using-browserlink)
 ## [Using JavaScriptServices for SPAs](xref:client-side/spa-services)
-## [Using the SPA project templates (preview)](xref:spa/index)
+## [Using the SPA project templates (RC)](xref:spa/index)
 ### [Angular project template](xref:spa/angular)
 ### [React project template](xref:spa/react)
 ### [React with Redux project template](xref:spa/react-with-redux)


### PR DESCRIPTION
We've now published version `2.0.0-rc1-final` of the SPA templates.

The final release should be soon (pending feedback) but this PR is to update the docs to reference the rc1 version in the meantime so people know they can try it.