### PR TITLE
Add 2.1 note to Partial Tag Helper doc

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/built-in/partial-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/partial-tag-helper.md
@@ -16,6 +16,8 @@ uid: mvc/views/tag-helpers/builtin-th/partial-tag-helper
 
 By [Scott Addie](https://github.com/scottaddie)
 
+[!INCLUDE[](~/includes/2.1.md)]
+
 [View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/mvc/views/tag-helpers/built-in/samples) ([how to download](xref:tutorials/index#how-to-download-a-sample))
 
 ## Overview

--- a/aspnetcore/mvc/views/tag-helpers/built-in/partial-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/partial-tag-helper.md
@@ -16,7 +16,7 @@ uid: mvc/views/tag-helpers/builtin-th/partial-tag-helper
 
 By [Scott Addie](https://github.com/scottaddie)
 
-[!INCLUDE[](~/includes/2.1.md)]
+[!INCLUDE [2.1 preview notice](~/includes/2.1.md)]
 
 [View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/mvc/views/tag-helpers/built-in/samples) ([how to download](xref:tutorials/index#how-to-download-a-sample))
 


### PR DESCRIPTION
Adds the 2.1 preview note to the Partial Tag Helper doc
