### PR TITLE
Remove LogoutPath from cookie options in Identity topic

### DIFF
--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -56,7 +56,7 @@ In this topic, you'll learn how to use ASP.NET Core Identity to add functionalit
 
     # [ASP.NET Core 2.x](#tab/aspnetcore2x)
     
-    [!code-csharp[](identity/sample/src/ASPNETv2-IdentityDemo/Startup.cs?name=snippet_configureservices&highlight=7-9,11-28,30-39)]
+    [!code-csharp[](identity/sample/src/ASPNETv2-IdentityDemo/Startup.cs?name=snippet_configureservices&highlight=7-9,11-28,30-42)]
     
     These services are made available to the application through [dependency injection](xref:fundamentals/dependency-injection).
     
@@ -66,7 +66,7 @@ In this topic, you'll learn how to use ASP.NET Core Identity to add functionalit
     
     # [ASP.NET Core 1.x](#tab/aspnetcore1x)
     
-    [!code-csharp[](identity/sample/src/ASPNET-IdentityDemo/Startup.cs?name=snippet_configureservices&highlight=7-9,13-34)]
+    [!code-csharp[](identity/sample/src/ASPNET-IdentityDemo/Startup.cs?name=snippet_configureservices&highlight=7-9,13-33)]
     
     These services are made available to the application through [dependency injection](xref:fundamentals/dependency-injection).
     
@@ -126,11 +126,11 @@ In this topic, you'll learn how to use ASP.NET Core Identity to add functionalit
 
     # [ASP.NET Core 2.x](#tab/aspnetcore2x)
     
-    [!code-csharp[](identity/sample/src/ASPNETv2-IdentityDemo/Startup.cs?name=snippet_configureservices&highlight=7-9,11-28,30-39)]
+    [!code-csharp[](identity/sample/src/ASPNETv2-IdentityDemo/Startup.cs?name=snippet_configureservices&highlight=7-9,11-28,30-42)]
     
     # [ASP.NET Core 1.x](#tab/aspnetcore1x)
     
-    [!code-csharp[](identity/sample/src/ASPNET-IdentityDemo/Startup.cs?name=snippet_configureservices&highlight=13-34)]
+    [!code-csharp[](identity/sample/src/ASPNET-IdentityDemo/Startup.cs?name=snippet_configureservices&highlight=13-33)]
 
     ---
 	

--- a/aspnetcore/security/authentication/identity/sample/src/ASPNET-IdentityDemo-PrimaryKeysConfig/Startup.cs
+++ b/aspnetcore/security/authentication/identity/sample/src/ASPNET-IdentityDemo-PrimaryKeysConfig/Startup.cs
@@ -73,7 +73,6 @@ namespace webapptemplate
                 options.Cookies.ApplicationCookie.CookieName = "YourAppCookieName";
                 options.Cookies.ApplicationCookie.ExpireTimeSpan = TimeSpan.FromDays(150);
                 options.Cookies.ApplicationCookie.LoginPath = "/Account/LogIn";
-                options.Cookies.ApplicationCookie.LogoutPath = "/Account/LogOff";
                 options.Cookies.ApplicationCookie.AccessDeniedPath = "/Account/AccessDenied";
                 options.Cookies.ApplicationCookie.AutomaticAuthenticate = true;
                 // Requires `using Microsoft.AspNetCore.Authentication.Cookies;`

--- a/aspnetcore/security/authentication/identity/sample/src/ASPNET-IdentityDemo/Startup.cs
+++ b/aspnetcore/security/authentication/identity/sample/src/ASPNET-IdentityDemo/Startup.cs
@@ -63,8 +63,7 @@ namespace IdentityDemo
 
                 // Cookie settings
                 options.Cookies.ApplicationCookie.ExpireTimeSpan = TimeSpan.FromDays(150);
-                options.Cookies.ApplicationCookie.LoginPath = "/Account/LogIn";
-                options.Cookies.ApplicationCookie.LogoutPath = "/Account/LogOut";
+                options.Cookies.ApplicationCookie.LoginPath = "/Account/Login";
 
                 // User settings
                 options.User.RequireUniqueEmail = true;

--- a/aspnetcore/security/authentication/identity/sample/src/ASPNETCore-IdentityDemoComplete/IdentityDemo/Startup.cs
+++ b/aspnetcore/security/authentication/identity/sample/src/ASPNETCore-IdentityDemoComplete/IdentityDemo/Startup.cs
@@ -54,9 +54,12 @@ namespace IdentityDemo
                 // Cookie settings
                 options.Cookie.HttpOnly = true;
                 options.Cookie.Expiration = TimeSpan.FromDays(150);
