### PR TITLE
added bootstrap 4.0.0 js but no css yet?

### DIFF
--- a/aspnet/ajax/cdn/overview.md
+++ b/aspnet/ajax/cdn/overview.md
@@ -795,9 +795,6 @@ The following releases of [getbootstrap.com](http://getbootstrap.com "getbootstr
 - http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap.css
 - http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap.css.map
 - http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap.min.css
-- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap-theme.css
-- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap-theme.css.map
-- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap-theme.min.css
 - http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/fonts/glyphicons-halflings-regular.eot
 - http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/fonts/glyphicons-halflings-regular.svg
 - http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/fonts/glyphicons-halflings-regular.ttf

--- a/aspnet/ajax/cdn/overview.md
+++ b/aspnet/ajax/cdn/overview.md
@@ -788,6 +788,11 @@ The following releases of [https://github.com/scottjehl/Respond](https://github.
 
 The following releases of [getbootstrap.com](http://getbootstrap.com "getbootstrap.com") bootstrap are hosted on the CDN:
 
+#### Bootstrap version 4.0.0
+
+- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/bootstrap.js
+- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/bootstrap.min.js
+
 #### Bootstrap version 3.3.7
 
 - http://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/bootstrap.js

--- a/aspnet/ajax/cdn/overview.md
+++ b/aspnet/ajax/cdn/overview.md
@@ -792,6 +792,9 @@ The following releases of [getbootstrap.com](http://getbootstrap.com "getbootstr
 
 - http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/bootstrap.js
 - http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/bootstrap.min.js
+- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap.css
+- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap.css.map
+- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap.min.css
 
 #### Bootstrap version 3.3.7
 

--- a/aspnet/ajax/cdn/overview.md
+++ b/aspnet/ajax/cdn/overview.md
@@ -795,6 +795,14 @@ The following releases of [getbootstrap.com](http://getbootstrap.com "getbootstr
 - http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap.css
 - http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap.css.map
 - http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap.min.css
+- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap-theme.css
+- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap-theme.css.map
+- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/css/bootstrap-theme.min.css
+- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/fonts/glyphicons-halflings-regular.eot
+- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/fonts/glyphicons-halflings-regular.svg
+- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/fonts/glyphicons-halflings-regular.ttf
+- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/fonts/glyphicons-halflings-regular.woff
+- http://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/fonts/glyphicons-halflings-regular.woff2
 
 #### Bootstrap version 3.3.7
 


### PR DESCRIPTION
Do not know if there is an issue yet, but bootstrap 4.0.0 has js on the aspnet cdn. No CSS yet though. Do not know who to contact for the CSS but the docs should list the js because it is available.

edit: my bad, 4.0.0 css is there too. It's the theme which is not there. http://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/css/bootstrap-theme.css 