### PR TITLE
Update index.md

### DIFF
--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -237,7 +237,7 @@ Middleware components can resolve their dependencies from dependency injection t
 
 Because middleware is constructed at app startup, not per-request, *scoped* lifetime services used by middleware constructors are not  shared with other dependency-injected types during each request. If you must share a *scoped* service between your middleware and other types, add these services to the `Invoke` method's signature. The `Invoke` method can accept additional parameters that are populated by dependency injection. For example:
 
-```c#
+```csharp
 public class MyMiddleware
 {
     private readonly RequestDelegate _next;


### PR DESCRIPTION
Updated myMiddleware index.md to use the code syntax highlight.

Noticed that on the asp.net page one code block wasnt highlighting (line 240). 

![image](https://user-images.githubusercontent.com/5913008/39105202-8fb2bfaa-4682-11e8-8e2c-6bbed25db611.png)

Noticed that the other blocks were using the keyword csharp instead of c# (example of line 122)

![image](https://user-images.githubusercontent.com/5913008/39105212-a3ddca6a-4682-11e8-979f-7798881a2c86.png)
