### PR TITLE
Remove deprecated DotNetCliToolReference node

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/TagHelpersBuiltIn.csproj
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/TagHelpersBuiltIn.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -6,10 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-preview2-final" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.1.0-preview1-final" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Removes a deprecated DotNetCliToolReference from the CSPROJ file. It has been replaced by a .NET Core CLI global tool.