### PR TITLE
[WIP] Add Web API controller definition doc

### DIFF
--- a/aspnetcore/web-api/define-controller.md
+++ b/aspnetcore/web-api/define-controller.md
@@ -1,0 +1,117 @@
+---
+title: Define a controller in ASP.NET Core Web API
+author: scottaddie
+description: Learn about the options for defining a controller class in an ASP.NET Core Web API and when it's most appropriate to use each.
+manager: wpickett
+ms.author: scaddie
+ms.custom: mvc
+ms.date: 04/17/2018
+ms.prod: aspnet-core
+ms.technology: aspnet
+ms.topic: article
+uid: web-api/define-controller
+---
+# Define a controller in ASP.NET Core Web API
+
+By [Scott Addie](https://github.com/scottaddie)
+
+::: moniker range=">= aspnetcore-2.1"
+[View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/web-api/define-controller/samples) ([how to download](xref:tutorials/index#how-to-download-a-sample))
+::: moniker-end
+
+ASP.NET Core offers the following options for creating a Web API controller:
+
+::: moniker range="<= aspnetcore-2.0"
+* [Derive class from Controller](#derive-class-from-controller)
+* [Derive class from ControllerBase](#derive-class-from-controllerbase)
+::: moniker-end
+::: moniker range=">= aspnetcore-2.1"
+* [Derive class from Controller](#derive-class-from-controller)
+* [Derive class from ControllerBase](#derive-class-from-controllerbase)
+* [Decorate class with ApiControllerAttribute](#decorate-class-with-apicontrollerattribute)
+::: moniker-end
+
+This document explains when it's most appropriate to use each option.
+
+## Derive class from Controller
+
+Inherit from the [Controller](/dotnet/api/microsoft.aspnetcore.mvc.controller) class when your controller needs to support MVC views in addition to Web API actions. For example:
+
+```csharp
+[Route("api/[controller]")]
+public class ProductsController : Controller
+{
+}
+```
+
+## Derive class from ControllerBase
+
+Inherit from the [ControllerBase](/dotnet/api/microsoft.aspnetcore.mvc.controllerbase) class when your controller doesn't need to support MVC views. For example:
+
+```csharp
+[Route("api/[controller]")]
+public class ProductsController : ControllerBase
+{
+}
+```
+
+::: moniker range=">= aspnetcore-2.1"
+## Decorate class with ApiControllerAttribute
+
+ASP.NET Core 2.1 introduces the `[ApiController]` attribute to denote a Web API controller class. For example:
+
+[!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Controllers/ProductsController.cs?name=snippet_ControllerSignature&highlight=2)]
+
+The following sections describe convenience features added by the attribute.
+
+### Automatic HTTP 400 responses
+
+Validation errors automatically trigger an HTTP 400 response. Code such as the following becomes unnecessary:
+
+```csharp
+if (!ModelState.IsValid)
+{
+    return BadRequest(ModelState);
+}
+```
+
+This default behavior is disabled with the following code in *Startup.ConfigureServices*:
+
+[!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Startup.cs?name=snippet_ConfigureApiBehaviorOptions&highlight=5)]
+
+### Binding source parameter inference
+
+Inference rules are applied for the default data sources of action parameters. The binding source attributes behave as follows:
+
+* [[FromBody]](/dotnet/api/microsoft.aspnetcore.mvc.frombodyattribute) is inferred for complex type parameters. An exception to this rule is any complex, built-in type with a special meaning, such as [IFormCollection](/dotnet/api/microsoft.aspnetcore.http.iformcollection) and [CancellationToken](/dotnet/api/system.threading.cancellationtoken). The binding source inference code ignores those special types. If you decide to explicitly apply the `[FromBody]` attribute, multiple occurrences of it in the same action results in an exception.
+* [[FromRoute]](/dotnet/api/microsoft.aspnetcore.mvc.fromrouteattribute) is inferred for any action parameter name matching a parameter in the route template. When multiple routes match an action parameter, any route value is considered `[FromRoute]`.
+* [[FromQuery]](/dotnet/api/microsoft.aspnetcore.mvc.fromqueryattribute) is inferred for anything else.
+
+For example, the `[FromBody]` attribute is implied for the `Product` parameter:
+
+[!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Controllers/ProductsController.cs?name=snippet_CreateAsync)]
+
+Inheriting from `ControllerBase` is necessary in the preceding example, since access to the [CreatedAtAction](/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.createdataction#Microsoft_AspNetCore_Mvc_ControllerBase_CreatedAtAction_System_String_System_Object_System_Object_) method is required.
+
+The default inference rules are disabled with the following code in *Startup.ConfigureServices*:
+
+[!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Startup.cs?name=snippet_ConfigureApiBehaviorOptions&highlight=4)]
+
+### Multipart/form-data request inference
+
+When an action parameter is annotated with the [[FromForm]](/dotnet/api/microsoft.aspnetcore.mvc.fromformattribute) attribute, the `multipart/form-data` request format is inferred.
+
+The default behavior is disabled with the following code in *Startup.ConfigureServices*:
+
+[!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Startup.cs?name=snippet_ConfigureApiBehaviorOptions&highlight=3)]
+
+### Attribute routing requirement
+
+Attribute routing becomes a requirement. For example:
+
+[!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Controllers/ProductsController.cs?name=snippet_ControllerSignature&highlight=1)]
+
+Actions are inaccessible via convention-based routes defined via [UseMvc](/dotnet/api/microsoft.aspnetcore.builder.mvcapplicationbuilderextensions.usemvc#Microsoft_AspNetCore_Builder_MvcApplicationBuilderExtensions_UseMvc_Microsoft_AspNetCore_Builder_IApplicationBuilder_System_Action_Microsoft_AspNetCore_Routing_IRouteBuilder__) in *Startup.Configure*.
+::: moniker-end
+
+## Additional resources

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/Controllers/ProductsController.cs
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/Controllers/ProductsController.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebApiSample.DataAccess.Models;
+using WebApiSample.DataAccess.Repositories;
+
+namespace WebApiSample.Api.Controllers
+{
+    #region snippet_ControllerSignature
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ProductsController : ControllerBase
+    #endregion
+    {
+        private readonly ProductsRepository _repository;
+
+        public ProductsController(ProductsRepository repository)
+        {
+            _repository = repository;
+        }
+
+        #region snippet_Get
+        [HttpGet]
+        public IEnumerable<Product> Get()
+        {
+            return _repository.GetProducts();
+        }
+        #endregion
+
+        #region snippet_GetById
+        [HttpGet("{id}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(404)]
+        public ActionResult<Product> GetById(int id)
+        {
+            if (!_repository.TryGetProduct(id, out var product))
+            {
+                return NotFound();
+            }
+
+            return product;
+        }
+        #endregion
+
+        #region snippet_CreateAsync
+        [HttpPost]
+        [ProducesResponseType(201)]
+        [ProducesResponseType(400)]
+        public async Task<ActionResult<Product>> CreateAsync(Product product)
+        {
+            await _repository.AddProductAsync(product);
+
+            return CreatedAtAction(nameof(GetById), 
+                new { id = product.Id }, product);
+        }
+        #endregion
+    }
+}

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/Controllers/ValuesController.cs
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/Controllers/ValuesController.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+
+namespace WebApiSample.Api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ValuesController : ControllerBase
+    {
+        // GET api/values
+        [HttpGet]
+        public ActionResult<IEnumerable<string>> Get()
+        {
+            return new string[] { "value1", "value2" };
+        }
+
+        // GET api/values/5
+        [HttpGet("{id}")]
+        public ActionResult<string> Get(int id)
+        {
+            return "value";
+        }
+
+        // POST api/values
+        [HttpPost]
+        public void Post([FromBody] string value)
+        {
+        }
+
+        // PUT api/values/5
+        [HttpPut("{id}")]
+        public void Put(int id, [FromBody] string value)
+        {
+        }
+
+        // DELETE api/values/5
+        [HttpDelete("{id}")]
+        public void Delete(int id)
+        {
+        }
+    }
+}

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/Program.cs
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace WebApiSample.Api
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+}

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/Startup.cs
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/Startup.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using WebApiSample.DataAccess;
+using WebApiSample.DataAccess.Repositories;
+
+namespace WebApiSample.Api
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddScoped<ProductsRepository>();
+            services.AddDbContext<ProductContext>(opt =>
+                opt.UseInMemoryDatabase("ProductInventory"));
+
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+
+            #region snippet_ConfigureApiBehaviorOptions
+            services.Configure<ApiBehaviorOptions>(options =>
+            {
+                options.SuppressConsumesConstraintForFormFileParameters = true;
+                options.SuppressInferBindingSourcesForParameters = true;
+                options.SuppressModelStateInvalidFilter = true;
+            });
+            #endregion
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseHsts();
+            }
+
+            app.UseHttpsRedirection();
+            app.UseMvc();
+        }
+    }
+}

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/WebApiSample.Api.csproj
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/WebApiSample.Api.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-preview2-final" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0-preview2-final" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebApiSample.DataAccess\WebApiSample.DataAccess.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/appsettings.Development.json
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/appsettings.json
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.DataAccess/Models/Product.cs
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.DataAccess/Models/Product.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace WebApiSample.DataAccess.Models
+{
+    public class Product
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string Name { get; set; }
+
+        public string Description { get; set; }
+    }
+}

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.DataAccess/ProductContext.cs
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.DataAccess/ProductContext.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.EntityFrameworkCore;
+using WebApiSample.DataAccess.Models;
+
+namespace WebApiSample.DataAccess
+{
+    public class ProductContext : DbContext
+    {
+        public ProductContext(DbContextOptions<ProductContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Product> Products { get; set; }
+    }
+}

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.DataAccess/Repositories/ProductsRepository.cs
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.DataAccess/Repositories/ProductsRepository.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WebApiSample.DataAccess.Models;
+
+namespace WebApiSample.DataAccess.Repositories
+{
+    public class ProductsRepository
+    {
+        private readonly ProductContext _context;
+
+        public ProductsRepository(ProductContext context)
+        {
+            _context = context;
+
+            if (_context.Products.Count() == 0)
+            {
+                _context.Products.AddRange(
+                    new Product
+                    {
+                        Name = "Learning ASP.NET Core",
+                        Description = "A best-selling book covering the fundamentals of ASP.NET Core"
+                    },
+                    new Product
+                    {
+                        Name = "Learning EF Core",
+                        Description = "A best-selling book covering the fundamentals of Entity Framework Core"
+                    });
+                _context.SaveChanges();
+            }
+        }
+
+        public IEnumerable<Product> GetProducts()
+        {
+            return _context.Products.ToList();
+        }
+
+        public bool TryGetProduct(int id, out Product product)
+        {
+            product = _context.Products.Find(id);
+
+            return (product != null);
+        }
+
+        public async Task<int> AddProductAsync(Product product)
+        {
+            int rowsAffected = 0;
+
+            _context.Products.Add(product);
+            rowsAffected = await _context.SaveChangesAsync();
+
+            return rowsAffected;
+        }
+    }
+}

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.DataAccess/WebApiSample.DataAccess.csproj
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.DataAccess/WebApiSample.DataAccess.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.EntityFrameworkCore">
+      <HintPath>..\..\..\..\..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.entityframeworkcore\2.1.0-preview2-final\lib\netstandard2.0\Microsoft.EntityFrameworkCore.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Annotations">
+      <HintPath>..\..\..\..\..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.netcore.app\2.1.0-preview2-26406-04\ref\netcoreapp2.1\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Addresses https://github.com/aspnet/Docs/issues/5401

This is a new doc explaining the various ways to create a Web API controller. The ASP.NET Core 2.1 `[ApiController]` attribute is covered in it.