### PR TITLE
Update first two lines of Options pattern topic

### DIFF
--- a/aspnetcore/fundamentals/configuration/options.md
+++ b/aspnetcore/fundamentals/configuration/options.md
@@ -15,7 +15,7 @@ uid: fundamentals/configuration/options
 
 By [Luke Latham](https://github.com/guardrex)
 
-The options pattern uses options classes to represent groups of related settings. When configuration settings are isolated by feature into separate options classes, the app adheres to two important software engineering principles:
+The options pattern uses classes to represent groups of related settings. When configuration settings are isolated by feature into separate classes, the app adheres to two important software engineering principles:
 
 * The [Interface Segregation Principle (ISP)](http://deviq.com/interface-segregation-principle/): Features (classes) that depend on configuration settings depend only on the configuration settings that they use.
 * [Separation of Concerns](http://deviq.com/separation-of-concerns/): Settings for different parts of the app aren't dependent or coupled to one another.


### PR DESCRIPTION
Reader feedback from @Baharestani ...

> The first line is referring to something called "option classes" which doesn't make any sense to a reader who is not familiar with Options Pattern.

The use of "options class" now first appears on line 29 where it's defined.

Thank you @Baharestani for pointing this out. :rocket: