### PR TITLE
Add 2.1 preview notice to Web API tutorials

### DIFF
--- a/aspnetcore/tutorials/first-web-api-mac.md
+++ b/aspnetcore/tutorials/first-web-api-mac.md
@@ -16,6 +16,10 @@ uid: tutorials/first-web-api-mac
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT) and [Mike Wasson](https://github.com/mikewasson)
 
+::: moniker range="= aspnetcore-2.1"
+[!INCLUDE[](~/includes/2.1.md)]
+::: moniker-end
+
 In this tutorial, build a web API for managing a list of "to-do" items. The UI isn't constructed.
 
 There are three versions of this tutorial:

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -15,6 +15,10 @@ uid: tutorials/first-web-api
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT) and [Mike Wasson](https://github.com/mikewasson)
 
+::: moniker range="= aspnetcore-2.1"
+[!INCLUDE[](~/includes/2.1.md)]
+::: moniker-end
+
 This tutorial builds a web API for managing a list of "to-do" items. A user interface (UI) isn't created.
 
 There are three versions of this tutorial:

--- a/aspnetcore/tutorials/web-api-vsc.md
+++ b/aspnetcore/tutorials/web-api-vsc.md
@@ -15,6 +15,10 @@ uid: tutorials/web-api-vsc
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT) and [Mike Wasson](https://github.com/mikewasson)
 
+::: moniker range="= aspnetcore-2.1"
+[!INCLUDE[](~/includes/2.1.md)]
+::: moniker-end
+
 In this tutorial, build a web API for managing a list of "to-do" items. A UI isn't constructed.
 
 There are three versions of this tutorial:


### PR DESCRIPTION
Add the ASP.NET Core 2.1 Preview banner to the top of each Web API tutorial (only when v2.1 is selected). This makes it even clearer to the reader that v2.1 is selected in the version selector.

**Internal Preview Pages**
* [VS Code](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/web-api-vsc?view=aspnetcore-2.1&branch=pr-en-us-6156)
* [VS for Mac](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/first-web-api-mac?view=aspnetcore-2.1&branch=pr-en-us-6156)
* [VS](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/first-web-api?view=aspnetcore-2.1&branch=pr-en-us-6156)