### PR TITLE
fixed globbing pattern.

### DIFF
--- a/aspnetcore/client-side/bundling-and-minification.md
+++ b/aspnetcore/client-side/bundling-and-minification.md
@@ -200,7 +200,7 @@ To minify *custom.css* and bundle it with *site.css* into a *site.min.css* file,
 > Alternatively, the following globbing pattern could be used:
 >
 > ```json
-> "inputFiles": ["wwwroot/**/*(*.!(min).css)"]
+> "inputFiles": ["wwwroot/**/@(*!(min).css)"]
 > ```
 >
 > This globbing pattern matches all CSS files and excludes the minified file pattern.

--- a/aspnetcore/client-side/bundling-and-minification.md
+++ b/aspnetcore/client-side/bundling-and-minification.md
@@ -200,7 +200,7 @@ To minify *custom.css* and bundle it with *site.css* into a *site.min.css* file,
 > Alternatively, the following globbing pattern could be used:
 >
 > ```json
-> "inputFiles": ["wwwroot/**/*(*.css|!(*.min.css)"]
+> "inputFiles": ["wwwroot/**/*(*.!(min).css)"]
 > ```
 >
 > This globbing pattern matches all CSS files and excludes the minified file pattern.


### PR DESCRIPTION
Good information. The old globbing pattern (ignoring the right parenthesis typo) would match every input so I fixed it. A third way I thought to do it would be: `/**/!(*.!(css))` which prevents min because the *. before the parenthesis will match only the first . and not the last `.`. Negating twice gets the .css extension back. I decided for the other way because this will also match .css in the middle of words.
