### PR TITLE
Use double double-quotes for verbatim string literals in RP tutorial?

### DIFF
--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/Models/MovieDateRatingDA.cs
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/Models/MovieDateRatingDA.cs
@@ -23,12 +23,12 @@ namespace RazorPagesMovie.Models
         public decimal Price { get; set; }
         #endregion
 
-        [RegularExpression(@"^[A-Z]+[a-zA-Z''-'\s]*$")]
+        [RegularExpression(@"^[A-Z]+[a-zA-Z""'\s-]*$")]
         [Required]
         [StringLength(30)]
         public string Genre { get; set; }
 
-        [RegularExpression(@"^[A-Z]+[a-zA-Z''-'\s]*$")]
+        [RegularExpression(@"^[A-Z]+[a-zA-Z""'\s-]*$")]
         [StringLength(5)]
         [Required]
         public string Rating { get; set; }

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/Models/MovieDateRatingDAmult.cs
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/Models/MovieDateRatingDAmult.cs
@@ -16,13 +16,13 @@ namespace RazorPagesMovie.Models
         [Display(Name = "Release Date"), DataType(DataType.Date)]
         public DateTime ReleaseDate { get; set; }
 
-        [RegularExpression(@"^[A-Z]+[a-zA-Z''-'\s]*$"), Required, StringLength(30)]
+        [RegularExpression(@"^[A-Z]+[a-zA-Z""'\s-]*$"), Required, StringLength(30)]
         public string Genre { get; set; }
 
         [Range(1, 100), DataType(DataType.Currency)]
         public decimal Price { get; set; }
 
-        [RegularExpression(@"^[A-Z]+[a-zA-Z''-'\s]*$"), StringLength(5)]
+        [RegularExpression(@"^[A-Z]+[a-zA-Z""'\s-]*$"), StringLength(5)]
         public string Rating { get; set; }
     }
 #endregion


### PR DESCRIPTION
Fixes #5140

* Double double-quotes to escape double quotes in verbatim strings. (*Say that ten times fast.* lol)
* Move dash to end of the class.

Please close if DOA, as these expressions might be by-design.