### PR TITLE
Update razor-pages-convention-features.md

### DIFF
--- a/aspnetcore/mvc/razor-pages/razor-pages-convention-features.md
+++ b/aspnetcore/mvc/razor-pages/razor-pages-convention-features.md
@@ -69,7 +69,7 @@ The sample app adds a `{globalTemplate?}` route template to all of the pages in 
 [!code-csharp[](razor-pages-convention-features/sample/Conventions/GlobalTemplatePageRouteModelConvention.cs?name=snippet1)]
 
 > [!NOTE]
-> The `Order` property for the `AttributeRouteModel` is set to `-1`. This ensures that this template is given priority for the first route data value position when a single route value is provided and also that it would have priority over automatically generated Razor Pages routes. For example, the sample adds an `{aboutTemplate?}` route template later in the topic. The `{aboutTemplate?}` template is given an `Order` of `1`. When the About page is requested at `/About/RouteDataValue`, "RouteDataValue" is loaded into `RouteData.Values["globalTemplate"]` (`Order = -1`) and not `RouteData.Values["aboutTemplate"]` (`Order = 1`) due to setting the `Order` property.
+> The order of the routes is determined by the order of the routes in the template variable. The `Order` property for the `AttributeRouteModel` is set to `-1`. This ensures that this template is given priority for the first route data value position when a single route value is provided over a conflicting template with a single route vale and also that it would have priority over automatically generated Razor Pages routes. For example, the sample adds an `{aboutTemplate?}` route template later in the topic. The `{aboutTemplate?}` template is given an `Order` of `1`. When the About page is requested at `/About/RouteDataValue`, "RouteDataValue" is loaded into `RouteData.Values["globalTemplate"]` (`Order = -1`) and not `RouteData.Values["aboutTemplate"]` (`Order = 1`) due to setting the `Order` property.
 
 Razor Pages options, such as adding [Conventions](/dotnet/api/microsoft.aspnetcore.mvc.razorpages.razorpagesoptions.conventions), are added when MVC is added to the service collection in `Startup.ConfigureServices`. For an example, see the [sample app](https://github.com/aspnet/Docs/tree/master/aspnetcore/mvc/razor-pages/razor-pages-convention-features/sample/).
 
@@ -139,7 +139,7 @@ The sample app uses `AddFolderRouteModelConvention` to add an `{otherPagesTempla
 [!code-csharp[](razor-pages-convention-features/sample/Startup.cs?name=snippet3)]
 
 > [!NOTE]
-> The `Order` property for the `AttributeRouteModel` is set to `1`. This ensures that the template for `{globalTemplate?}` (set earlier in the topic) is given priority for the first route data value position when a single route value is provided. If the Page1 page is requested at `/OtherPages/Page1/RouteDataValue`, "RouteDataValue" is loaded into `RouteData.Values["globalTemplate"]` (`Order = -1`) and not `RouteData.Values["otherPagesTemplate"]` (`Order = 1`) due to setting the `Order` property.
+> The order that the routes ({globalTemplate?} followed by {otherPagesTemplate?}) was determined by the order that the templates were added to the model.Selectors AttributeRouteModel template because no conflict of equally specific templates ocurred. 
 
 Request the sample's Page1 page at `localhost:5000/OtherPages/Page1/GlobalRouteValue/OtherPagesRouteValue` and inspect the result:
 


### PR DESCRIPTION
Two bugs: 
1)Navigate to the sample app localhost:5000/TheContactPage
The index page is loaded instead of localhost:5000/Contact when the optional route is left off with the TheContact. I stepped through the call stack starting from the loading of RazorPages from the pages directory and haven't found the point where the index is loaded yet so I don't know if this is a doc or core bug. 

2)Navigate to the sample app localhost:5000/TheContactPage/TextValue
Mouse over the links in the top and you will see that every link has been replaced with the TheContactPage appended to every link.

3) A confusing point in the article: The notes all indicate that the order property determines which route comes first {globalTemplate?} vs {aboutTemplate?}. This wording makes it seem like the order of directories /GlobalRouteValue/OtherPagesRouteValue was determined by this number but stepping through the sourcelink provided .NET CORE source code shows that the order of the route order is determined by the order that options.Conventions.Add are called in the startup. This is because the model.Selectors.Add in the sample adds a new selector attribute route model template on top of the one that already exists. So each route added creates a route plus the old ie 1,2, 1/2, 3, 1/3, 1/2/3, 1/4, 2/4, etc... The example happened to create a conflict by appending templates rather than adding a new template and the selection of the template when one value is provided then gets resolved between {globalTemplate?} vs {aboutTemplate?}  using the order. I think you could make this clear just by adding one line at the top note saying the order of routes is determined by the template. You can see an example by switching the call order in startup between snippets 1 and 3  `options.Conventions.AddFolderRouteModelConvention("/OtherPages"` and `options.Conventions.Add(new GlobalTemplatePageRouteModelConvention()` and then navigating to localhost:5000/OtherPages/Page1/GlobalRouteValue/OtherPagesRouteValue and observe that the html now displays 
"Route data for 'globalTemplate' was provided: OtherPagesRouteValue
Route data for 'otherPagesTemplate' was provided: GlobalRouteValue" 
in contradiction with the note stating that the order property decided the route order "The Order property for the AttributeRouteModel is set to 1. This ensures that the template for {globalTemplate?} (set earlier in the topic) is given priority for the first route data value position". Here there was no conflict between equally specific routes and was determined by the calls to the order.

