### PR TITLE
Surface the intro topic in the RP tutorial

### DIFF
--- a/aspnetcore/mvc/controllers/actions.md
+++ b/aspnetcore/mvc/controllers/actions.md
@@ -35,7 +35,7 @@ Controllers should follow the [Explicit Dependencies Principle](http://deviq.com
 
 Within the **M**odel-**V**iew-**C**ontroller pattern, a controller is responsible for the initial processing of the request and instantiation of the model. Generally, business decisions should be performed within the model.
 
-The controller takes the result of the model's processing (if any) and returns either the proper view and its associated view data or the result of the API call. Learn more at [Overview of ASP.NET Core MVC](xref:mvc/overview) and [Getting started with ASP.NET Core MVC and Visual Studio](xref:tutorials/first-mvc-app/start-mvc).
+The controller takes the result of the model's processing (if any) and returns either the proper view and its associated view data or the result of the API call. Learn more at [Overview of ASP.NET Core MVC](xref:mvc/overview) and [Get started with ASP.NET Core MVC and Visual Studio](xref:tutorials/first-mvc-app/start-mvc).
 
 The controller is a *UI-level* abstraction. Its responsibilities are to ensure request data is valid and to choose which view (or result for an API) should be returned. In well-factored apps, it doesn't directly include data access or business logic. Instead, the controller delegates to services handling these responsibilities.
 

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -16,7 +16,7 @@ By [Rick Anderson](https://twitter.com/RickAndMSFT) and [Ryan Nowak](https://git
 
 Razor Pages is a new feature of ASP.NET Core MVC that makes coding page-focused scenarios easier and more productive.
 
-If you're looking for a tutorial that uses the Model-View-Controller approach, see [Getting started with ASP.NET Core MVC](xref:tutorials/first-mvc-app/start-mvc).
+If you're looking for a tutorial that uses the Model-View-Controller approach, see [Get started with ASP.NET Core MVC](xref:tutorials/first-mvc-app/start-mvc).
 
 This document provides an introduction to Razor Pages. It's not a step by step tutorial. If you find some of the sections too advanced, see [Get started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start). For an overview of ASP.NET Core, see the [Introduction to ASP.NET Core](xref:index).
 
@@ -37,7 +37,7 @@ If you're using Visual Studio, install [Visual Studio](https://www.visualstudio.
 
 # [Visual Studio](#tab/visual-studio) 
 
-See [Getting started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start) for detailed instructions on how to create a Razor Pages project using Visual Studio.
+See [Get started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start) for detailed instructions on how to create a Razor Pages project using Visual Studio.
 
 #	[Visual Studio for Mac](#tab/visual-studio-mac)
 
@@ -380,7 +380,7 @@ To precompile views, see [Razor view compilation](xref:mvc/views/view-compilatio
 
 [Download or view sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/mvc/razor-pages/index/sample).
 
-See [Getting started with Razor Pages in ASP.NET Core](xref:tutorials/razor-pages/razor-pages-start), which builds on this introduction.
+See [Get started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start), which builds on this introduction.
 
 ### Specify that Razor Pages are at the content root
 
@@ -411,7 +411,7 @@ services.AddMvc()
 ## See also
 
 * [Introduction to ASP.NET Core](xref:index)
-* [Getting started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start)
+* [Get started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start)
 * [Razor Pages authorization conventions](xref:security/authorization/razor-pages-authorization)
 * [Razor Pages custom route and page model providers](xref:mvc/razor-pages/razor-pages-convention-features)
 * [Razor Pages unit and integration testing](xref:testing/razor-pages-testing)

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -18,7 +18,7 @@ Razor Pages is a new feature of ASP.NET Core MVC that makes coding page-focused 
 
 If you're looking for a tutorial that uses the Model-View-Controller approach, see [Getting started with ASP.NET Core MVC](xref:tutorials/first-mvc-app/start-mvc).
 
-This document provides an introduction to Razor Pages. It's not a step by step tutorial. If you find some of the sections difficult to follow, see [Getting started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start).
+This document provides an introduction to Razor Pages. It's not a step by step tutorial. If you find some of the sections too advanced, see [Getting started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start). For an overview of ASP.NET Core, see the [Introduction to ASP.NET Core](xref:index).
 
 <a name="prerequisites"></a>
 
@@ -410,6 +410,7 @@ services.AddMvc()
 
 ## See also
 
+* [Introduction to ASP.NET Core](xref:index)
 * [Getting started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start)
 * [Razor Pages authorization conventions](xref:security/authorization/razor-pages-authorization)
 * [Razor Pages custom route and page model providers](xref:mvc/razor-pages/razor-pages-convention-features)

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -18,7 +18,7 @@ Razor Pages is a new feature of ASP.NET Core MVC that makes coding page-focused 
 
 If you're looking for a tutorial that uses the Model-View-Controller approach, see [Getting started with ASP.NET Core MVC](xref:tutorials/first-mvc-app/start-mvc).
 
-This document provides an introduction to Razor Pages. It's not a step by step tutorial. If you find some of the sections too advanced, see [Getting started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start). For an overview of ASP.NET Core, see the [Introduction to ASP.NET Core](xref:index).
+This document provides an introduction to Razor Pages. It's not a step by step tutorial. If you find some of the sections too advanced, see [Get started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start). For an overview of ASP.NET Core, see the [Introduction to ASP.NET Core](xref:index).
 
 <a name="prerequisites"></a>
 

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc.md
@@ -1,7 +1,7 @@
 ---
-title: Getting started with ASP.NET Core MVC and Visual Studio
+title: Get started with ASP.NET Core MVC and Visual Studio
 author: rick-anderson
-description: Getting started with ASP.NET Core MVC and Visual Studio
+description: Learn how to get started with ASP.NET Core MVC and Visual Studio.
 manager: wpickett
 ms.author: riande
 ms.date: 10/07/2017
@@ -10,7 +10,7 @@ ms.technology: aspnet
 ms.topic: get-started-article
 uid: tutorials/first-mvc-app/start-mvc
 ---
-# Getting started with ASP.NET Core MVC and Visual Studio
+# Get started with ASP.NET Core MVC and Visual Studio
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)
 


### PR DESCRIPTION
Addresses #5649 

This topic is the landing page for a reader arriving along the chain of links starting with `https://dot.net` (`https://www.microsoft.com/net`). In addition to the current link allowing a reader to get out to the *Get started with RP* page, I suggest we provide an additional circuit breaker that will allow the reader to get out to the doc set's main landing page.