### PR TITLE
Fix unordered list formatting with monikers

### DIFF
--- a/aspnetcore/web-api/action-return-types.md
+++ b/aspnetcore/web-api/action-return-types.md
@@ -19,9 +19,13 @@ By [Scott Addie](https://github.com/scottaddie)
 
 ASP.NET Core offers the following options for Web API controller action return types:
 
+::: moniker range="<= aspnetcore-2.0"
 * [Specific type](#specific-type)
 * [IActionResult](#iactionresult-type)
+::: moniker-end
 ::: moniker range=">= aspnetcore-2.1"
+* [Specific type](#specific-type)
+* [IActionResult](#iactionresult-type)
 * [ActionResult\<T>](#actionresultt-type)
 ::: moniker-end
 


### PR DESCRIPTION
Eliminates the awkward line break before the 3rd list item in the following doc:
https://docs.microsoft.com/en-us/aspnet/core/web-api/action-return-types?view=aspnetcore-2.1