### PR TITLE
Remove log filtering from Logger Message samp

### DIFF
--- a/aspnetcore/fundamentals/logging/loggermessage.md
+++ b/aspnetcore/fundamentals/logging/loggermessage.md
@@ -140,7 +140,7 @@ The sample app has a **Clear All** button for deleting all of the quotes in the 
 
 Enable `IncludeScopes` in the console logger options:
 
-[!code-csharp[Main](loggermessage/sample/Program.cs?name=snippet1&highlight=22)]
+[!code-csharp[Main](loggermessage/sample/Program.cs?name=snippet1&highlight=10)]
 
 Setting `IncludeScopes` is required in ASP.NET Core 2.0 apps to enable log scopes. Setting `IncludeScopes` via *appsettings* configuration files is a feature that's planned for the ASP.NET Core 2.1 release.
 

--- a/aspnetcore/fundamentals/logging/loggermessage/sample/Program.cs
+++ b/aspnetcore/fundamentals/logging/loggermessage/sample/Program.cs
@@ -17,22 +17,10 @@ namespace LoggerMessageSample
                 .UseStartup<Startup>()
                 .ConfigureLogging((hostingContext, logging) =>
                 {
-                    // Remove the Debug provider (and other providers) and filter most
-                    // of the remaining logging. Reducing the logging output makes it
-                    // easier to see the log messages produced by the LoggerMessage
-                    // pattern demonstrated in this sample app.
-                    //
                     // Setting options.IncludeScopes is required in ASP.NET Core 2.0
                     // apps. Setting IncludeScopes via appsettings configuration files
                     // is a feature that's planned for the ASP.NET Core 2.1 release.
                     // See: https://github.com/aspnet/Logging/pull/706
-                    logging.ClearProviders();
-                    logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
-                    logging.AddFilter("Microsoft.EntityFrameworkCore.Update", LogLevel.None);
-                    logging.AddFilter("Microsoft.EntityFrameworkCore.Infrastructure", LogLevel.None);
-                    logging.AddFilter("Microsoft.AspNetCore.Mvc.RedirectToRouteResult", LogLevel.None);
-                    logging.AddFilter("Microsoft.AspNetCore.Mvc.RazorPages.Internal.PageActionInvoker", LogLevel.None);
-                    logging.AddFilter("Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware", LogLevel.None);
                     logging.AddConsole(options => options.IncludeScopes = true);
                 })
                 .Build();


### PR DESCRIPTION
Per @davidfowl ... devs might start doing something like this all the time. It was here to clean up the output so that the messages are super-easy to see; but if it shows a foul pattern, then it should go.