### PR TITLE
Add step for vscode to signalr get started doc

### DIFF
--- a/aspnetcore/signalr/get-started.md
+++ b/aspnetcore/signalr/get-started.md
@@ -88,6 +88,8 @@ Visual Studio includes the `Microsoft.AspNetCore.SignalR` package containing its
       npm install @aspnet/signalr
     ```
 
+3. Copy the *signalr.js* file from *node_modules\\@aspnet\signalr\dist\browser* to the *lib* folder in your project.
+
 -----
 
 ## Create the SignalR Hub


### PR DESCRIPTION
Resolves: [Signalr.js not found](https://stackoverflow.com/q/50053462/8601760)