### PR TITLE
Surface the new public style manual

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,10 @@ DocFX requires the .NET Framework on Windows, or Mono for Linux or macOS.
 
 Our goal is to write documentation that is easily understandable by the widest possible audience. To that end we have established guidelines for writing style that we ask our contributors to follow. For more information, see [Voice and tone guidelines](https://github.com/dotnet/docs/blob/master/styleguide/voice-tone.md) in the .NET repo.
 
+## Microsoft Writing Style Guide
+
+The [Microsoft Writing Style Guide](/style-guide/welcome/) provides writing style and terminology guidance for all forms of technology communication, including the ASP.NET Core documentation.
+
 ## Redirects
 
 If you delete an article, change its file name, or move it to a different folder, create a redirect so that people who bookmarked the article won't get 404s.  Add redirects to the [master redirect file](https://github.com/aspnet/Docs/blob/master/.openpublishing.redirection.json).


### PR DESCRIPTION
Suggestion: Placed into its own section here because it goes beyond "voice and tone."

Note that the voice and tone doc pushes conversational tone and 2nd person more than I think we're actually embracing here. It might be best to carve out active voice, reading level, future tense, and the note at the end for this doc and drop the link to the voice and tone doc ... let me know.

[Voice and tone doc](https://github.com/dotnet/docs/blob/master/styleguide/voice-tone.md)