### PR TITLE
Added missing operating system

### DIFF
--- a/aspnet/signalr/overview/getting-started/supported-platforms.md
+++ b/aspnet/signalr/overview/getting-started/supported-platforms.md
@@ -36,6 +36,7 @@ The SignalR server component can be hosted in the following server or client ope
 
 - Windows Server 2012
 - Windows Server 2008 r2
+- Windows 10
 - Windows 8
 - Windows 7
 - Windows Azure


### PR DESCRIPTION
_Windows 10_ has not been mentioned in the _Supported Platforms_ for SignalR. That has been added.