### PR TITLE
Inconsistent usage of the 'role' word

### DIFF
--- a/aspnetcore/security/authorization/roles.md
+++ b/aspnetcore/security/authorization/roles.md
@@ -22,7 +22,7 @@ When an identity is created it may belong to one or more roles. For example, Tra
 
 Role based authorization checks are declarative&mdash;the developer embeds them within their code, against a controller or an action within a controller, specifying roles which the current user must be a member of to access the requested resource.
 
-For example, the following code would limit access to any actions on the `AdministrationController` to users who are a member of the `Administrator` group.
+For example, the following code would limit access to any actions on the `AdministrationController` to users who are a member of the `Administrator` role.
 
 ```csharp
 [Authorize(Roles = "Administrator")]

--- a/aspnetcore/security/authorization/roles.md
+++ b/aspnetcore/security/authorization/roles.md
@@ -20,9 +20,9 @@ When an identity is created it may belong to one or more roles. For example, Tra
 
 ## Adding role checks
 
-Role based authorization checks are declarative&mdash;the developer embeds them within their code, against a controller or an action within a controller, specifying roles which the current user must be a member of to access the requested resource.
+Role-based authorization checks are declarative&mdash;the developer embeds them within their code, against a controller or an action within a controller, specifying roles which the current user must be a member of to access the requested resource.
 
-For example, the following code would limit access to any actions on the `AdministrationController` to users who are a member of the `Administrator` role.
+For example, the following code limits access to any actions on the `AdministrationController` to users who are a member of the `Administrator` role:
 
 ```csharp
 [Authorize(Roles = "Administrator")]


### PR DESCRIPTION
On line 43 the 'Administrator' gets called a 'role' while at line 25 the 'Administrator' gets called a 'group'

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
