### PR TITLE
Fix metadata in Web API help pages docs

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-NSwag.md
+++ b/aspnetcore/tutorials/getting-started-with-NSwag.md
@@ -2,11 +2,10 @@
 title: Get started with NSwag
 author: zuckerthoben
 description: This tutorial provides a walkthrough of adding NSwag to generate documentation and help pages for a Web API app.
-keywords: ASP.NET Core,Swagger,NSwag,help pages,Web API
-ms.author: scaddie
 manager: wpickett
+ms.author: scaddie
 ms.custom: mvc
-ms.date: 03/09/2018
+ms.date: 03/15/2018
 ms.prod: asp.net-core
 ms.technology: aspnet
 ms.topic: article

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -2,11 +2,10 @@
 title: Get started with Swashbuckle
 author: zuckerthoben
 description: This tutorial provides a walkthrough of adding Swashbuckle to your project to integrate the Swagger UI.
-keywords: ASP.NET Core,Swagger,Swashbuckle,help pages,Web API
-ms.author: scaddie
 manager: wpickett
+ms.author: scaddie
 ms.custom: mvc
-ms.date: 03/09/2018
+ms.date: 03/15/2018
 ms.prod: asp.net-core
 ms.technology: aspnet
 ms.topic: article


### PR DESCRIPTION
Fix the metadata in the 2 Web API help pages docs.