### PR TITLE
Add back the dest property for group1 in docfx.json

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -50,6 +50,7 @@
     "markdownEngineName": "markdig",
     "groups": {
       "group1": {
+        "dest": "group1-dest",
         "moniker_range": ">= aspnetcore-1.0"
       }
     }


### PR DESCRIPTION
Revert the removal of the group1 dest property, as it seemed to break nested links in the TOC.