### PR TITLE
SignalR Example: add method to ChatHub broadcast

### DIFF
--- a/aspnetcore/signalr/get-started-signalr-core/sample/Hubs/ChatHub.cs
+++ b/aspnetcore/signalr/get-started-signalr-core/sample/Hubs/ChatHub.cs
@@ -6,10 +6,10 @@ namespace SignalRChat.Hubs
 {
     public class ChatHub : Hub
     {
-        public Task Send(string user, string message)
+        public Task SendMessage(string user, string message)
         {
             string timestamp = DateTime.Now.ToShortTimeString();
-            return Clients.All.SendAsync(timestamp, user, message);
+            return Clients.All.SendAsync("ReceiveMessage", timestamp, user, message);
         }
     }
 }

--- a/aspnetcore/signalr/get-started-signalr-core/sample/wwwroot/js/chat.js
+++ b/aspnetcore/signalr/get-started-signalr-core/sample/wwwroot/js/chat.js
@@ -1,6 +1,6 @@
 ﻿const connection = new signalR.HubConnection('/chathub');
 
-connection.on('Send', (timestamp, user, message) => {
+connection.on('ReceiveMessage', (timestamp, user, message) => {
     const encodedUser = user;
     const encodedMsg = message;
     const listItem = document.createElement('li');
@@ -12,7 +12,7 @@ document.getElementById('send').addEventListener('click', event => {
     const msg = document.getElementById('message').value;
     const usr = document.getElementById('user').value;
 
-    connection.invoke('Send', usr, msg).catch(err => showErr(err));
+    connection.invoke('SendMessage', usr, msg).catch(err => showErr(err));
     event.preventDefault();
 });
 


### PR DESCRIPTION
I followed this example today and was getting this error:

![screenshot from 2018-03-12 20-59-53](https://user-images.githubusercontent.com/2414837/37316952-6eab6d08-2638-11e8-9401-5c6434786e4d.png)

I realized that this example omits the method name `Send`, and it is passing `timestamp` as the method name instead (when that should be the first argument)

Here is the function deceleration, it requires method name:

```
    /// <summary>
    /// Invokes a method on the connection(s) represented by the <see cref="T:Microsoft.AspNetCore.SignalR.IClientProxy" /> instance.
    /// Does not wait for a response from the receiver.
    /// </summary>
    /// <param name="clientProxy">The <see cref="T:Microsoft.AspNetCore.SignalR.IClientProxy" /></param>
    /// <param name="method">name of the method to invoke</param>
    /// <param name="arg1">The first argument</param>
    /// <param name="arg2">The second argument</param>
    /// <returns>A task that represents when the data has been sent to the client.</returns>
    public static Task SendAsync(this IClientProxy clientProxy, string method, object arg1, object arg2)
```

After I added the method name `Send`, the example started working