### PR TITLE
Suggestion for better wording.

### DIFF
--- a/aspnetcore/includes/RP/model4Win.md
+++ b/aspnetcore/includes/RP/model4Win.md
@@ -1,13 +1,12 @@
 <a name="scaffold"></a>
 ### Scaffold the Movie model
 
-* Open a command window in the project directory (The directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
-* Run the following command:
+* Run the following command from the command line (in the project directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
 
   ```console
   dotnet aspnet-codegenerator razorpage -m Movie -dc MovieContext -udl -outDir Pages\Movies --referenceScriptLibraries
   ```
-  
+
 If you get the error:
   ```
 No executable found matching command "dotnet-aspnet-codegenerator"
@@ -17,8 +16,8 @@ Open a command window in the project directory (The directory that contains the 
 
 If you get the error:
   ```
-  The process cannot access the file 
- 'RazorPagesMovie/bin/Debug/netcoreapp2.0/RazorPagesMovie.dll' 
+  The process cannot access the file
+ 'RazorPagesMovie/bin/Debug/netcoreapp2.0/RazorPagesMovie.dll'
   because it is being used by another process.
   ```
 

--- a/aspnetcore/includes/RP/model4Win.md
+++ b/aspnetcore/includes/RP/model4Win.md
@@ -1,7 +1,7 @@
 <a name="scaffold"></a>
 ### Scaffold the Movie model
 
-* Run the following command from the command line (in the project directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
+* Run the following from the command line (in the project directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files):
 
   ```console
   dotnet aspnet-codegenerator razorpage -m Movie -dc MovieContext -udl -outDir Pages\Movies --referenceScriptLibraries
@@ -12,7 +12,7 @@ If you get the error:
 No executable found matching command "dotnet-aspnet-codegenerator"
   ```
 
-Open a command window in the project directory (The directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
+Open a command shell to the project directory (The directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
 
 If you get the error:
   ```

--- a/aspnetcore/includes/RP/model4x.md
+++ b/aspnetcore/includes/RP/model4x.md
@@ -1,13 +1,12 @@
 <a name="scaffold"></a>
 ### Scaffold the Movie model
 
-* Open a command window in the project directory (The directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
-* Run the following command:
+* Run the following command from the command line (in the project directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
 
   ```console
   dotnet aspnet-codegenerator razorpage -m Movie -dc MovieContext -udl -outDir Pages/Movies --referenceScriptLibraries
   ```
-  
+
 If you get the error:
   ```
 No executable found matching command "dotnet-aspnet-codegenerator"

--- a/aspnetcore/includes/RP/model4x.md
+++ b/aspnetcore/includes/RP/model4x.md
@@ -1,7 +1,7 @@
 <a name="scaffold"></a>
 ### Scaffold the Movie model
 
-* Run the following command from the command line (in the project directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
+* Run the following from the command line (in the project directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files):
 
   ```console
   dotnet aspnet-codegenerator razorpage -m Movie -dc MovieContext -udl -outDir Pages/Movies --referenceScriptLibraries
@@ -12,4 +12,4 @@ If you get the error:
 No executable found matching command "dotnet-aspnet-codegenerator"
   ```
 
-Open a command window in the project directory (The directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).
+Open a command shell to the project directory (The directory that contains the *Program.cs*, *Startup.cs*, and *.csproj* files).


### PR DESCRIPTION
While going through the tutorial on Mac, I was confused by this wording. I assumed that "command window" was something that was part of Visual Studio.

It may be clearer (especially to newcomers) to be consistent with the wording that's only a few lines above "From the command line, run the following .NET Core CLI commands:".

This is just a suggestion, now I realize that the words "Open a command window" appear in many parts of the documentation.

Motivated by my conversation [here](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages-mac/model#scaffold-the-movie-model) (click the livefyre comment icon).