-                options.LoginPath = "/Account/Login"; // If the LoginPath is not set here, ASP.NET Core will default to /Account/Login
-                options.LogoutPath = "/Account/Logout"; // If the LogoutPath is not set here, ASP.NET Core will default to /Account/Logout
-                options.AccessDeniedPath = "/Account/AccessDenied"; // If the AccessDeniedPath is not set here, ASP.NET Core will default to /Account/AccessDenied
+                // If the LoginPath isn't set, ASP.NET Core defaults 
+                // the path to /Account/Login.
+                options.LoginPath = "/Account/Login";
+                // If the AccessDeniedPath isn't set, ASP.NET Core defaults 
+                // the path to /Account/AccessDenied.
+                options.AccessDeniedPath = "/Account/AccessDenied";
                 options.SlidingExpiration = true;
             });
 

--- a/aspnetcore/security/authentication/identity/sample/src/ASPNETv2-IdentityDemo-Configuration/Startup.cs
+++ b/aspnetcore/security/authentication/identity/sample/src/ASPNETv2-IdentityDemo-Configuration/Startup.cs
@@ -59,7 +59,6 @@ namespace WebApplication5
                 options.Cookie.HttpOnly = true; 
                 options.ExpireTimeSpan = TimeSpan.FromMinutes(60); 
                 options.LoginPath = "/Account/Login";
-                options.LogoutPath = "/Account/Logout";
                 // ReturnUrlParameter requires `using Microsoft.AspNetCore.Authentication.Cookies;`
                 options.ReturnUrlParameter = CookieAuthenticationDefaults.ReturnUrlParameter;
                 options.SlidingExpiration = true;

--- a/aspnetcore/security/authentication/identity/sample/src/ASPNETv2-IdentityDemo-PrimaryKeysConfig/Startup.cs
+++ b/aspnetcore/security/authentication/identity/sample/src/ASPNETv2-IdentityDemo-PrimaryKeysConfig/Startup.cs
@@ -62,7 +62,6 @@ namespace webapptemplate
                 options.Cookie.Name = "YourAppCookieName";
                 options.ExpireTimeSpan = TimeSpan.FromDays(150);
                 options.LoginPath = "/Account/LogIn";
-                options.LogoutPath = "/Account/LogOff";
                 options.ReturnUrlParameter = CookieAuthenticationDefaults.ReturnUrlParameter;
             });
         }

--- a/aspnetcore/security/authentication/identity/sample/src/ASPNETv2-IdentityDemo/Startup.cs
+++ b/aspnetcore/security/authentication/identity/sample/src/ASPNETv2-IdentityDemo/Startup.cs
@@ -54,9 +54,12 @@ namespace WebApplication5
                 // Cookie settings
                 options.Cookie.HttpOnly = true;
                 options.ExpireTimeSpan = TimeSpan.FromMinutes(30);
-                options.LoginPath = "/Account/Login"; // If the LoginPath is not set here, ASP.NET Core will default to /Account/Login
-                options.LogoutPath = "/Account/Logout"; // If the LogoutPath is not set here, ASP.NET Core will default to /Account/Logout
-                options.AccessDeniedPath = "/Account/AccessDenied"; // If the AccessDeniedPath is not set here, ASP.NET Core will default to /Account/AccessDenied
+                // If the LoginPath isn't set, ASP.NET Core defaults 
+                // the path to /Account/Login.
+                options.LoginPath = "/Account/Login";
+                // If the AccessDeniedPath isn't set, ASP.NET Core defaults 
+                // the path to /Account/AccessDenied.
+                options.AccessDeniedPath = "/Account/AccessDenied";
                 options.SlidingExpiration = true;
             });
 


### PR DESCRIPTION
Fixes #5615 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/security/authentication/identity?branch=pr-en-us-5666)

The engineers decided not to change the template ([2.1 ref source](https://github.com/aspnet/templating/blob/dev/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/Controllers/AccountController.cs#L104) and [comment \#5615](https://github.com/aspnet/templating/issues/88#issuecomment-370969013)). In effect, the template is set up so that the `LogOff` method performs a hard `RedirectToAction` to the Home controller `Index` method. Therefore, setting the `LogoutPath` option no-ops, which might be unexpected behavior given that the doc is showing how to set it.

I added the note on this to the code, and I think it should stay with the sample (and future samples for this topic). When a dev pulls down the code, they'll always get the note. I think if we have this information in the topic, it will be lost by the time the dev gets into configuring the sample app.