### PR TITLE
Fixed hidden element rendered in md

### DIFF
--- a/aspnetcore/client-side/bootstrap.md
+++ b/aspnetcore/client-side/bootstrap.md
@@ -76,7 +76,7 @@ The default template uses a set of `<div>` elements to render a top navbar and t
 </button>
 ```
 
-It also includes the application name, which appears in the top left. The main navigation menu is rendered by the `<ul>` element within the second div, and includes links to Home, About, and Contact. Additional links for Register and Login are added by the _LoginPartial line on line 29. Below the navigation, the main body of each page is rendered in another `<div>`, marked with the "container" and "body-content" classes. In the simple default _Layout file shown here, the contents of the page are rendered by the specific View associated with the page, and then a simple `<footer>` is added to the end of the `<div>` element. You can see how the built-in About page appears using this template:
+It also includes the application name, which appears in the top left. The main navigation menu is rendered by the `<ul>` element within the second div, and includes links to Home, About, and Contact. Below the navigation, the main body of each page is rendered in another `<div>`, marked with the "container" and "body-content" classes. In the simple default _Layout file shown here, the contents of the page are rendered by the specific View associated with the page, and then a simple `<footer>` is added to the end of the `<div>` element. You can see how the built-in About page appears using this template:
 
 ![about page](bootstrap/_static/about-page-wide.png)
 
@@ -141,7 +141,7 @@ The default button classes and their colors are shown in the figure below.
 
 ### Badges
 
-Badges refer to small, usually numeric callouts next to a navigation item. They can indicate a number of messages or notifications waiting, or the presence of updates. Specifying such badges is as simple as adding a <span> containing the text, with a class of "badge":
+Badges refer to small, usually numeric callouts next to a navigation item. They can indicate a number of messages or notifications waiting, or the presence of updates. Specifying such badges is as simple as adding a `<span>` containing the text, with a class of "badge":
 
 ![themed badges](bootstrap/_static/theme-badges.png)
 


### PR DESCRIPTION
The span is invisible on the page. Also, everything in the intro recommending using bower "Adding Bootstrap to an ASP.NET Core project is simply a matter of adding it to bower.json as a dependency:" should be updated to nuget and csproj. Also the ASP.NET CORE WEB application template no longer contains a login on VS 15.7 preview 3 so maybe just delete the reference?
