### PR TITLE
SEO fix to disambiguate Visual Studio docs from ASP.NET docs

### DIFF
--- a/aspnet/visual-studio/overview/2012/index.md
+++ b/aspnet/visual-studio/overview/2012/index.md
@@ -1,8 +1,8 @@
 ---
 uid: visual-studio/overview/2012/index
-title: "Visual Studio 2012 | Microsoft Docs"
+title: "ASP.NET and Visual Studio 2012 | Microsoft Docs"
 author: rick-anderson
-description: "Visual Studio 2012"
+description: "Developing ASP.NET web apps with Visual Studio 2012"
 ms.author: aspnetcontent
 manager: wpickett
 ms.date: 06/25/2013
@@ -13,9 +13,9 @@ ms.prod: .net-framework
 msc.legacyurl: /visual-studio/overview/2012
 msc.type: chapter
 ---
-Visual Studio 2012
+ASP.NET and Visual Studio 2012
 ====================
-> Visual Studio 2012
+> Developing ASP.NET web apps with Visual Studio 2012
 
 
 - [Visual Studio 2012 HTML Editing Features](visual-studio-2012-html-editing-features.md)


### PR DESCRIPTION
When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
