### PR TITLE
Typo correction in intro.md

### DIFF
--- a/aspnetcore/includes/webApi/intro.md
+++ b/aspnetcore/includes/webApi/intro.md
@@ -18,7 +18,7 @@ The following diagram shows the basic design of the app.
 
 * The client is whatever consumes the web API (mobile app, browser, etc.). This tutorial doesn't create a client. [Postman](https://www.getpostman.com/) or [curl](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/curl.1.html) is used as the client to test the app.
 
-* A *model* is an object that represents the data in the app. In this case, the only model is a to-do item. Models are represented as C# classes, also know as **P**lain **O**ld **C**# **O**bject (POCOs).
+* A *model* is an object that represents the data in the app. In this case, the only model is a to-do item. Models are represented as C# classes, also known as **P**lain **O**ld **C**# **O**bject (POCOs).
 
 * A *controller* is an object that handles HTTP requests and creates the HTTP response. This app has a single controller.
 


### PR DESCRIPTION
Fixes a spelling mistake in **intro.md** file, which is used building web APIs tutorials.