### PR TITLE
Update highlight on dependency-injection.md

### DIFF
--- a/aspnetcore/mvc/views/dependency-injection.md
+++ b/aspnetcore/mvc/views/dependency-injection.md
@@ -35,7 +35,7 @@ This view displays a list of `ToDoItem` instances, along with a summary showing 
 
 The `StatisticsService` performs some calculations on the set of `ToDoItem` instances, which it accesses via a repository:
 
-[!code-csharp[](../../mvc/views/dependency-injection/sample/src/ViewInjectSample/Model/Services/StatisticsService.cs?highlight=15,20,26)]
+[!code-csharp[](../../mvc/views/dependency-injection/sample/src/ViewInjectSample/Model/Services/StatisticsService.cs?highlight=15,20,25)]
 
 The sample repository uses an in-memory collection. The implementation shown above (which operates on all of the data in memory) isn't recommended for large, remotely accessed data sets.
 


### PR DESCRIPTION
Currently the highlight is mapping the operation of GetAveragePriority on the incorrect line:

![image](https://user-images.githubusercontent.com/5913008/37677317-14c7e3d8-2c51-11e8-8678-1c0ed4c7ccdc.png)

The correction is to highlight the previous line.

*** Files no issue since its a minor correction, apologies.