### PR TITLE
Prereqs tuneup

### DIFF
--- a/aspnetcore/client-side/spa-services.md
+++ b/aspnetcore/client-side/spa-services.md
@@ -65,8 +65,8 @@ To work with SpaServices, install the following:
 
 Note: If you're deploying to an Azure web site, you don't need to do anything here &mdash; Node.js is installed and available in the server environments.
 
-* [.NET Core SDK](https://www.microsoft.com/net/download/all) 1.0 (or later)
-    * If you're on Windows, this can be installed by selecting Visual Studio 2017's **.NET Core cross-platform development** workload.
+* [!INCLUDE[](~/includes/net-core-sdk-download-link.md)]
+  * If you're on Windows using Visual Studio 2017, the SDK is installed by selecting the **.NET Core cross-platform development** workload.
 
 * [Microsoft.AspNetCore.SpaServices](https://www.nuget.org/packages/Microsoft.AspNetCore.SpaServices/) NuGet package
 

--- a/aspnetcore/data/ef-mvc/intro.md
+++ b/aspnetcore/data/ef-mvc/intro.md
@@ -30,7 +30,7 @@ EF Core 2.0 is the latest version of EF but doesn't yet have all the features of
 
 ## Prerequisites
 
-[!INCLUDE[install 2.0](../../includes/install2.0.md)]
+[!INCLUDE[](~/includes/net-core-prereqs.md)]
 
 ## Troubleshooting
 

--- a/aspnetcore/data/ef-rp/intro.md
+++ b/aspnetcore/data/ef-rp/intro.md
@@ -23,7 +23,7 @@ The sample app is a web site for a fictional Contoso University. It includes fun
 
 ## Prerequisites
 
-[!INCLUDE[install 2.0](../../includes/install2.0.md)]
+[!INCLUDE[](~/includes/net-core-prereqs.md)]
 
 Familiarity with [Razor Pages](xref:mvc/razor-pages/index). New programmers should complete [Get started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start) before starting this series.
 

--- a/aspnetcore/getting-started-1.1.md
+++ b/aspnetcore/getting-started-1.1.md
@@ -15,7 +15,7 @@ uid: getting-started-1.1
 > [!NOTE]
 > These instructions are for ASP.NET Core 1.1. Looking for the latest version? See [the current version of this tutorial](xref:getting-started).
 
-1. Install the .NET Core **SDK Installer** for SDK 1.0.4 from the [.NET Core 1.0.5 & 1.1.2 SDK 1.0.4 downloads page](https://github.com/dotnet/core/blob/master/release-notes/download-archives/1.0.5-download.md).
+1. Install the .NET Core **SDK Installer** for SDK 1.0.4 from the [.NET Core All Downloads page](https://www.microsoft.com/net/download/all).
 
 2. Create a folder for a new .NET Core project.
 

--- a/aspnetcore/getting-started.md
+++ b/aspnetcore/getting-started.md
@@ -15,7 +15,7 @@ uid: getting-started
 > [!NOTE]
 > These instructions are for the latest version of ASP.NET Core. Looking to get started with an earlier version? See [the 1.1 version of this tutorial](xref:getting-started-1.1).
 
-1. Install [.NET Core](https://www.microsoft.com/net/core/).
+1. Install the [!INCLUDE[](~/includes/net-core-sdk-download-link.md)].
 
 2. Create a new .NET Core project.
 

--- a/aspnetcore/host-and-deploy/azure-apps/azure-continuous-deployment.md
+++ b/aspnetcore/host-and-deploy/azure-apps/azure-continuous-deployment.md
@@ -29,7 +29,7 @@ See also [Use VSTS to Build and Publish to an Azure Web App with Continuous Depl
 This tutorial assumes the following software is installed:
 
 * [Visual Studio](https://www.visualstudio.com)
-* [.NET Core SDK](https://www.microsoft.com/net/download/all) (runtime and tooling)
+* [!INCLUDE[](~/includes/net-core-sdk-download-link.md)]
 * [Git](https://git-scm.com/downloads) for Windows
 
 ## Create an ASP.NET Core web app

--- a/aspnetcore/host-and-deploy/iis/development-time-iis-support.md
+++ b/aspnetcore/host-and-deploy/iis/development-time-iis-support.md
@@ -19,8 +19,7 @@ This article describes [Visual Studio](https://www.visualstudio.com/vs/) support
 
 ## Prerequisites
 
-* Visual Studio (2017/version 15.3 or later)
-* ASP.NET and web development workload *OR* the .NET Core cross-platform development workload
+[!INCLUDE[](~/includes/net-core-prereqs-windows.md)]
 
 ## Enable IIS
 

--- a/aspnetcore/includes/install2.0.md
+++ b/aspnetcore/includes/install2.0.md
@@ -1,4 +1,0 @@
-Install the following:
-
-* [.NET Core 2.0.0 SDK](https://www.microsoft.com/net/core) or later.
-* [Visual Studio 2017](https://www.visualstudio.com/downloads/) version 15.3 or later with the **ASP.NET and web development** workload.

--- a/aspnetcore/includes/net-core-prereqs-macos.md
+++ b/aspnetcore/includes/net-core-prereqs-macos.md
@@ -1,0 +1,1 @@
+[Visual Studio for Mac](https://www.microsoft.com/net/download/macos)

--- a/aspnetcore/includes/net-core-prereqs-vscode.md
+++ b/aspnetcore/includes/net-core-prereqs-vscode.md
@@ -1,0 +1,5 @@
+Install the following:
+
+* [!INCLUDE[](~/includes/net-core-sdk-download-link.md)]
+* [Visual Studio Code](https://www.microsoft.com/net/download/linux)
+* [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)

--- a/aspnetcore/includes/net-core-prereqs-windows.md
+++ b/aspnetcore/includes/net-core-prereqs-windows.md
@@ -1,0 +1,3 @@
+[Visual Studio for Windows](https://www.microsoft.com/net/download/windows)
+* **ASP.NET and web development** workload
+* **.NET Core cross-platform development** workload

--- a/aspnetcore/includes/net-core-prereqs.md
+++ b/aspnetcore/includes/net-core-prereqs.md
@@ -1,0 +1,9 @@
+Install **one** of the following:
+
+* CLI tooling: Windows, Linux, or macOS: [!INCLUDE[](~/includes/net-core-sdk-download-link.md)]
+* IDE/editor tooling
+  * Windows: [Visual Studio for Windows](https://www.microsoft.com/net/download/windows)
+    * **ASP.NET and web development** workload
+    * **.NET Core cross-platform development** workload
+  * Linux: [Visual Studio Code](https://www.microsoft.com/net/download/linux)
+  * macOS: [Visual Studio for Mac](https://www.microsoft.com/net/download/macos)

--- a/aspnetcore/includes/net-core-sdk-download-link.md
+++ b/aspnetcore/includes/net-core-sdk-download-link.md
@@ -1,0 +1,1 @@
+[.NET Core SDK 2.0 or later](https://www.microsoft.com/net/download)

--- a/aspnetcore/migration/proper-to-2x/index.md
+++ b/aspnetcore/migration/proper-to-2x/index.md
@@ -19,7 +19,7 @@ This article serves as a reference guide for migrating ASP.NET applications to A
 
 ## Prerequisites
 
-* [.NET Core 2.0.0 SDK](https://dot.net/core) or later.
+[!INCLUDE[](~/includes/net-core-sdk-download-link.md)]
 
 ## Target frameworks
 ASP.NET Core 2.0 projects offer developers the flexibility of targeting .NET Core, .NET Framework, or both. See [Choosing between .NET Core and .NET Framework for server apps](https://docs.microsoft.com/dotnet/standard/choosing-core-framework-server) to determine which target framework is most appropriate.

--- a/aspnetcore/migration/proper-to-2x/mvc2.md
+++ b/aspnetcore/migration/proper-to-2x/mvc2.md
@@ -10,7 +10,6 @@ ms.technology: aspnet
 ms.topic: article
 uid: migration/mvc2
 ---
-
 # Migrating from ASP.NET to ASP.NET Core 2.0
 
 By [Isaac Levin](https://isaaclevin.com)
@@ -19,7 +18,12 @@ This article serves as a reference guide for migrating ASP.NET applications to A
 
 ## Prerequisites
 
-* [.NET Core 2.0.0 SDK](https://www.microsoft.com/net/core) or later.
+Install **one** of the following from [.NET Downloads: Windows](https://www.microsoft.com/net/download/windows):
+
+* .NET Core SDK
+* Visual Studio for Windows
+  * **ASP.NET and web development** workload
+  * **.NET Core cross-platform development** workload
 
 ## Target frameworks
 ASP.NET Core 2.0 projects offer developers the flexibility of targeting .NET Core, .NET Framework, or both. See [Choosing between .NET Core and .NET Framework for server apps](https://docs.microsoft.com/dotnet/standard/choosing-core-framework-server) to determine which target framework is most appropriate.

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -20,16 +20,9 @@ If you're looking for a tutorial that uses the Model-View-Controller approach, s
 
 This document provides an introduction to Razor Pages. It's not a step by step tutorial. If you find some of the sections too advanced, see [Get started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start). For an overview of ASP.NET Core, see the [Introduction to ASP.NET Core](xref:index).
 
-<a name="prerequisites"></a>
+## Prerequisites
 
-## ASP.NET Core 2.0 prerequisites
-
-Install [.NET Core](https://www.microsoft.com/net/core) 2.0.0 or later.
-
-If you're using Visual Studio, install [Visual Studio](https://www.visualstudio.com/vs/) 2017 version 15.3 or later with the following workloads:
-
-* **ASP.NET and web development**
-* **.NET Core cross-platform development**
+[!INCLUDE[](~/includes/net-core-prereqs.md)]
 
 <a name="rpvs17"></a>
 
@@ -39,7 +32,7 @@ If you're using Visual Studio, install [Visual Studio](https://www.visualstudio.
 
 See [Get started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start) for detailed instructions on how to create a Razor Pages project using Visual Studio.
 
-#	[Visual Studio for Mac](#tab/visual-studio-mac)
+# [Visual Studio for Mac](#tab/visual-studio-mac)
 
 Run `dotnet new razor` from the command line.
 
@@ -49,7 +42,7 @@ Open the generated *.csproj* file from Visual Studio for Mac.
 
 Run `dotnet new razor` from the command line.
 
-#	[.NET Core CLI](#tab/netcore-cli) 
+# [.NET Core CLI](#tab/netcore-cli) 
 
 Run `dotnet new razor` from the command line.
 

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -29,7 +29,7 @@ For example, if you create a new ASP.NET Core web app with individual user accou
 
 ## Secret Manager
 
-The Secret Manager tool stores sensitive data for development work outside of your project tree. The Secret Manager tool is a project tool that can be used to store secrets for a [.NET Core](https://www.microsoft.com/net/core) project during development. With the Secret Manager tool, you can associate app secrets with a specific project and share them across multiple projects.
+The Secret Manager tool stores sensitive data for development work outside of your project tree. The Secret Manager tool is a project tool that can be used to store secrets for a .NET Core project during development. With the Secret Manager tool, you can associate app secrets with a specific project and share them across multiple projects.
 
 >[!WARNING]
 > The Secret Manager tool doesn't encrypt the stored secrets and shouldn't be treated as a trusted store. It's for development purposes only. The keys and values are stored in a JSON configuration file in the user profile directory.

--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -25,7 +25,7 @@ See [this PDF file](https://github.com/aspnet/Docs/tree/master/aspnetcore/securi
 
 ## Prerequisites
 
-[.NET Core 2.1.4 SDK](https://www.microsoft.com/net/core) or later.
+[!INCLUDE[](~/includes/net-core-prereqs.md)]
 
 ## Create a new ASP.NET Core project with the .NET Core CLI
 

--- a/aspnetcore/security/data-protection/configuration/machine-wide-policy.md
+++ b/aspnetcore/security/data-protection/configuration/machine-wide-policy.md
@@ -66,4 +66,4 @@ If EncryptionType is Managed, the system is configured to use a managed Symmetri
 If EncryptionType has any other value other than null or empty, the Data Protection system throws an exception at startup.
 
 > [!WARNING]
-> When configuring a default policy setting that involves type names (EncryptionAlgorithmType, ValidationAlgorithmType, KeyEscrowSinks), the types must be available to the app. This means that for apps running on Desktop CLR, the assemblies that contain these types should be present in the Global Assembly Cache (GAC). For ASP.NET Core apps running on [.NET Core](https://www.microsoft.com/net/core), the packages that contain these types should be installed.
+> When configuring a default policy setting that involves type names (EncryptionAlgorithmType, ValidationAlgorithmType, KeyEscrowSinks), the types must be available to the app. This means that for apps running on Desktop CLR, the assemblies that contain these types should be present in the Global Assembly Cache (GAC). For ASP.NET Core apps running on .NET Core, the packages that contain these types should be installed.

--- a/aspnetcore/security/data-protection/implementation/key-encryption-at-rest.md
+++ b/aspnetcore/security/data-protection/implementation/key-encryption-at-rest.md
@@ -90,7 +90,7 @@ In this scenario, the AD domain controller is responsible for distributing the e
 
 ## Certificate-based encryption with Windows DPAPI-NG
 
-If you're running on Windows 8.1 / Windows Server 2012 R2 or later, you can use Windows DPAPI-NG to perform certificate-based encryption, even if the application is running on [.NET Core](https://www.microsoft.com/net/core). To take advantage of this, use the rule descriptor string "CERTIFICATE=HashId:thumbprint", where thumbprint is the hex-encoded SHA1 thumbprint of the certificate to use. See below for an example.
+If you're running on Windows 8.1 / Windows Server 2012 R2 or later, you can use Windows DPAPI-NG to perform certificate-based encryption, even if the application is running on .NET Core. To take advantage of this, use the rule descriptor string "CERTIFICATE=HashId:thumbprint", where thumbprint is the hex-encoded SHA1 thumbprint of the certificate to use. See below for an example.
 
 ```csharp
 sc.AddDataProtection()

--- a/aspnetcore/spa/index.md
+++ b/aspnetcore/spa/index.md
@@ -19,7 +19,7 @@ uid: spa/index
 
 ## Prerequisites
 
-* [.NET Core SDK](https://www.microsoft.com/net/download), version 2.0.0 or later
+* [!INCLUDE[](~/includes/net-core-sdk-download-link.md)]
 * [Node.js](https://nodejs.org), version 6 or later
 
 ## Installation

--- a/aspnetcore/tutorials/first-mvc-app-mac/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app-mac/start-mvc.md
@@ -26,12 +26,7 @@ There are 3 versions of this tutorial:
 
 ## Prerequisites
 
-This tutorial requires the [.NET Core 2.0.0 SDK](https://www.microsoft.com/net/core) or later.
-
-Install the following:
-
-- [.NET Core 2.0.0 SDK](https://www.microsoft.com/net/core) or later
-- [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/)
+[!INCLUDE[](~/includes/net-core-prereqs-macos.md)]
 
 ## Create a web app
 

--- a/aspnetcore/tutorials/first-mvc-app-xplat/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app-xplat/start-mvc.md
@@ -24,15 +24,9 @@ There are 3 versions of this tutorial:
 * Windows: [Create an ASP.NET Core MVC app with Visual Studio](xref:tutorials/first-mvc-app/start-mvc)
 * macOS, Linux, and Windows: [Create an ASP.NET Core MVC app with Visual Studio Code](xref:tutorials/first-mvc-app-xplat/start-mvc) 
 
-## Install VS Code and .NET Core
+## Prerequisites
 
-This tutorial requires the [.NET Core 2.0.0 SDK](https://www.microsoft.com/net/core) or later. See [the pdf](https://github.com/aspnet/Docs/blob/master/aspnetcore/tutorials/first-mvc-app-mac/start-mvc/8-23-17.pdf) for the ASP.NET Core 1.1 version.
-
-Install the following:
-
-* [.NET Core 2.0.0 SDK](https://www.microsoft.com/net/core) or later.
-* [Visual Studio Code](https://code.visualstudio.com)
-* VS Code [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) 
+[!INCLUDE[](~/includes/net-core-prereqs-vscode.md)]
 
 ## Create a web app with dotnet
 

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc.md
@@ -26,7 +26,7 @@ There are 3 versions of this tutorial:
 
 # [ASP.NET Core 2.x](#tab/aspnetcore2x)
 
-[!INCLUDE[install 2.0](../../includes/install2.0.md)]
+[!INCLUDE[](~/includes/net-core-prereqs.md)]
 
 # [ASP.NET Core 1.x](#tab/aspnetcore1x)
 

--- a/aspnetcore/tutorials/first-web-api-mac.md
+++ b/aspnetcore/tutorials/first-web-api-mac.md
@@ -28,14 +28,11 @@ There are 3 versions of this tutorial:
 
 [!INCLUDE[template files](../includes/webApi/intro.md)]
 
-* See [Introduction to ASP.NET Core MVC on macOS or Linux](xref:tutorials/first-mvc-app-xplat/index) for an example that uses a persistent database.
+See [Introduction to ASP.NET Core MVC on macOS or Linux](xref:tutorials/first-mvc-app-xplat/index) for an example that uses a persistent database.
 
 ## Prerequisites
 
-Install the following:
-
-- [.NET Core 2.0.0 SDK](https://www.microsoft.com/net/core) or later
-- [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/)
+[!INCLUDE[](~/includes/net-core-prereqs-macos.md)]
 
 ## Create the project
 

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -29,15 +29,13 @@ There are 3 versions of this tutorial:
 
 ## Prerequisites
 
-[!INCLUDE[install 2.0](../includes/install2.0.md)]
-
-See [this PDF](https://github.com/aspnet/Docs/blob/master/aspnetcore/tutorials/first-web-api/_static/_webAPI.pdf) for the ASP.NET Core 1.1 version.
+[!INCLUDE[](~/includes/net-core-prereqs-windows.md)]
 
 ## Create the project
 
 From Visual Studio, select **File** menu, > **New** > **Project**.
 
-Select **.NET Core** >  **ASP.NET Core Web Application** project template. Name the project `TodoApi` and select **OK**.
+Select **.NET Core** > **ASP.NET Core Web Application** project template. Name the project `TodoApi` and select **OK**.
 
 ![New project dialog](first-web-api/_static/new-project.png)
 

--- a/aspnetcore/tutorials/publish-to-azure-webapp-using-cli.md
+++ b/aspnetcore/tutorials/publish-to-azure-webapp-using-cli.md
@@ -33,7 +33,7 @@ In this tutorial, you learn how to:
 To complete this tutorial, you'll need:
 
 * A [Microsoft Azure subscription](https://azure.microsoft.com/free/)
-* [.NET Core](https://www.microsoft.com/net/download/all)
+* [!INCLUDE[](~/includes/net-core-sdk-download-link.md)]
 * [Git](https://www.git-scm.com/) command line client
 
 ## Create a web application

--- a/aspnetcore/tutorials/razor-pages-mac/razor-pages-start.md
+++ b/aspnetcore/tutorials/razor-pages-mac/razor-pages-start.md
@@ -18,10 +18,7 @@ This tutorial teaches the basics of building an ASP.NET Core Razor Pages web app
 
 ## Prerequisites
 
-Install the following:
-
-* [.NET Core 2.0.0 SDK](https://www.microsoft.com/net/core) or later
-* [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/)
+[!INCLUDE[](~/includes/net-core-prereqs-macos.md)]
 
 ## Create a Razor web app
 

--- a/aspnetcore/tutorials/razor-pages-vsc/razor-pages-start.md
+++ b/aspnetcore/tutorials/razor-pages-vsc/razor-pages-start.md
@@ -18,11 +18,7 @@ This tutorial teaches the basics of building an ASP.NET Core Razor Pages web app
 
 ## Prerequisites
 
-Install the following:
-
-* [.NET Core 2.0.0 SDK](https://www.microsoft.com/net/core) or later
-* [Visual Studio Code](https://code.visualstudio.com)
-* VS Code [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) 
+[!INCLUDE[](~/includes/net-core-prereqs-vscode.md)]
 
 ## Create a Razor web app
 

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start.md
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start.md
@@ -26,7 +26,7 @@ There are three versions of this tutorial:
 
 ## Prerequisites
 
-[!INCLUDE[install 2.0](../../includes/install2.0.md)]
+[!INCLUDE[](~/includes/net-core-prereqs-windows.md)]
 
 ## Create a Razor web app
 

--- a/aspnetcore/tutorials/web-api-vsc.md
+++ b/aspnetcore/tutorials/web-api-vsc.md
@@ -27,12 +27,9 @@ There are 3 versions of this tutorial:
 
 [!INCLUDE[template files](../includes/webApi/intro.md)]
 
-## Set up your development environment
+## Prerequisites
 
-Download and install:
-- [.NET Core 2.0.0 SDK](https://www.microsoft.com/net/core) or later.
-- [Visual Studio Code](https://code.visualstudio.com)
-- Visual Studio Code [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+[!INCLUDE[](~/includes/net-core-prereqs-vscode.md)]
 
 ## Create the project
 


### PR DESCRIPTION
Fixes #5585 

I was going to touch **ONE** topic, but then I took a look at a few other prereq sections ... got too close to the black hole ... now all that's left of me is a *Hawking Radiation* signature! ☢️

Here's a stable set of INCLUDES on this PR that we can use ...

### Windows (*includes\net-core-prereqs-windows.md*)

\[Visual Studio for Windows](https://www.microsoft.com/net/download/windows)
\* \*\*ASP.NET and web development\*\* workload
\* \*\*.NET Core cross-platform development\*\* workload

### macOS (*includes\net-core-prereqs-macos.md*)

\[Visual Studio for Mac](https://www.microsoft.com/net/download/macos)

### VSC (*includes\net-core-prereqs-vscode.md*)

Install the following:

* \[!INCLUDE\[](~/includes/net-core-sdk-download-link.md)]
* \[Visual Studio Code](https://www.microsoft.com/net/download/linux)
* \[C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)

### .NET Core SDK 2.0 or later (*net-core-sdk-download-link.md*)

Here's the INCLUDE for the SDK link with the version. Now, we only need to change this in one spot as we go.

\[.NET Core SDK 2.0 or later](https://www.microsoft.com/net/download)

### Additional

Finally, there were a few security topics that open `https://www.microsoft.com/net/learn/get-started/windows` via the link `https://www.microsoft.com/net/core` when just making a passing reference to ".NET Core." I think that link provided different content ages ago. Now, the link provides a not-so-good endpoint. Best to just leave ".NET Core" as text in those spots.

John is going to TAL at prereq coverage in dotnet/docs. I wish we could link over there, but we'll have to see how it all plays out. https://github.com/dotnet/docs/issues/4688