### PR TITLE
Typos in ef-rp/read-related-data.md

### DIFF
--- a/aspnetcore/data/ef-rp/read-related-data.md
+++ b/aspnetcore/data/ef-rp/read-related-data.md
@@ -122,7 +122,7 @@ The `OnGetAsync` method loads related data with the `Include` method:
 
 [!code-csharp[Main](intro/samples/cu/Pages/Courses/Index.cshtml.cs?name=snippet_RevisedIndexMethod&highlight=4)]
 
-The `Select` operator loads only the related data needed. For single items, like the `Department.Name` it uses a SQL INNER JOIN. For collections, it uses another database access, but so does the .`Include` operator on collections.
+The `Select` operator loads only the related data needed. For single items, like the `Department.Name` it uses a SQL INNER JOIN. For collections, it uses another database access, but so does the `Include` operator on collections.
 
 The following code loads related data with the `Select` method:
 

--- a/aspnetcore/data/ef-rp/read-related-data.md
+++ b/aspnetcore/data/ef-rp/read-related-data.md
@@ -144,7 +144,7 @@ In this section, the Instructors page is created.
 This page reads and displays related data in the following ways:
 
 * The list of instructors displays related data from the `OfficeAssignment` entity (Office in the preceding image). The `Instructor` and `OfficeAssignment` entities are in a one-to-zero-or-one relationship. Eager loading is used for the `OfficeAssignment` entities. Eager loading is typically more efficient when the related data needs to be displayed. In this case, office assignments for the instructors are displayed.
-* When the user selects an instructor (Harui in the preceding image), related `Course` entities are displayed. The `Instructor` and `Course` entities are in a many-to-many relationship. Eager loading for the `Course` entities and their related `Department` entities is used. In this case, separate queries might be more efficient because only courses for the selected instructor are needed. This example shows how to use eager loading for navigation properties in entities that are in navigation properties.
+* When the user selects an instructor (Harui in the preceding image), related `Course` entities are displayed. The `Instructor` and `Course` entities are in a many-to-many relationship. Eager loading is used for the `Course` entities and their related `Department` entities. In this case, separate queries might be more efficient because only courses for the selected instructor are needed. This example shows how to use eager loading for navigation properties in entities that are in navigation properties.
 * When the user selects a course (Chemistry in the preceding image), related data from the `Enrollments` entity is displayed. In the preceding image, student name and grade are displayed. The `Course` and `Enrollment` entities are in a one-to-many relationship.
 
 ### Create a view model for the Instructor Index view
@@ -197,7 +197,7 @@ Update *Pages/Instructors/Index.cshtml* with the following markup:
 
 The preceding markup makes the following changes:
 
-* Updates the `page` directive from `@page` to `@page "{id:int?}"`. `"{id:int?}"` is a route template. The route template changes integer query strings in the URL to route data. For example, clicking on the **Select** link for an instructor when the page directive produces a URL like the following:
+* Updates the `page` directive from `@page` to `@page "{id:int?}"`. `"{id:int?}"` is a route template. The route template changes integer query strings in the URL to route data. For example, clicking on the **Select** link for an instructor with only the `@page` directive produces a URL like the following:
 
 	`http://localhost:1234/Instructors?id=2`
 

--- a/aspnetcore/data/ef-rp/read-related-data.md
+++ b/aspnetcore/data/ef-rp/read-related-data.md
@@ -122,7 +122,7 @@ The `OnGetAsync` method loads related data with the `Include` method:
 
 [!code-csharp[Main](intro/samples/cu/Pages/Courses/Index.cshtml.cs?name=snippet_RevisedIndexMethod&highlight=4)]
 
-The `Select` operator loads only the related data needed. For single items, like the `Department.Name` it uses a SQL INNER JOIN. For collections it uses another database access, but so does the .`Include` operator on collections.
+The `Select` operator loads only the related data needed. For single items, like the `Department.Name` it uses a SQL INNER JOIN. For collections, it uses another database access, but so does the .`Include` operator on collections.
 
 The following code loads related data with the `Select` method:
 


### PR DESCRIPTION
For collections it uses... : add comma

Does 'Eager loading for the `Course` entities and their related `Department` entities is used' means 'Eager loading is used for the `Course` entities and their related `Department` entities'?

'related data from the `Enrollments` entity is displayed' => may be 'are displayed' ?

'clicking on the **Select** link for an instructor when the page directive produces a URL like the following': There must be some missing words.