### PR TITLE
M17961: Potential missing verbe: "manage"

### DIFF
--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -118,7 +118,7 @@ The *Pages/Create.cshtml.cs* page model:
 
 By convention, the `PageModel` class is called `<PageName>Model` and is in the same namespace as the page.
 
-The `PageModel` class allows separation of the logic of a page from its presentation. It defines page handlers for requests sent to the page and the data used to render the page. This separation allows you to manage page dependencies through [dependency injection](xref:fundamentals/dependency-injection) and to [unit test](xref:testing/razor-pages-testing) the pages.
+The `PageModel` class allows separation of the logic of a page from its presentation. It defines page handlers for requests sent to the page and the data used to render the page. This separation allows you to manage page dependencies through [dependency injection](xref:fundamentals/dependency-injection) and to manage [unit test](xref:testing/razor-pages-testing) the pages.
 
 The page has an `OnPostAsync` *handler method*, which runs on `POST` requests (when a user posts the form). You can add handler methods for any HTTP verb. The most common handlers are:
 


### PR DESCRIPTION
Hello, @Rick-Anderson, 

Translator has reported possible source content issue.  There is no verb between 'and to' and 'unit test' the pages.

Please, help to check my proposed file change into the article and help to merge if you agree with fix. If not, please, let me know either if you would like me to fix it in another way within this PR, if you prefer to fix it in another PR, or if I should close this PR as by-design. In case of using another PR, please, let me know of your PR number, so we can confirm and close this PR. 

Many thanks in advance.

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
