### PR TITLE
Fix typo

### DIFF
--- a/aspnet/web-api/overview/security/authentication-filters/samples/sample3.cs
+++ b/aspnet/web-api/overview/security/authentication-filters/samples/sample3.cs
@@ -2,7 +2,7 @@ public static class WebApiConfig
 {
     public static void Register(HttpConfiguration config)
     {
-        config.Filters.Add(new IdentityBasicAuthenticationAttribute());
+        config.Filters.Add(new IdentityBasicAuthentication());
 
         // Other configuration code not shown...
     }


### PR DESCRIPTION
Fixing typo  The other two examples have the attribute called 

>[IdentityBasicAuthentication] // Enable Basic authentication for this controller.

This section will also need to use IdentityBasicAuthentication

IdentityBasicAuthentication


