### PR TITLE
fixed infinite loop error

### DIFF
--- a/aspnetcore/fundamentals/primitives/change-tokens/sample/Utilities/Utilities.cs
+++ b/aspnetcore/fundamentals/primitives/change-tokens/sample/Utilities/Utilities.cs
@@ -23,7 +23,8 @@ namespace ChangeTokenSample.Utilities
                             return System.Security.Cryptography.SHA1.Create().ComputeHash(fs);
                         }
                     }
-                    else {
+                    else 
+                    {
                         throw new FileNotFoundException();
                     }
                 }

--- a/aspnetcore/fundamentals/primitives/change-tokens/sample/Utilities/Utilities.cs
+++ b/aspnetcore/fundamentals/primitives/change-tokens/sample/Utilities/Utilities.cs
@@ -23,6 +23,9 @@ namespace ChangeTokenSample.Utilities
                             return System.Security.Cryptography.SHA1.Create().ComputeHash(fs);
                         }
                     }
+                    else {
+                        throw new FileNotFoundException();
+                    }
                 }
                 catch (IOException ex)
                 {


### PR DESCRIPTION
The original would loop infinitely if the file doesn't exist. (bug).

 Now, private void InvokeChanged(IHostingEnvironment env) should invoke computenhash() in a try catch... I could add that if desired