### PR TITLE
npm test directory wrong

### DIFF
--- a/aspnetcore/client-side/spa-services.md
+++ b/aspnetcore/client-side/spa-services.md
@@ -287,7 +287,7 @@ Using the Angular application as an example, two Jasmine test cases are already 
 
 [!code-typescript[](../client-side/spa-services/sample/SpaServicesSampleApp/ClientApp/app/components/counter/counter.component.spec.ts?range=15-28)]
 
-Open the command prompt at the project root, and run the following command:
+Open the command prompt in the **ClientApp** subdirectory, and run the following command:
 
 ```console
 npm test

--- a/aspnetcore/client-side/spa-services.md
+++ b/aspnetcore/client-side/spa-services.md
@@ -287,7 +287,7 @@ Using the Angular application as an example, two Jasmine test cases are already 
 
 [!code-typescript[](../client-side/spa-services/sample/SpaServicesSampleApp/ClientApp/app/components/counter/counter.component.spec.ts?range=15-28)]
 
-Open the command prompt in the **ClientApp** subdirectory, and run the following command:
+Open the command prompt in the *ClientApp* directory. Run the following command:
 
 ```console
 npm test


### PR DESCRIPTION
Running the command in the project root complains that no package.json can be found. You have to run the command from the ClientApp directory where the package.json is located also indicated in the instructions on the splash page "The ClientApp subdirectory is a standard Angular CLI application. If you open a command prompt in that directory, you can run any ng command (e.g., ng test), or use npm to install extra packages into it."
