### PR TITLE
Update platform-specific-configuration.md

### DIFF
--- a/aspnetcore/host-and-deploy/platform-specific-configuration.md
+++ b/aspnetcore/host-and-deploy/platform-specific-configuration.md
@@ -1,8 +1,9 @@
 ---
-title: Add app features with a platform-specific configuration in ASP.NET Core
+title: Add app features with a platform-specific configuration in ASP.NET Core with IHostingStartup
 author: guardrex
 description: Discover how to add features to an ASP.NET Core app from an external assembly using an IHostingStartup implementation.
 manager: wpickett
+monikerRange: '>= aspnetcore-2.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 12/07/2017


### PR DESCRIPTION
Would be nice to get `IHostingStartup` in the title.

This is how Identity is added by the scaffolder. I think update the doc to mention that. It's an easy way to see this in action for 2.1+