### PR TITLE
Fixed a jQuery error on the Model validation page

### DIFF
--- a/aspnetcore/mvc/models/validation.md
+++ b/aspnetcore/mvc/models/validation.md
@@ -173,13 +173,13 @@ $.get({
     url: "https://url/that/returns/a/control",
     dataType: "html",
     error: function(jqXHR, textStatus, errorThrown) {
-        alert(textStatus + ": Couldn't add form. " + errorThrown);
+        alert(textStatus + ": Couldn't add control. " + errorThrown);
     },
     success: function(newInputHTML) {
         var form = document.getElementById("my-form");
         form.insertAdjacentHTML("beforeend", newInputHTML);
-        form.removeData("validator")    // Added by the raw jQuery Validate
-            .removeData("unobtrusiveValidation");   // Added by jQuery Unobtrusive Validation
+        $(form).removeData("validator")    // Added by jQuery Validate
+               .removeData("unobtrusiveValidation");   // Added by jQuery Unobtrusive Validation
         $.validator.unobtrusive.parse(form);
     }
 })


### PR DESCRIPTION
The code samples added while fixing #4752 attempted to use the jQuery [`removeData()`](https://api.jquery.com/removeData/) function on a vanilla FormElement.  As pointed out in a comment by user Allen_Wang1 on the [Add Validation to Dynamic Controls](https://docs.microsoft.com/en-us/aspnet/core/mvc/models/validation#add-validation-to-dynamic-controls) section of the Model Validation docs page, this results in an `Uncaught TypeError`.  This PR fixes that error.