### PR TITLE
Typo fix on specifying-the-master-page-programmatically-cs.md

### DIFF
--- a/aspnet/web-forms/overview/older-versions-getting-started/master-pages/specifying-the-master-page-programmatically-cs.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/master-pages/specifying-the-master-page-programmatically-cs.md
@@ -134,7 +134,7 @@ Next, add the following declarative markup to `Alternate.master`. As you can see
 
 ### Testing the New Master Page
 
-To test this new master page update the `BasePage` class's `OnPreInit` method so that the `MasterPageFile` property is assigned the value "~/Alternate.maser" and then visit the website. Every page should function without error except for two: `~/Admin/AddProduct.aspx` and `~/Admin/Products.aspx`. Adding a product to the DetailsView in `~/Admin/AddProduct.aspx` results in a `NullReferenceException` from the line of code that attempts to set the master page's `GridMessageText` property. When visiting `~/Admin/Products.aspx` an `InvalidCastException` is thrown on page load with the message: "Unable to cast object of type 'ASP.alternate\_master' to type 'ASP.site\_master'."
+To test this new master page update the `BasePage` class's `OnPreInit` method so that the `MasterPageFile` property is assigned the value "~/Alternate.master" and then visit the website. Every page should function without error except for two: `~/Admin/AddProduct.aspx` and `~/Admin/Products.aspx`. Adding a product to the DetailsView in `~/Admin/AddProduct.aspx` results in a `NullReferenceException` from the line of code that attempts to set the master page's `GridMessageText` property. When visiting `~/Admin/Products.aspx` an `InvalidCastException` is thrown on page load with the message: "Unable to cast object of type 'ASP.alternate\_master' to type 'ASP.site\_master'."
 
 These errors occur because the `Site.master` code-behind class includes public events, properties, and methods that are not defined in `Alternate.master`. The markup portion of these two pages have a `@MasterType` directive that references the `Site.master` master page.
 


### PR DESCRIPTION
Corrected the typo error on line #137 (Alternate.master)

No Issue is related to this fix.
