### PR TITLE
Update sample9.cs

### DIFF
--- a/aspnet/web-api/overview/formats-and-model-binding/parameter-binding-in-aspnet-web-api/samples/sample9.cs
+++ b/aspnet/web-api/overview/formats-and-model-binding/parameter-binding-in-aspnet-web-api/samples/sample9.cs
@@ -41,7 +41,7 @@ public class GeoPointModelBinder : IModelBinder
         }
 
         bindingContext.ModelState.AddModelError(
-            bindingContext.ModelName, "Cannot convert value to Location");
+            bindingContext.ModelName, "Cannot convert value to GeoPoint");
         return false;
     }
 }


### PR DESCRIPTION
Updated model error to correctly name 'GeoPoint' opposed to 'location'.
