### PR TITLE
Add example IApplicationLifetime.StopApplication

### DIFF
--- a/aspnetcore/fundamentals/hosting.md
+++ b/aspnetcore/fundamentals/hosting.md
@@ -860,7 +860,7 @@ public class Startup
 }
 ```
 
-[StopApplication](/dotnet/api/microsoft.aspnetcore.hosting.iapplicationlifetime.stopapplication) requests termination of the app. The following Razor Pages page model class uses `StopApplication` to gracefully shutdown an app when a shutdown button is selected in the UI:
+[StopApplication](/dotnet/api/microsoft.aspnetcore.hosting.iapplicationlifetime.stopapplication) requests termination of the app. The following [Razor Pages](xref:mvc/razor-pages/index) page model class uses `StopApplication` to gracefully shutdown an app. The `OnPostShutdown` method executes after a shutdown button in the UI is selected:
 
 ```cshtml
 <button type="submit" asp-page-handler="Shutdown" class="btn btn-default">Shutdown</button>

--- a/aspnetcore/fundamentals/hosting.md
+++ b/aspnetcore/fundamentals/hosting.md
@@ -860,7 +860,7 @@ public class Startup
 }
 ```
 
-[StopApplication](/dotnet/api/microsoft.aspnetcore.hosting.iapplicationlifetime.stopapplication) requests termination of the app. The following [Razor Pages](xref:mvc/razor-pages/index) page model class uses `StopApplication` to gracefully shutdown an app. The `OnPostShutdown` method executes after a shutdown button in the UI is selected:
+[StopApplication](/dotnet/api/microsoft.aspnetcore.hosting.iapplicationlifetime.stopapplication) requests termination of the app. The following [Razor Pages](xref:mvc/razor-pages/index) page model class uses `StopApplication` to gracefully shutdown an app. The `OnPostShutdown` method executes after the **Shutdown** button in the UI is selected:
 
 ```cshtml
 <button type="submit" asp-page-handler="Shutdown" class="btn btn-default">Shutdown</button>

--- a/aspnetcore/fundamentals/hosting.md
+++ b/aspnetcore/fundamentals/hosting.md
@@ -818,17 +818,13 @@ public async Task Invoke(HttpContext context, IHostingEnvironment env)
 
 ## IApplicationLifetime interface
 
-[IApplicationLifetime](/aspnet/core/api/microsoft.aspnetcore.hosting.iapplicationlifetime) allows for post-startup and shutdown activities. Three properties on the interface are cancellation tokens used to register `Action` methods that define startup and shutdown events. There's also a `StopApplication` method.
+[IApplicationLifetime](/aspnet/core/api/microsoft.aspnetcore.hosting.iapplicationlifetime) allows for post-startup and shutdown activities. Three properties on the interface are cancellation tokens used to register `Action` methods that define startup and shutdown events.
 
 | Cancellation Token    | Triggered when&#8230; |
 | --------------------- | --------------------- |
 | `ApplicationStarted`  | The host has fully started. |
 | `ApplicationStopping` | The host is performing a graceful shutdown. Requests may still be processing. Shutdown blocks until this event completes. |
 | `ApplicationStopped`  | The host is completing a graceful shutdown. All requests should be processed. Shutdown blocks until this event completes. |
-
-| Method            | Action                                           |
-| ----------------- | ------------------------------------------------ |
-| `StopApplication` | Requests termination of the current application. |
 
 ```csharp
 public class Startup 
@@ -860,6 +856,34 @@ public class Startup
     private void OnStopped()
     {
         // Perform post-stopped activities here
+    }
+}
+```
+
+[StopApplication](/dotnet/api/microsoft.aspnetcore.hosting.iapplicationlifetime.stopapplication) requests termination of the app. The following Razor Pages page model class uses `StopApplication` to gracefully shutdown an app when a shutdown button is selected in the UI:
+
+```cshtml
+<button type="submit" asp-page-handler="Shutdown" class="btn btn-default">Shutdown</button>
+```
+
+```csharp
+public class IndexModel : PageModel
+{
+    private readonly IApplicationLifetime _appLifetime;
+
+    public IndexModel(IApplicationLifetime appLifetime)
+    {
+        _appLifetime = appLifetime;
+    }
+
+    public void OnGet()
+    {
+        ...
+    }
+
+    public void OnPostShutdown()
+    {
+        _appLifetime.StopApplication();
     }
 }
 ```


### PR DESCRIPTION
This surfaces `StopApplication` with a quick RP example. Feels like this method won't be very useful outside of debugging scenarios, but it might be good to show how it can be used to gracefully shutdown an app from a web app UI. Because this probably releases locked files, it might be useful in some deployment scenarios.