### PR TITLE
DI scope validation enabled by default

### DIFF
--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -188,6 +188,10 @@ Observe which of the `OperationId` values vary within a request, and between req
 
 * *Singleton* objects are the same for every object and every request (regardless of whether an instance is provided in `ConfigureServices`)
 
+## Scope validation
+
+In ASP.NET Core 2.0 or later, the default service provider performs a check to verify that scoped services aren't resolved from the root provider when the app is running in the Development environment. For more information, see [Scope validation in the Hosting topic](xref:fundamentals/hosting#scope-validation).
+
 ## Request Services
 
 The services available within an ASP.NET request from `HttpContext` are exposed through the `RequestServices` collection.

--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -192,8 +192,12 @@ Observe which of the `OperationId` values vary within a request, and between req
 
 When the app is running in the Development environment on ASP.NET Core 2.0 or later, the default service provider performs checks to verify that:
 
-* Scoped services aren't directly or indirectly resolved from the root provider.
+* Scoped services aren't directly or indirectly resolved from the root service provider.
 * Scoped services aren't directly or indirectly injected into singletons.
+
+The root service provider is created when [BuildServiceProvider](/dotnet/api/microsoft.extensions.dependencyinjection.servicecollectioncontainerbuilderextensions.buildserviceprovider) is called. The root service provider's lifetime usually corresponds to the app/server's lifetime.
+
+Scoped services are disposed by the container that created them. If a scoped service is created in the root container, the service's lifetime is effectively promoted to singleton because it's only disposed by the root container when app/server is shut down. Validating service scopes catches these situations when `BuildServiceProvider` is called.
 
 For more information, see [Scope validation in the Hosting topic](xref:fundamentals/hosting#scope-validation).
 

--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -195,7 +195,7 @@ When the app is running in the Development environment on ASP.NET Core 2.0 or la
 * Scoped services aren't directly or indirectly resolved from the root service provider.
 * Scoped services aren't directly or indirectly injected into singletons.
 
-The root service provider is created when [BuildServiceProvider](/dotnet/api/microsoft.extensions.dependencyinjection.servicecollectioncontainerbuilderextensions.buildserviceprovider) is called. The root service provider's lifetime usually corresponds to the app/server's lifetime.
+The root service provider is created when [BuildServiceProvider](/dotnet/api/microsoft.extensions.dependencyinjection.servicecollectioncontainerbuilderextensions.buildserviceprovider) is called. The root service provider's lifetime corresponds to the app/server's lifetime when the provider starts with the app and is disposed when the app shuts down.
 
 Scoped services are disposed by the container that created them. If a scoped service is created in the root container, the service's lifetime is effectively promoted to singleton because it's only disposed by the root container when app/server is shut down. Validating service scopes catches these situations when `BuildServiceProvider` is called.
 

--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -190,7 +190,12 @@ Observe which of the `OperationId` values vary within a request, and between req
 
 ## Scope validation
 
-In ASP.NET Core 2.0 or later, the default service provider performs a check to verify that scoped services aren't resolved from the root provider when the app is running in the Development environment. For more information, see [Scope validation in the Hosting topic](xref:fundamentals/hosting#scope-validation).
+When the app is running in the Development environment on ASP.NET Core 2.0 or later, the default service provider performs checks to verify that:
+
+* Scoped services aren't directly or indirectly resolved from the root provider.
+* Scoped services aren't directly or indirectly injected into singletons.
+
+For more information, see [Scope validation in the Hosting topic](xref:fundamentals/hosting#scope-validation).
 
 ## Request Services
 

--- a/aspnetcore/fundamentals/hosting.md
+++ b/aspnetcore/fundamentals/hosting.md
@@ -898,7 +898,7 @@ When `ValidateScopes` is set to `true`, the default service provider performs ch
 * Scoped services aren't directly or indirectly resolved from the root service provider.
 * Scoped services aren't directly or indirectly injected into singletons.
 
-The root service provider is created when [BuildServiceProvider](/dotnet/api/microsoft.extensions.dependencyinjection.servicecollectioncontainerbuilderextensions.buildserviceprovider) is called. The root service provider's lifetime usually corresponds to the app/server's lifetime.
+The root service provider is created when [BuildServiceProvider](/dotnet/api/microsoft.extensions.dependencyinjection.servicecollectioncontainerbuilderextensions.buildserviceprovider) is called. The root service provider's lifetime corresponds to the app/server's lifetime when the provider starts with the app and is disposed when the app shuts down.
 
 Scoped services are disposed by the container that created them. If a scoped service is created in the root container, the service's lifetime is effectively promoted to singleton because it's only disposed by the root container when app/server is shut down. Validating service scopes catches these situations when `BuildServiceProvider` is called.
 

--- a/aspnetcore/fundamentals/hosting.md
+++ b/aspnetcore/fundamentals/hosting.md
@@ -895,8 +895,12 @@ In ASP.NET Core 2.0 or later, [CreateDefaultBuilder](/dotnet/api/microsoft.aspne
 
 When `ValidateScopes` is set to `true`, the default service provider performs checks to verify that:
 
-* Scoped services aren't directly or indirectly resolved from the root provider.
+* Scoped services aren't directly or indirectly resolved from the root service provider.
 * Scoped services aren't directly or indirectly injected into singletons.
+
+The root service provider is created when [BuildServiceProvider](/dotnet/api/microsoft.extensions.dependencyinjection.servicecollectioncontainerbuilderextensions.buildserviceprovider) is called. The root service provider's lifetime usually corresponds to the app/server's lifetime.
+
+Scoped services are disposed by the container that created them. If a scoped service is created in the root container, the service's lifetime is effectively promoted to singleton because it's only disposed by the root container when app/server is shut down. Validating service scopes catches these situations when `BuildServiceProvider` is called.
 
 To always validate scopes, including in the Production environment, configure the [ServiceProviderOptions](/dotnet/api/microsoft.extensions.dependencyinjection.serviceprovideroptions) with [UseDefaultServiceProvider](/dotnet/api/microsoft.aspnetcore.hosting.webhostbuilderextensions.usedefaultserviceprovider) on the host builder:
 

--- a/aspnetcore/fundamentals/hosting.md
+++ b/aspnetcore/fundamentals/hosting.md
@@ -893,7 +893,12 @@ public class IndexModel : PageModel
 
 In ASP.NET Core 2.0 or later, [CreateDefaultBuilder](/dotnet/api/microsoft.aspnetcore.webhost.createdefaultbuilder) sets [ServiceProviderOptions.ValidateScopes](/dotnet/api/microsoft.extensions.dependencyinjection.serviceprovideroptions.validatescopes) to `true` if the app's environment is Development.
 
-When `ValidateScopes` is set to `true`, the default service provider performs a check to verify that scoped services aren't resolved from the root provider. To always validate scopes, including in the Production environment, configure the [ServiceProviderOptions](/dotnet/api/microsoft.extensions.dependencyinjection.serviceprovideroptions) with [UseDefaultServiceProvider](/dotnet/api/microsoft.aspnetcore.hosting.webhostbuilderextensions.usedefaultserviceprovider) on the host builder:
+When `ValidateScopes` is set to `true`, the default service provider performs checks to verify that:
+
+* Scoped services aren't directly or indirectly resolved from the root provider.
+* Scoped services aren't directly or indirectly injected into singletons.
+
+To always validate scopes, including in the Production environment, configure the [ServiceProviderOptions](/dotnet/api/microsoft.extensions.dependencyinjection.serviceprovideroptions) with [UseDefaultServiceProvider](/dotnet/api/microsoft.aspnetcore.hosting.webhostbuilderextensions.usedefaultserviceprovider) on the host builder:
 
 ```csharp
 WebHost.CreateDefaultBuilder(args)

--- a/aspnetcore/fundamentals/hosting.md
+++ b/aspnetcore/fundamentals/hosting.md
@@ -36,6 +36,7 @@ Create a host using an instance of [WebHostBuilder](/dotnet/api/microsoft.aspnet
   * Command-line arguments.
 * Configures [logging](xref:fundamentals/logging/index) for console and debug output. Logging includes [log filtering](xref:fundamentals/logging/index#log-filtering) rules specified in a Logging configuration section of an *appsettings.json* or *appsettings.{Environment}.json* file.
 * When running behind IIS, enables [IIS integration](xref:host-and-deploy/iis/index). Configures the base path and port the server listens on when using the [ASP.NET Core Module](xref:fundamentals/servers/aspnet-core-module). The module creates a reverse proxy between IIS and Kestrel. Also configures the app to [capture startup errors](#capture-startup-errors). For the IIS default options, see [the IIS options section of Host ASP.NET Core on Windows with IIS](xref:host-and-deploy/iis/index#iis-options).
+* Sets [ServiceProviderOptions.ValidateScopes](/dotnet/api/microsoft.extensions.dependencyinjection.serviceprovideroptions.validatescopes) to `true` if the app's environment is Development. For more information, see [Scope validation](#scope-validation).
 
 The *content root* determines where the host searches for content files, such as MVC view files. When the app is started from the project's root folder, the project's root folder is used as the content root. This is the default used in [Visual Studio](https://www.visualstudio.com/) and the [dotnet new templates](/dotnet/core/tools/dotnet-new).
 
@@ -886,6 +887,19 @@ public class IndexModel : PageModel
         _appLifetime.StopApplication();
     }
 }
+```
+
+## Scope validation
+
+In ASP.NET Core 2.0 or later, [CreateDefaultBuilder](/dotnet/api/microsoft.aspnetcore.webhost.createdefaultbuilder) sets [ServiceProviderOptions.ValidateScopes](/dotnet/api/microsoft.extensions.dependencyinjection.serviceprovideroptions.validatescopes) to `true` if the app's environment is Development.
+
+When `ValidateScopes` is set to `true`, the default service provider performs a check to verify that scoped services aren't resolved from the root provider. To always validate scopes, including in the Production environment, configure the [ServiceProviderOptions](/dotnet/api/microsoft.extensions.dependencyinjection.serviceprovideroptions) with [UseDefaultServiceProvider](/dotnet/api/microsoft.aspnetcore.hosting.webhostbuilderextensions.usedefaultserviceprovider) on the host builder:
+
+```csharp
+WebHost.CreateDefaultBuilder(args)
+    .UseDefaultServiceProvider((context, options) => {
+        options.ValidateScopes = true;
+    })
 ```
 
 ## Troubleshooting System.ArgumentException


### PR DESCRIPTION
Fixes #3660 

[Internal Review Topic (DI)](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?branch=pr-en-us-5507#scope-validation)
[Internal Review Topic (Hosting)](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/hosting?branch=pr-en-us-5507#scope-validation)

@pakrym The docs don't describe the "root provider" anywhere. I don't think we can put this up without briefly describing it and why scoped services shouldn't be resolved from it. If you'll provide a few notes, I'll wordsmith them in here.