### PR TITLE
Convert SignalR Prereqs section's h1 heading to h2

### DIFF
--- a/aspnetcore/signalr/get-started-signalr-core.md
+++ b/aspnetcore/signalr/get-started-signalr-core.md
@@ -28,7 +28,7 @@ This tutorial demonstrates the following SignalR development tasks:
 > * Create a SignalR hub to push content to clients.
 > * Use the SignalR JavaScript library to send messages and display updates from the hub.
 
-# Prerequisites
+## Prerequisites
 
 Install the following software:
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/Docs/issues/5620