### PR TITLE
RP conventions topic update

### DIFF
--- a/aspnetcore/mvc/razor-pages/razor-pages-convention-features.md
+++ b/aspnetcore/mvc/razor-pages/razor-pages-convention-features.md
@@ -5,7 +5,7 @@ description: Discover how route and app model provider convention features help 
 manager: wpickett
 monikerRange: '>= aspnetcore-2.0'
 ms.author: riande
-ms.date: 10/23/2017
+ms.date: 04/12/2018
 ms.prod: asp.net-core
 ms.technology: aspnet
 ms.topic: article
@@ -19,20 +19,31 @@ Learn how to use page [route and app model provider convention](xref:mvc/control
 
 [View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/mvc/razor-pages/razor-pages-convention-features/sample/) ([how to download](xref:tutorials/index#how-to-download-a-sample))
 
+::: moniker range="= aspnetcore-2.0"
 | Features | The sample demonstrates ... |
 | -------- | --------------------------- |
-| [Route and app model conventions](#add-route-and-app-model-conventions)<br><br>Conventions.Add<ul><li>IPageRouteModelConvention</li><li>IPageApplicationModelConvention</li></ul> | Adding a route template and header to an app's pages. |
-| [Page route action conventions](#page-route-action-conventions)<ul><li>AddFolderRouteModelConvention</li><li>AddPageRouteModelConvention</li><li>AddPageRoute</li></ul> | Adding a route template to pages in a folder and to a single page. |
-| [Page model action conventions](#page-model-action-conventions)<ul><li>AddFolderApplicationModelConvention</li><li>AddPageApplicationModelConvention</li><li>ConfigureFilter (filter class, lambda expression, or filter factory)</li></ul> | Adding a header to pages in a folder, adding a header to a single page, and configuring a [filter factory](xref:mvc/controllers/filters#ifilterfactory) to add a header to an app's pages. |
-| [Default page app model provider](#replace-the-default-page-app-model-provider) | Replacing the default page model provider to change the conventions for handler naming. |
+| [Model conventions](#model-conventions)<br><br>Conventions.Add<ul><li>IPageRouteModelConvention</li><li>IPageApplicationModelConvention</li></ul> | Add a route template and header to an app's pages. |
+| [Page route action conventions](#page-route-action-conventions)<ul><li>AddFolderRouteModelConvention</li><li>AddPageRouteModelConvention</li><li>AddPageRoute</li></ul> | Add a route template to pages in a folder and to a single page. |
+| [Page model action conventions](#page-model-action-conventions)<ul><li>AddFolderApplicationModelConvention</li><li>AddPageApplicationModelConvention</li><li>ConfigureFilter (filter class, lambda expression, or filter factory)</li></ul> | Add a header to pages in a folder, add a header to a single page, and configure a [filter factory](xref:mvc/controllers/filters#ifilterfactory) to add a header to an app's pages. |
+| [Default page app model provider](#replace-the-default-page-app-model-provider) | Replace the default page model provider to change the conventions for handler names. |
+::: moniker-end
+::: moniker range=">= aspnetcore-2.1"
+| Features | The sample demonstrates ... |
+| -------- | --------------------------- |
+| [Model conventions](#model-conventions)<br><br>Conventions.Add<ul><li>IPageRouteModelConvention</li><li>IPageApplicationModelConvention</li><li>IPageHandlerModelConvention</li></ul> | Add a route template and header to an app's pages. |
+| [Page route action conventions](#page-route-action-conventions)<ul><li>AddFolderRouteModelConvention</li><li>AddPageRouteModelConvention</li><li>AddPageRoute</li></ul> | Add a route template to pages in a folder and to a single page. |
+| [Page model action conventions](#page-model-action-conventions)<ul><li>AddFolderApplicationModelConvention</li><li>AddPageApplicationModelConvention</li><li>ConfigureFilter (filter class, lambda expression, or filter factory)</li></ul> | Add a header to pages in a folder, add a header to a single page, and configure a [filter factory](xref:mvc/controllers/filters#ifilterfactory) to add a header to an app's pages. |
+| [Default page app model provider](#replace-the-default-page-app-model-provider) | Replace the default page model provider to change the conventions for handler names. |
+::: moniker-end
 
-## Add route and app model conventions
 
-Add a delegate for [IPageConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipageconvention) to add [route and app model conventions](xref:mvc/controllers/application-model#conventions) that apply to Razor Pages.
+## Model conventions
+
+Add a delegate for [IPageConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipageconvention) to add [model conventions](xref:mvc/controllers/application-model#conventions) that apply to Razor Pages.
 
 **Add a route model convention to all pages**
 
-Use [Conventions](/dotnet/api/microsoft.aspnetcore.mvc.razorpages.razorpagesoptions.conventions) to create and add an [IPageRouteModelConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipageroutemodelconvention) to the collection of [IPageConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipageconvention) instances that are applied during route and page model construction.
+Use [Conventions](/dotnet/api/microsoft.aspnetcore.mvc.razorpages.razorpagesoptions.conventions) to create and add an [IPageRouteModelConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipageroutemodelconvention) to the collection of [IPageConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipageconvention) instances that are applied during page route model construction.
 
 The sample app adds a `{globalTemplate?}` route template to all of the pages in the app:
 
@@ -51,7 +62,7 @@ Request the sample's About page at `localhost:5000/About/GlobalRouteValue` and i
 
 **Add an app model convention to all pages**
 
-Use [Conventions](/dotnet/api/microsoft.aspnetcore.mvc.razorpages.razorpagesoptions.conventions) to create and add an [IPageApplicationModelConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipageapplicationmodelconvention) to the collection of [IPageConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipageconvention) instances that are applied during route and page model construction.
+Use [Conventions](/dotnet/api/microsoft.aspnetcore.mvc.razorpages.razorpagesoptions.conventions) to create and add an [IPageApplicationModelConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipageapplicationmodelconvention) to the collection of [IPageConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipageconvention) instances that are applied during page app model construction.
 
 To demonstrate this and other conventions later in the topic, the sample app includes an `AddHeaderAttribute` class. The class constructor accepts a `name` string and a `values` string array. These values are used in its `OnResultExecuting` method to set a response header. The full class is shown in the [Page model action conventions](#page-model-action-conventions) section later in the topic.
 
@@ -66,6 +77,35 @@ The sample app uses the `AddHeaderAttribute` class to add a header, `GlobalHeade
 Request the sample's About page at `localhost:5000/About` and inspect the headers to view the result:
 
 ![Response headers of the About page show that the GlobalHeader has been added.](razor-pages-convention-features/_static/about-page-global-header.png)
+
+::: moniker range=">= aspnetcore-2.1"
+**Add a handler model convention to all pages**
+
+[!INCLUDE[](~/includes/2.1.md)]
+
+Use [Conventions](/dotnet/api/microsoft.aspnetcore.mvc.razorpages.razorpagesoptions.conventions) to create and add an [IPageHandlerModelConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipagehandlermodelconvention) to the collection of [IPageConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipageconvention) instances that are applied during page handler model construction.
+
+```csharp
+public class GlobalPageHandlerModelConvention 
+    : IPageHandlerModelConvention
+{
+    public void Apply(PageHandlerModel model)
+    {
+        ...
+    }
+}
+```
+
+`Startup.ConfigureServices`:
+
+```csharp
+services.AddMvc()
+    .AddRazorPagesOptions(options =>
+        {
+            options.Conventions.Add(new GlobalPageHandlerModelConvention());
+        });
+```
+::: moniker-end
 
 ## Page route action conventions
 

--- a/aspnetcore/mvc/razor-pages/razor-pages-convention-features/sample/README.md
+++ b/aspnetcore/mvc/razor-pages/razor-pages-convention-features/sample/README.md
@@ -4,10 +4,9 @@ This sample illustrates use of Razor Pages custom route and page model providers
 
 ## Examples in this sample
 
-|                                                                                     Features                                                                                      |                                                             Sample demo                                                              |
-|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-|         [Add route and app model conventions](https://docs.microsoft.com/aspnet/core/mvc/razor-pages/razor-pages-convention-features#add-route-and-app-model-conventions)         |                                         Add a route attribute and header to the app's pages.                                         |
-|               [Use AddPageRoute to add a page route](https://docs.microsoft.com/aspnet/core/mvc/razor-pages/razor-pages-convention-features#configure-a-page-route)               |                                     Adds the specified route to the page at the specified page.                                      |
-|               [Page model action conventions](https://docs.microsoft.com/aspnet/core/mvc/razor-pages/razor-pages-convention-features#page-model-action-conventions)               | Add a header to pages in a folder, add a header to a single page, and configure a filter factory to add a header to the app's pages. |
-| [Replace the default page app model provider](https://docs.microsoft.com/aspnet/core/mvc/razor-pages/razor-pages-convention-features#replace-the-default-page-app-model-provider) |                                              Change the conventions for handler naming.                                              |
-
+| Features | Sample demo |
+| -------- | ----------- |
+| [Model conventions](https://docs.microsoft.com/aspnet/core/mvc/razor-pages/razor-pages-convention-features#model-conventions) | Add a route attribute and header to the app's pages. |
+| [Use AddPageRoute to add a page route](https://docs.microsoft.com/aspnet/core/mvc/razor-pages/razor-pages-convention-features#configure-a-page-route) | Adds the specified route to the page at the specified page. |
+| [Page model action conventions](https://docs.microsoft.com/aspnet/core/mvc/razor-pages/razor-pages-convention-features#page-model-action-conventions) | Add a header to pages in a folder, add a header to a single page, and configure a filter factory to add a header to the app's pages. |
+| [Replace the default page app model provider](https://docs.microsoft.com/aspnet/core/mvc/razor-pages/razor-pages-convention-features#replace-the-default-page-app-model-provider) | Change the conventions for handler naming. |


### PR DESCRIPTION
Fixes #5520 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/razor-pages/razor-pages-convention-features?view=aspnetcore-2.0&branch=pr-en-us-5961)

* I can't see the built topic, please check rendering on review.
* I've added a note to the [Sample Update Tracking Issue](https://github.com/aspnet/Docs/issues/5495) to add `IPageHandlerModelConvention` to the sample when it's upgraded to 2.1.

To speed up review of the table, the major change there (in the *Model Conventions* row) is

\<= 2.0
* IPageRouteModelConvention
* IPageApplicationModelConvention

\>= 2.1
* IPageRouteModelConvention
* IPageApplicationModelConvention
* IPageHandlerModelConvention