### PR TITLE
Identity Server Link to Original Tutorial

### DIFF
--- a/aspnetcore/security/authentication/community.md
+++ b/aspnetcore/security/authentication/community.md
@@ -21,7 +21,7 @@ The list below is sorted alphabetically.
 | Name | Description |
 |:--------------|:------------------|
 | [AspNet.Security.OpenIdConnect.Server (ASOS)](https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server) | Low-level/protocol-first OpenID Connect server framework for ASP.NET Core and OWIN/Katana |
-| [IdentityServer4](https://identityserver.io/) | OpenID Connect and OAuth 2.0 framework for ASP.NET Core - officially certified by the OpenID Foundation and under governance of the .NET Foundation |
+| [IdentityServer4](https://identityserver4.readthedocs.io/en/release/) | OpenID Connect and OAuth 2.0 framework for ASP.NET Core - officially certified by the OpenID Foundation and under governance of the .NET Foundation |
 | [OpenIddict](https://github.com/openiddict/openiddict-core) | Easy-to-use OpenID Connect server for ASP.NET Core  |
 | [Cierge](https://github.com/pwdless/Cierge) | Passwordless, drop-in OpenID Connect authentication   |
 

--- a/aspnetcore/security/authentication/community.md
+++ b/aspnetcore/security/authentication/community.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Lists open source authentication options for ASP.NET Core.
 manager: wpickett
 ms.author: riande
-ms.date: 08/18/2017
+ms.date: 03/12/2018
 ms.prod: asp.net-core
 ms.technology: aspnet
 ms.topic: article
@@ -12,17 +12,17 @@ uid: security/authentication/community
 ---
 # Community OSS authentication options
 
-This page contains community-provided, open source authentication options for ASP.NET Core. This page will be periodically updated as new providers become available.
+This page contains community-provided, open source authentication options for ASP.NET Core. This page is periodically updated as new providers become available.
 
-# OSS Authentication Providers
+# OSS authentication providers
 
 The list below is sorted alphabetically.
 
 | Name | Description |
-|:--------------|:------------------|
-| [AspNet.Security.OpenIdConnect.Server (ASOS)](https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server) | Low-level/protocol-first OpenID Connect server framework for ASP.NET Core and OWIN/Katana |
-| [IdentityServer4](https://identityserver4.readthedocs.io/en/release/) | OpenID Connect and OAuth 2.0 framework for ASP.NET Core - officially certified by the OpenID Foundation and under governance of the .NET Foundation |
-| [OpenIddict](https://github.com/openiddict/openiddict-core) | Easy-to-use OpenID Connect server for ASP.NET Core  |
-| [Cierge](https://github.com/pwdless/Cierge) | Passwordless, drop-in OpenID Connect authentication   |
+| ---- | ----------- |
+| [AspNet.Security.OpenIdConnect.Server (ASOS)](https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server) | ASOS is a low-level, protocol-first OpenID Connect server framework for ASP.NET Core and OWIN/Katana. |
+| [IdentityServer](https://identityserver.io/) | IdentityServer is an OpenID Connect and OAuth 2.0 framework for ASP.NET Core, officially certified by the OpenID Foundation and under governance of the .NET Foundation. For more information, see [Welcome to IdentityServer4 (Documentation)](https://identityserver4.readthedocs.io/en/release/). |
+| [OpenIddict](https://github.com/openiddict/openiddict-core) | OpenIddict is an easy-to-use OpenID Connect server for ASP.NET Core. |
+| [Cierge](https://github.com/pwdless/Cierge) | Cierge is an OpenID Connect server that handles user signup, login, profiles, management, social logins, and more. |
 
-To get your provider added here [edit this page](https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Faspnet%2FDocs%2Fedit%2Fmaster%2Faspnetcore%2Fsecurity%2Fauthentication%2Fcommunity.md).
+To add a provider, [edit this page](https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Faspnet%2FDocs%2Fedit%2Fmaster%2Faspnetcore%2Fsecurity%2Fauthentication%2Fcommunity.md).


### PR DESCRIPTION
This may or may not be desired, but this link used to go to this page: https://identityserver4.readthedocs.io/en/release/, but now goes to the Identity Server 4 home page. You have to make extra clicks to get to the tutorial.

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
