### PR TITLE
Angular CLI live reloading when branching middleware

### DIFF
--- a/aspnetcore/spa/angular.md
+++ b/aspnetcore/spa/angular.md
@@ -193,17 +193,17 @@ At the same time, there are significant drawbacks to enabling SSR. It adds compl
 
 ## Live Reloading
 
-When utilizing `UseAngularCliServer` in development mode, `ng serve` will by default enable live reload. Live reload will watch for changes in your client application, trigger a build, and refresh the browser. Angular CLI assumes the `sockjs` endpoint it uses to trigger the browser refresh will be at the path `/sockjs-node`. However if you are [branching the middleware chain](xref:fundamentals/middleware/index#use-run-and-map), e.g. using `Map` to proxy your client application at anything other than the root server path, you will need to configure the `sockjs` endpoint using the `live-reload-client` (aka `public-host`) option. Note that this argument requires a fully qualified URL.
+When utilizing `UseAngularCliServer` in development mode, `ng serve` enables live reload by default. Live reload watches for changes in your client app, triggers a build, and refreshes the browser. Angular CLI assumes the `sockjs` endpoint it uses to trigger the browser refresh is at the path `/sockjs-node`. If you're [branching the middleware chain](xref:fundamentals/middleware/index#use-run-and-map) (for example, using `Map` to proxy your client app at anything other than the root server path) configure the `sockjs` endpoint using the `live-reload-client` (also known as `public-host`) option. Note that this argument requires a fully qualified URL.
 
-e.g. When branching to `myapp`:
+For example, when branching to `myapp`:
 
 ```json
-  "scripts": {
+"scripts": {
     "start": "ng serve --extract-css --live-reload-client=http://localhost:5000/myapp/sockjs-node/",
-  }
+}
 ```
 
-If you are also utilizing pre-rendering via `UseSpaPrerendering`, you will need to update the `ExcludeUrls` in your rendering options as well:
+If you're utilizing pre-rendering via `UseSpaPrerendering`, update the `ExcludeUrls` in your rendering options as well:
 
 ```csharp
 options.ExcludeUrls = new[] { "/myapp/sockjs-node" };

--- a/aspnetcore/spa/angular.md
+++ b/aspnetcore/spa/angular.md
@@ -190,3 +190,21 @@ At the same time, there are significant drawbacks to enabling SSR. It adds compl
         // Call browser-specific APIs here
     }
     ```
+
+## Live Reloading
+
+When utilizing `UseAngularCliServer` in development mode, `ng serve` will by default enable live reload. Live relaod will watch for changes in your client application, trigger a build, and refresh the browser. Angular CLI assumes the `sockjs` endpoint it uses to trigger the browser refresh will be at the path `/sockjs-node`. However if you are [branching the middleware chain](xref:fundamentals/middleware/index#use-run-and-map), e.g. using `Map` to proxy your client application at anything other than the root server path, you will need to configure the `sockjs` endpoint using the `live-reload-client` (aka `public-host`) option. Note that this argument requires a fully qualified URL.
+
+e.g. When branching to `myapp`:
+
+```json
+  "scripts": {
+    "start": "ng serve --extract-css --live-reload-client=http://localhost:5000/myapp/sockjs-node/",
+  }
+```
+
+If you are also utilizing pre-rendering via `UseSpaPrerendering`, you will need to update the `ExcludeUrls` in your rendering options as well:
+
+```csharp
+options.ExcludeUrls = new[] { "/myapp/sockjs-node" };
+```

--- a/aspnetcore/spa/angular.md
+++ b/aspnetcore/spa/angular.md
@@ -193,7 +193,7 @@ At the same time, there are significant drawbacks to enabling SSR. It adds compl
 
 ## Live Reloading
 
-When utilizing `UseAngularCliServer` in development mode, `ng serve` will by default enable live reload. Live relaod will watch for changes in your client application, trigger a build, and refresh the browser. Angular CLI assumes the `sockjs` endpoint it uses to trigger the browser refresh will be at the path `/sockjs-node`. However if you are [branching the middleware chain](xref:fundamentals/middleware/index#use-run-and-map), e.g. using `Map` to proxy your client application at anything other than the root server path, you will need to configure the `sockjs` endpoint using the `live-reload-client` (aka `public-host`) option. Note that this argument requires a fully qualified URL.
+When utilizing `UseAngularCliServer` in development mode, `ng serve` will by default enable live reload. Live reload will watch for changes in your client application, trigger a build, and refresh the browser. Angular CLI assumes the `sockjs` endpoint it uses to trigger the browser refresh will be at the path `/sockjs-node`. However if you are [branching the middleware chain](xref:fundamentals/middleware/index#use-run-and-map), e.g. using `Map` to proxy your client application at anything other than the root server path, you will need to configure the `sockjs` endpoint using the `live-reload-client` (aka `public-host`) option. Note that this argument requires a fully qualified URL.
 
 e.g. When branching to `myapp`:
 

--- a/aspnetcore/spa/angular.md
+++ b/aspnetcore/spa/angular.md
@@ -191,9 +191,9 @@ At the same time, there are significant drawbacks to enabling SSR. It adds compl
     }
     ```
 
-## Live Reloading
+## Live reloading
 
-When utilizing `UseAngularCliServer` in development mode, `ng serve` enables live reload by default. Live reload watches for changes in your client app, triggers a build, and refreshes the browser. Angular CLI assumes the `sockjs` endpoint it uses to trigger the browser refresh is at the path `/sockjs-node`. If you're [branching the middleware chain](xref:fundamentals/middleware/index#use-run-and-map) (for example, using `Map` to proxy your client app at anything other than the root server path) configure the `sockjs` endpoint using the `live-reload-client` (also known as `public-host`) option. Note that this argument requires a fully qualified URL.
+When utilizing `UseAngularCliServer` in development mode, `ng serve` enables live reload by default. Live reload watches for changes in your client app, triggers a build, and refreshes the browser. Angular CLI assumes the SockJS endpoint it uses to trigger the browser refresh is at the path `/sockjs-node`. If you [branch the middleware chain](xref:fundamentals/middleware/index#use-run-and-map) (for example, using `Map` to proxy your client app at anything other than the root server path), configure the SockJS endpoint using the `live-reload-client` (also known as `public-host`) option. This argument requires a fully qualified URL.
 
 For example, when branching to `myapp`:
 
@@ -203,7 +203,7 @@ For example, when branching to `myapp`:
 }
 ```
 
-If you're utilizing pre-rendering via `UseSpaPrerendering`, update the `ExcludeUrls` in your rendering options as well:
+If you're using pre-rendering via `UseSpaPrerendering`, update the `ExcludeUrls` property in your rendering options:
 
 ```csharp
 options.ExcludeUrls = new[] { "/myapp/sockjs-node" };


### PR DESCRIPTION
* Added information on changes needed when using `Map` to branch middleware for a SPA, e.g. when doing a multi-SPA setup
* See https://github.com/aspnet/JavaScriptServices/issues/1491

[Internal Review Page](https://review.docs.microsoft.com/en-us/aspnet/core/spa/angular?view=aspnetcore-2.1&branch=pr-en-us-5953&tabs=visual-studio#live-reloading)