### PR TITLE
Task continuation correction

### DIFF
--- a/aspnetcore/fundamentals/owin.md
+++ b/aspnetcore/fundamentals/owin.md
@@ -78,8 +78,11 @@ app.UseOwin(pipeline =>
     pipeline(next =>
     {
         // do something before
-        return OwinHello;
-        // do something after
+        return OwinHello.ContinueWith((t)=>
+        {
+            // do something after
+        });
+        
     });
 });
 ```
@@ -92,7 +95,7 @@ OWIN-based servers can host ASP.NET applications. One such server is [Nowin](htt
 
 [!code-csharp[](owin/sample/src/NowinSample/Program.cs?highlight=15)]
 
-`IServer` is an interface that requires an `Features` property and a `Start` method.
+`IServer` is an interface that requires a `Features` property and a `Start` method.
 
 `Start` is responsible for configuring and starting the server, which in this case is done through a series of fluent API calls that set addresses parsed from the IServerAddressesFeature. Note that the fluent configuration of the `_builder` variable specifies that requests will be handled by the `appFunc` defined earlier in the method. This `Func` is called on each request to process incoming requests.
 
@@ -129,7 +132,7 @@ namespace Microsoft.AspNetCore.Hosting
 }
 ```
 
-With this in place, all that's required to run an ASP.NET application using this custom server to call the extension in *Program.cs*:
+With this in place, all that's required to run an ASP.NET application using this custom server is to call the extension in *Program.cs*:
 
 ```csharp
 
@@ -217,7 +220,7 @@ This [sample](https://github.com/aspnet/Docs/tree/master/aspnetcore/fundamentals
 
 ## OWIN environment
 
-You can construct a OWIN environment using the `HttpContext`.
+You can construct an OWIN environment using the `HttpContext`.
 
 ```csharp
 


### PR DESCRIPTION
I think the example should be written using `task.ContinueWith` as the original implies the more calls could be made after the function already returned.
