### PR TITLE
Cookie auth w/o Identity: Tie sample code (sign in) into the topic

### DIFF
--- a/aspnetcore/security/authentication/cookie.md
+++ b/aspnetcore/security/authentication/cookie.md
@@ -164,13 +164,9 @@ To create a cookie holding user information, you must construct a [ClaimsPrincip
 
 # [ASP.NET Core 2.x](#tab/aspnetcore2x)
 
-Call [SignInAsync](/dotnet/api/microsoft.aspnetcore.authentication.authenticationhttpcontextextensions.signinasync?view=aspnetcore-2.0) to sign in the user:
+Create a [ClaimsIdentity](/dotnet/api/system.security.claims.claimsidentity) with any required [Claim](/dotnet/api/system.security.claims.claim)s and call [SignInAsync](/dotnet/api/microsoft.aspnetcore.authentication.authenticationhttpcontextextensions.signinasync?view=aspnetcore-2.0) to sign in the user:
 
-```csharp
-await HttpContext.SignInAsync(
-    CookieAuthenticationDefaults.AuthenticationScheme, 
-    new ClaimsPrincipal(claimsIdentity));
-```
+[!code-csharp[Main](cookie/sample/Pages/Account/Login.cshtml.cs?name=snippet1)]
 
 # [ASP.NET Core 1.x](#tab/aspnetcore1x)
 
@@ -194,10 +190,7 @@ Under the covers, the encryption used is ASP.NET Core's [Data Protection](xref:s
 
 To sign out the current user and delete their cookie, call [SignOutAsync](/dotnet/api/microsoft.aspnetcore.authentication.authenticationhttpcontextextensions.signoutasync?view=aspnetcore-2.0):
 
-```csharp
-await HttpContext.SignOutAsync(
-    CookieAuthenticationDefaults.AuthenticationScheme);
-```
+[!code-csharp[Main](cookie/sample/Pages/Account/Login.cshtml.cs?name=snippet2)]
 
 # [ASP.NET Core 1.x](#tab/aspnetcore1x)
 

--- a/aspnetcore/security/authentication/cookie/sample/Pages/Account/Login.cshtml.cs
+++ b/aspnetcore/security/authentication/cookie/sample/Pages/Account/Login.cshtml.cs
@@ -49,7 +49,10 @@ namespace CookieSample.Pages.Account
             }
 
             // Clear the existing external cookie
-            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            #region snippet2
+            await HttpContext.SignOutAsync(
+                CookieAuthenticationDefaults.AuthenticationScheme);
+            #endregion
 
             ReturnUrl = returnUrl;
         }
@@ -75,6 +78,7 @@ namespace CookieSample.Pages.Account
                     return Page();
                 }
 
+                #region snippet1
                 var claims = new List<Claim>
                 {
                     new Claim(ClaimTypes.Name, user.Email),
@@ -111,7 +115,9 @@ namespace CookieSample.Pages.Account
 
                 await HttpContext.SignInAsync(
                     CookieAuthenticationDefaults.AuthenticationScheme, 
-                    new ClaimsPrincipal(claimsIdentity), authProperties);
+                    new ClaimsPrincipal(claimsIdentity), 
+                    authProperties);
+                #endregion
 
                 _logger.LogInformation($"User {user.Email} logged in at {DateTime.UtcNow}.");
 


### PR DESCRIPTION
John Hargrove remarked on the topic that the establishment of a ClaimsPrincipal wasn't adequately addressed by the topic. I took a closer look, and there's an inline code snippet that doesn't do ClaimsPrincipal/ClaimsIdentity justice. This brings the sample's code into the topic to showcase that setup better.

cc/ @HaoK :point_right: [Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/security/authentication/cookie?branch=pr-en-us-5307&tabs=aspnetcore2x#creating-an-authentication-cookie)