### PR TITLE
Add .Value for .NET Core 2.0

### DIFF
--- a/aspnetcore/mvc/models/file-uploads/sample/FileUploadSample/MultipartRequestHelper.cs
+++ b/aspnetcore/mvc/models/file-uploads/sample/FileUploadSample/MultipartRequestHelper.cs
@@ -10,7 +10,8 @@ namespace FileUploadSample
         // The spec says 70 characters is a reasonable limit.
         public static string GetBoundary(MediaTypeHeaderValue contentType, int lengthLimit)
         {
-            var boundary = HeaderUtilities.RemoveQuotes(contentType.Boundary);
+            // Add .Value for .NET Core 2.0
+            var boundary = HeaderUtilities.RemoveQuotes(contentType.Boundary).Value;
             if (string.IsNullOrWhiteSpace(boundary))
             {
                 throw new InvalidDataException("Missing content-type boundary.");


### PR DESCRIPTION
Add .Value to convert boundary to string



  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
