### PR TITLE
Demonstrate how to access config in a RP page and MVC view

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -408,9 +408,52 @@ Left: 1988
 
 A *web.config* file is required when hosting the app in IIS or IIS Express. Settings in *web.config* enable the [ASP.NET Core Module](xref:fundamentals/servers/aspnet-core-module) to launch the app and configure other IIS settings and modules. If the *web.config* file isn't present and the project file includes `<Project Sdk="Microsoft.NET.Sdk.Web">`, publishing the project creates a *web.config* file in the published output (the *publish* folder). For more information, see [Host ASP.NET Core on Windows with IIS](xref:host-and-deploy/iis/index#webconfig-file).
 
-## Accessing configuration during startup
+## Access configuration during startup
 
 To access configuration within `ConfigureServices` or `Configure` during startup, see the examples in the [Application startup](xref:fundamentals/startup) topic.
+
+## Access configuration in a Razor Page or MVC view
+
+To access configuration settings in a Razor Pages page or an MVC view, add a [using directive](xref:mvc/views/razor#using) ([C# reference: using directive](/dotnet/csharp/language-reference/keywords/using-directive)) for the [Microsoft.Extensions.Configuration namespace](/dotnet/api/microsoft.extensions.configuration) and inject [IConfiguration](/dotnet/api/microsoft.extensions.configuration.iconfiguration) into the page or view.
+
+In a Razor Pages page:
+
+```cshtml
+@page
+@model IndexModel
+
+@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Index Page</title>
+</head>
+<body>
+    <h1>Access configuration in a Razor Pages page</h1>
+    <p>Configuration[&quot;key&quot;]: @Configuration["key"]</p>
+</body>
+</html>
+```
+
+In an MVC view:
+
+```cshtml
+@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Index View</title>
+</head>
+<body>
+    <h1>Access configuration in an MVC view</h1>
+    <p>Configuration[&quot;key&quot;]: @Configuration["key"]</p>
+</body>
+</html>
+```
 
 ## Additional notes
 


### PR DESCRIPTION
Fixes #5731 

It takes considerably more lines of code to show full examples of each. It could be shown quickly in one code block. However, *Fundamentals* is above MVC/RP topics. It's nice for new devs to see explicit examples in fundamentals topics if they skip *Tutorials* and just start reading.

Alternatively, we could show one block of:
```cshtml
// Add directives to the top of the page or view
@using Microsoft.Extensions.Configuration
@inject IConfiguration Configuration

// Access the value with Razor syntax
<p>Configuration[&quot;key&quot;]: @Configuration["key"]</p>
```

[EDIT] Thought it over 🤔 ... I'd be happy with it either way. Let me know which way you want to go. @rachelappel plz TAL, too.