### PR TITLE
Update authoring.md

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/authoring.md
+++ b/aspnetcore/mvc/views/tag-helpers/authoring.md
@@ -89,8 +89,6 @@ To add a tag helper to a view using a FQN, you first add the FQN (`AuthoringTagH
 
 4. Run the app and use your favorite browser to view the HTML source so you can verify that the email tags are replaced with anchor markup (For example, `<a>Support</a>`). *Support* and *Marketing* are rendered as a links, but they don't have an `href` attribute to make them functional. We'll fix that in the next section.
 
-Note: Like HTML tags and attributes, tags, class names and attributes in Razor are **not** case-sensitive.
-
 ## SetAttribute and SetContent
 
 In this section, we'll update the `EmailTagHelper` so that it will create a valid anchor tag for email. We'll update it to take information from a Razor view (in the form of a `mail-to` attribute) and use that in generating the anchor.

--- a/aspnetcore/mvc/views/tag-helpers/authoring.md
+++ b/aspnetcore/mvc/views/tag-helpers/authoring.md
@@ -89,7 +89,7 @@ To add a tag helper to a view using a FQN, you first add the FQN (`AuthoringTagH
 
 4. Run the app and use your favorite browser to view the HTML source so you can verify that the email tags are replaced with anchor markup (For example, `<a>Support</a>`). *Support* and *Marketing* are rendered as a links, but they don't have an `href` attribute to make them functional. We'll fix that in the next section.
 
-Note: Like HTML tags and attributes, tags, class names and attributes in Razor, and C# are not case-sensitive.
+Note: Like HTML tags and attributes, tags, class names and attributes in Razor are **not** case-sensitive.
 
 ## SetAttribute and SetContent
 


### PR DESCRIPTION
It sounds like we were saying C# class names are not case-sensitive.

See #6144
