### PR TITLE
Update caching documentation for VaryByQueryKeys

### DIFF
--- a/aspnetcore/performance/caching/middleware.md
+++ b/aspnetcore/performance/caching/middleware.md
@@ -74,6 +74,8 @@ if (responseCachingFeature != null)
 }
 ```
 
+Using a single value equal to `*` in `VaryByQueryKeys` varies the cache by all request query parameters.
+
 ## HTTP headers used by Response Caching Middleware
 
 Response caching by the middleware is configured using HTTP headers.


### PR DESCRIPTION
The source indicates that using `*` as a single value in VaryByQueryKeys is also valid.

See https://github.com/aspnet/ResponseCaching/blob/release/2.0/src/Microsoft.AspNetCore.ResponseCaching/Internal/ResponseCachingKeyProvider.cs#L165

