### PR TITLE
Fix link to writing style guide in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Our goal is to write documentation that is easily understandable by the widest p
 
 ## Microsoft Writing Style Guide
 
-The [Microsoft Writing Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/) provides writing style and terminology guidance for all forms of technology communication, including the ASP.NET Core documentation.
+The [Microsoft Writing Style Guide](https://docs.microsoft.com/style-guide/welcome/) provides writing style and terminology guidance for all forms of technology communication, including the ASP.NET Core documentation.
 
 ## Redirects
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Our goal is to write documentation that is easily understandable by the widest p
 
 ## Microsoft Writing Style Guide
 
-The [Microsoft Writing Style Guide](/style-guide/welcome/) provides writing style and terminology guidance for all forms of technology communication, including the ASP.NET Core documentation.
+The [Microsoft Writing Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/) provides writing style and terminology guidance for all forms of technology communication, including the ASP.NET Core documentation.
 
 ## Redirects
 


### PR DESCRIPTION
The link to Microsoft Writing Style Guide was pointing to `/style-guide/welcome/` path that does not exist in this project's repository. As I have not found the GitHub project that contains the source for Microsoft Writing Style Guide, I modify the link to point to the published version at Microsoft website.
