### PR TITLE
Update SPA templates references to 2.0.0-rc2-final

### DIFF
--- a/aspnetcore/spa/index.md
+++ b/aspnetcore/spa/index.md
@@ -27,7 +27,7 @@ uid: spa/index
 Run the following command to install the **release candidate** of the ASP.NET Core templates for Angular, React, and React with Redux:
 
 ```console
-dotnet new --install Microsoft.DotNet.Web.Spa.ProjectTemplates::2.0.0-rc1-final
+dotnet new --install Microsoft.DotNet.Web.Spa.ProjectTemplates::2.0.0-rc2-final
 ```
 
 ## Use the templates

--- a/aspnetcore/spa/sample/AngularServerSideRendering/AngularServerSideRendering.csproj
+++ b/aspnetcore/spa/sample/AngularServerSideRendering/AngularServerSideRendering.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="2.0.0-rc1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="2.0.0-rc2-final" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hopefully the final release will be in the next week, but in the meantime it's useful to update the docs so people try out the new RC2 build.