### PR TITLE
Remove code-behind from RP terminology

### DIFF
--- a/aspnetcore/data/ef-rp/crud.md
+++ b/aspnetcore/data/ef-rp/crud.md
@@ -18,7 +18,7 @@ By [Tom Dykstra](https://github.com/tdykstra), [Jon P Smith](https://twitter.com
 
 In this tutorial, the scaffolded CRUD (create, read, update, delete) code is reviewed and customized.
 
-Note: To minimize complexity and keep these tutorials focused on EF Core, EF Core code is used in the Razor Pages code-behind files. Some developers use a service layer or repository pattern in to create an abstraction layer between the UI (Razor Pages) and the data access layer.
+Note: To minimize complexity and keep these tutorials focused on EF Core, EF Core code is used in the Razor Pages page models. Some developers use a service layer or repository pattern in to create an abstraction layer between the UI (Razor Pages) and the data access layer.
 
 In this tutorial, the Create, Edit, Delete, and Details Razor Pages in the *Student* folder are modified.
 
@@ -143,7 +143,7 @@ The value "OverPost" is successfully added to the `Secret` property of the inser
 <a name="vm"></a>
 ### View model
 
-A view model typically contains a subset of the properties included in the model used by the application. The application model is often called the domain model. The domain model typically contains all the properties required by the corresponding entity in the DB. The view model contains only the properties needed for the UI layer (for example, the Create page). In addition to the view model, some apps use a binding model or input model to pass data between the Razor Pages code-behind class and the browser. Consider the following `Student` view model:
+A view model typically contains a subset of the properties included in the model used by the application. The application model is often called the domain model. The domain model typically contains all the properties required by the corresponding entity in the DB. The view model contains only the properties needed for the UI layer (for example, the Create page). In addition to the view model, some apps use a binding model or input model to pass data between the Razor Pages page model class and the browser. Consider the following `Student` view model:
 
 [!code-csharp[Main](intro/samples/cu/Models/StudentVM.cs)]
 
@@ -161,7 +161,7 @@ In Razor Pages, the `PageModel` derived class is the view model.
 
 ## Update the Edit page
 
-Update the Edit page code-behind file:
+Update the page model for the Edit page:
 
 [!code-csharp[Main](intro/samples/cu/Pages/Students/Edit.cshtml.cs?name=snippet_OnPostAsync&highlight=20,36)]
 

--- a/aspnetcore/data/ef-rp/sort-filter-page.md
+++ b/aspnetcore/data/ef-rp/sort-filter-page.md
@@ -103,7 +103,7 @@ Step through the debugger.
 To add filtering to the Students Index page:
 
 * A text box and a submit button is added to the Razor Page. The text box supplies a search string on the first or last name.
-* The code-behind file is updated to use the text box value.
+* The page model is updated to use the text box value.
 
 ### Add filtering functionality to the Index method
 
@@ -241,7 +241,7 @@ Step through the debugger.
 In this step, *Pages/About.cshtml* is updated to display how many students have enrolled for each enrollment date. The update uses grouping, and includes the following steps:
 
 * Create a view model class for the data used by the **About** Page.
-* Modify the About Razor Page and code-behind file.
+* Modify the About Razor Page and page model.
 
 ### Create the view model
 
@@ -251,7 +251,7 @@ In the *SchoolViewModels* folder, add a *EnrollmentDateGroup.cs* with the follow
 
 [!code-csharp[Main](intro/samples/cu/Models/SchoolViewModels/EnrollmentDateGroup.cs)]
 
-### Update the About code-behind page
+### Update the About page model
 
 Update the *Pages/About.cshtml.cs* file with the following code:
 

--- a/aspnetcore/fundamentals/logging/loggermessage.md
+++ b/aspnetcore/fundamentals/logging/loggermessage.md
@@ -87,7 +87,7 @@ The static extension method for adding a quote, `QuoteAdded`, receives the quote
 
 [!code-csharp[Main](loggermessage/sample/Internal/LoggerExtensions.cs?name=snippet10)]
 
-In the Index page's code-behind file (*Pages/Index.cshtml.cs*), `QuoteAdded` is called to log the message:
+In the Index page's page model (*Pages/Index.cshtml.cs*), `QuoteAdded` is called to log the message:
 
 [!code-csharp[Main](loggermessage/sample/Pages/Index.cshtml.cs?name=snippet3&highlight=6)]
 
@@ -109,7 +109,7 @@ Note how the exception is passed to the delegate in `QuoteDeleteFailed`:
 
 [!code-csharp[Main](loggermessage/sample/Internal/LoggerExtensions.cs?name=snippet11)]
 
-In the Index page code-behind, a successful quote deletion calls the `QuoteDeleted` method on the logger. When a quote isn't found for deletion, an `ArgumentNullException` is thrown. The exception is trapped by the `try`&ndash;`catch` statement and logged by calling the `QuoteDeleteFailed` method on the logger in the `catch` block (*Pages/Index.cshtml.cs*):
+In the page model for the Index page, a successful quote deletion calls the `QuoteDeleted` method on the logger. When a quote isn't found for deletion, an `ArgumentNullException` is thrown. The exception is trapped by the `try`&ndash;`catch` statement and logged by calling the `QuoteDeleteFailed` method on the logger in the `catch` block (*Pages/Index.cshtml.cs*):
 
 [!code-csharp[Main](loggermessage/sample/Pages/Index.cshtml.cs?name=snippet5&highlight=14,18)]
 

--- a/aspnetcore/includes/RP/page1.md
+++ b/aspnetcore/includes/RP/page1.md
@@ -106,9 +106,9 @@ The preceding anchor element is a [Tag Helper](xref:mvc/views/tag-helpers/intro)
 
 Save your changes, and test the app by clicking on the **RpMovie** link. See the [_Layout.cshtml](https://github.com/aspnet/Docs/blob/master/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/Pages/_Layout.cshtml) file in GitHub.
 
-### The Create code-behind page
+### The Create page model
 
-Examine the *Pages/Movies/Create.cshtml.cs* code-behind file:
+Examine the *Pages/Movies/Create.cshtml.cs* page model:
 
 [!code-csharp[Main](../../tutorials/razor-pages/razor-pages-start/snapshot_sample/RazorPagesMovie/Pages/Movies/Create.cshtml.cs?name=snippetALL)]
 

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -72,7 +72,7 @@ A similar page, using a `PageModel` class, is shown in the following two files. 
 
 [!code-cshtml[main](index/sample/RazorPagesIntro/Pages/Index2.cshtml)]
 
-The *Pages/Index2.cshtml.cs* "code-behind" file:
+The *Pages/Index2.cshtml.cs* page model:
 
 [!code-cs[main](index/sample/RazorPagesIntro/Pages/Index2.cshtml.cs)]
 
@@ -112,7 +112,7 @@ The *Pages/Create.cshtml* view file:
 
 [!code-cshtml[main](index/sample/RazorPagesContacts/Pages/Create.cshtml)]
 
-The *Pages/Create.cshtml.cs* code-behind file for the view:
+The *Pages/Create.cshtml.cs* page model:
 
 [!code-cs[main](index/sample/RazorPagesContacts/Pages/Create.cshtml.cs?name=snippet_ALL)]
 
@@ -328,7 +328,7 @@ The following markup in the *Pages/Customers/Index.cshtml* file displays the val
 <h3>Msg: @Model.Message</h3>
 ```
 
-The *Pages/Customers/Index.cshtml.cs* code-behind file applies the `[TempData]` attribute to the `Message` property.
+The *Pages/Customers/Index.cshtml.cs* page model applies the `[TempData]` attribute to the `Message` property.
 
 ```cs
 [TempData]
@@ -348,7 +348,7 @@ The following page generates markup for two page handlers using the `asp-page-ha
 
 The form in the preceding example has two submit buttons, each using the `FormActionTagHelper` to submit to a different URL. The `asp-page-handler` attribute is a companion to `asp-page`. `asp-page-handler` generates URLs that submit to each of the handler methods defined by a page. `asp-page` isn't specified because the sample is linking to the current page.
 
-The code-behind file:
+The page model:
 
 [!code-cs[main](index/sample/RazorPagesContacts2/Pages/Customers/CreateFATH.cshtml.cs?highlight=20,32)]
 

--- a/aspnetcore/mvc/razor-pages/razor-pages-convention-features.md
+++ b/aspnetcore/mvc/razor-pages/razor-pages-convention-features.md
@@ -257,7 +257,7 @@ Register the `CustomPageApplicationModelProvider` in the `Startup` class:
 
 [!code-csharp[Main](razor-pages-convention-features/sample/Startup.cs?name=snippet10)]
 
-The code-behind file *Index.cshtml.cs* shows how the ordinary handler method naming conventions are changed for pages in the app. The ordinary "On" prefix naming used with Razor Pages is removed. The method that initializes the page state is now named `Get`. You can see this convention used throughout the app if you open any code-behind file for any of the pages.
+The page model in *Index.cshtml.cs* shows how the ordinary handler method naming conventions are changed for pages in the app. The ordinary "On" prefix naming used with Razor Pages is removed. The method that initializes the page state is now named `Get`. You can see this convention used throughout the app if you open any page model for any of the pages.
 
 Each of the other methods start with the HTTP verb that describes its processing. The two methods that start with `Delete` would normally be treated as DELETE HTTP verbs, but the logic in `TryParseHandlerMethod` explicitly sets the verb to POST for both handlers.
 
@@ -281,7 +281,7 @@ The Page filter ([IPageFilter](/dotnet/api/microsoft.aspnetcore.mvc.filters.ipag
 
 This filter checks for a `globalTemplate` route value of "TriggerValue" and swaps in "ReplacementValue".
 
-The `ReplaceRouteValueFilter` attribute can be applied directly to a `PageModel` in code-behind:
+The `ReplaceRouteValueFilter` attribute can be applied directly to a `PageModel`:
 
 [!code-csharp[Main](razor-pages-convention-features/sample/Pages/OtherPages/Page3.cshtml.cs?range=10-12&highlight=1)]
 

--- a/aspnetcore/tutorials/razor-pages/uploading-files.md
+++ b/aspnetcore/tutorials/razor-pages/uploading-files.md
@@ -71,9 +71,9 @@ Each form group includes a **\<label>** that displays the name of each class pro
 
 Each form group includes a validation **\<span>**. If the user's input fails to meet the property attributes set in the `FileUpload` class or if any of the `ProcessFormFile` method file validation checks fail, the model fails to validate. When model validation fails, a helpful validation message is rendered to the user. For example, the `Title` property is annotated with `[Required]` and `[StringLength(60, MinimumLength = 3)]`. If the user fails to supply a title, they receive a message indicating that a value is required. If the user enters a value less than three characters or more than sixty characters, they receive a message indicating that the value has an incorrect length. If a file is provided that has no content, a message appears indicating that the file is empty.
 
-## Add the code-behind file
+## Add the page model
 
-Add the code-behind file (*Index.cshtml.cs*) to the *Schedules* folder:
+Add the page model (*Index.cshtml.cs*) to the *Schedules* folder:
 
 [!code-csharp[Main](razor-pages-start/sample/RazorPagesMovie/Pages/Schedules/Index.cshtml.cs)]
 
@@ -105,7 +105,7 @@ When the user clicks to delete a schedule, you want them to have a chance to can
 
 [!code-cshtml[Main](razor-pages-start/sample/RazorPagesMovie/Pages/Schedules/Delete.cshtml)]
 
-The code-behind file (*Delete.cshtml.cs*) loads a single schedule identified by `id` in the request's route data. Add the *Delete.cshtml.cs* file to the *Schedules* folder:
+The page model (*Delete.cshtml.cs*) loads a single schedule identified by `id` in the request's route data. Add the *Delete.cshtml.cs* file to the *Schedules* folder:
 
 [!code-csharp[Main](razor-pages-start/sample/RazorPagesMovie/Pages/Schedules/Delete.cshtml.cs)]
 


### PR DESCRIPTION
I avoid using "page model file" in many spots where it was "code-behind file." It seems sufficient to just state "page model."