### PR TITLE
Make consistent use of IList in Movie page model

### DIFF
--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/Pages/Movies/Index.cshtml.cs
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/Pages/Movies/Index.cshtml.cs
@@ -23,7 +23,7 @@ namespace RazorPagesMovie.Pages.Movies
             _context = context;
         }
 
-        public List<Movie> Movie;
+        public IList<Movie> Movie;
         public SelectList Genres;
         public string MovieGenre { get; set; }
         #endregion


### PR DESCRIPTION
This PR tries to ensure consistent use of `IList` interface for declaring collection of `Movie` in tutorial about Razor Pages.

The code snippet displayed in ["Adding search to ..."](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/search) was using `List` class instead of `IList` interface when declaring `Movie` collection in Movie's page model. It was different from previous step of the tutorial (i.e. ["Scaffolded Razor Pages ..."](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/page) where `Movie` collection was declared using `IList` interface. 

Additionally, `Schedule` page model already using `IList` for declaring the collection of schedule in the index page.