### PR TITLE
fix regex in url-rewriting.md

### DIFF
--- a/aspnetcore/fundamentals/url-rewriting.md
+++ b/aspnetcore/fundamentals/url-rewriting.md
@@ -364,7 +364,7 @@ Original Request: `/image.jpg`
 | Rewrite path into querystring | `^path/(.*)/(.*)`<br>`/path/abc/123` | `path?var1=$1&var2=$2`<br>`/path?var1=abc&var2=123` |
 | Strip trailing slash | `(.*)/$`<br>`/path/` | `$1`<br>`/path` |
 | Enforce trailing slash | `(.*[^/])$`<br>`/path` | `$1/`<br>`/path/` |
-| Avoid rewriting specific requests | `(.*[^(\.axd)])$`<br>Yes: `/resource.htm`<br>No: `/resource.axd` | `rewritten/$1`<br>`/rewritten/resource.htm`<br>`/resource.axd` |
+| Avoid rewriting specific requests | `^(.*)(?<!\.axd)$` or `^(?!.*\.axd$)(.*)$`<br>Yes: `/resource.htm`<br>No: `/resource.axd` | `rewritten/$1`<br>`/rewritten/resource.htm`<br>`/resource.axd` |
 | Rearrange URL segments | `path/(.*)/(.*)/(.*)`<br>`path/1/2/3` | `path/$3/$2/$1`<br>`path/3/2/1` |
 | Replace a URL segment | `^(.*)/segment2/(.*)`<br>`/segment1/segment2/segment3` | `$1/replaced/$2`<br>`/segment1/replaced/segment3` |
 


### PR DESCRIPTION
In the original, the character class will negate individual characters in brackets, but not the extension as desired. Fixed and tested regex using negative look ahead and negative look behind variations.

