### PR TITLE
Iterating the PendingRequirements collection and calling Succeed on a…

### DIFF
--- a/aspnetcore/security/authorization/policies/samples/PoliciesAuthApp1/Services/Handlers/PermissionHandler.cs
+++ b/aspnetcore/security/authorization/policies/samples/PoliciesAuthApp1/Services/Handlers/PermissionHandler.cs
@@ -10,7 +10,9 @@
     {
         public Task HandleAsync(AuthorizationHandlerContext context)
         {
-            foreach (var requirement in context.PendingRequirements)
+            var pendingRequirements = context.PendingRequirements.ToList();
+
+            foreach (var requirement in pendingRequirements)
             {
                 if (requirement is ReadPermission)
                 {


### PR DESCRIPTION
Iterating the `PendingRequirements` collection and calling `Succeed()` on an element modifies the underlying collection which triggers an `InvalidOperationException`. This behavior isn't going to be changed: https://github.com/aspnet/Security/issues/1375