### PR TITLE
Typo error updated

### DIFF
--- a/aspnetcore/includes/mvc-intro/adding_view2.md
+++ b/aspnetcore/includes/mvc-intro/adding_view2.md
@@ -18,7 +18,7 @@ Tap the menu links (**MvcMovie**, **Home**, **About**). Each page shows the same
 
 ## Change the title and menu link in the layout file
 
-In the title element, change `MvcMovie` to `Movie App`. Change the anchor text in the layout template from `MvcMovie` to `Mvc Movie` and the controller from `Home` to `Movies` as highlighted below:
+In the title element, change `MvcMovie` to `Movie App`. Change the anchor text in the layout template from `MvcMovie` to `Movie App` and the controller from `Home` to `Movies` as highlighted below:
 
 Note: The ASP.NET Core 2.0 version is slightly different. It doesn't contain `@inject ApplicationInsights` and `@Html.Raw(JavaScriptSnippet.FullScript)`.
 


### PR DESCRIPTION
Mvc Movie changed to Movie App, since anchor text on layout was change from MvcMovie to Movie App on Index.cshtml file

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
