### PR TITLE
IAuthorizationPolicyProvider documentation

### DIFF
--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -32,7 +32,7 @@ The `IAuthorizationPolicyProvider` interface contains two APIs. `GetPolicyAsync(
 
 ## Parameterized Authorize Attribute Example
 
-One scenario where `IAuthorizationPolicyProvider` is useful is enabling custom `[Authorize]` attributes whose requirements depend on a parameter. For example, in [policy-based authorization](xref:security/authorization/policies) documentation, an age-based (“AtLeast21”) policy was used as a sample. If different controller actions in an application should be made available to users of *different* ages, though, it might be useful to have many different age-based policies. An alternative to registering all the different age-based policies that the application will need would be to generate the policies dynamically with a custom `IAuthorizationPolicyProvider` and annotate actions with an authorization attribute like `[MinimumAgeAuthorize(20)]`.
+One scenario where `IAuthorizationPolicyProvider` is useful is enabling custom `[Authorize]` attributes whose requirements depend on a parameter. For example, in [policy-based authorization](xref:security/authorization/policies) documentation, an age-based (“AtLeast21”) policy was used as a sample. If different controller actions in an application should be made available to users of *different* ages, though, it might be useful to have many different age-based policies. Instead of registering all the different age-based policies that the application will need individually, you can generate the policies dynamically with a custom `IAuthorizationPolicyProvider` and annotate actions with an authorization attribute like `[MinimumAgeAuthorize(20)]`.
 
 ## Custom Authorization Attributes
 
@@ -65,7 +65,7 @@ internal class MinimumAgeAuthorizeAttribute : AuthorizeAttribute
 }
 ```
 
-This attribute type has a `Policy` string based on the hard-coded prefix (`"MinimumAge"`) and the integer passed in via the constructor.
+This attribute type has a `Policy` string based on the hard-coded prefix (`"MinimumAge"`) and an integer passed in via the constructor.
 
 You can apply it to actions in the same way as other `Authorize` attributes except that it takes an integer as a parameter.
 
@@ -125,9 +125,9 @@ As with all aspects of custom `IAuthorizationPolicyProvider`s, though, you can c
 
 ## Using a Custom IAuthorizationPolicyProvider
 
-A custom `IAuthorizationPolicyProvider` allows extensibility in how ASP.NET Core applications find authorization policies for given policy names. As with other policy-based authorization scenarios, the policies returned from a custom `IAuthorizationPolicyProvider` will need to have requirements (likely using custom `IAuthorizationRequirement`s). If you use `IAuthorizationRequirement`s, then you will need to register appropriate `AuthorizationHandler`s with dependency injection as always (and as described in [policy-based authorization](xref:security/authorization/policies#authorization-handlers) documentation).
+A custom `IAuthorizationPolicyProvider` allows extensibility in how ASP.NET Core applications find authorization policies for given policy names. As with other policy-based authorization scenarios, the policies returned from a custom `IAuthorizationPolicyProvider` will need to have requirements and you will need to register appropriate `AuthorizationHandler`s with dependency injection (as described in [policy-based authorization](xref:security/authorization/policies#authorization-handlers) documentation).
 
-Custom `IAuthorizationPolicyProvider` types must be registered in the application's dependency injection service collection (in `Startup.ConfigureServices`), as well, to replace the default policy provider.
+You also need to register custom `IAuthorizationPolicyProvider` types in the application's dependency injection service collection (in `Startup.ConfigureServices`) to replace the default policy provider.
 
 ```CSharp
 services.AddTransient<IAuthorizationPolicyProvider, MinimumAgePolicyProvider>();

--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -19,8 +19,9 @@ Typically when using [policy-based authorization](xref:security/authorization/po
 
 Examples of scenarios where a custom [IAuthorizationPolicyProvider](/dotnet/api/microsoft.aspnetcore.authorization.iauthorizationpolicyprovider) may be useful include:
 
-* Creating policies at runtime based on information in an external data source (like a database) or determining authorization requirements dynamically through another mechanism.
+* Using an external service to provide policy evaluation.
 * Using a large range of policies (for different room numbers or ages, for example), so it doesn’t make sense to add each individual authorization policy with an `AuthorizationOptions.AddPolicy` call.
+* Creating policies at runtime based on information in an external data source (like a database) or determining authorization requirements dynamically through another mechanism.
 
 ## Customizing policy retrieval
 

--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -15,12 +15,12 @@ uid: security/authorization/iauthorizationpolicyprovider
 
 By [Mike Rousos](https://github.com/mjrousos)
 
-Typically when using [policy-based authorization](xref:security/authorization/policies), policies are registered by calling `AuthorizationOptions.AddPolicy` as part of authorization service configuration. In some scenarios, though, it may not be possible (or desirable) to register all authorization policies in this way. In those cases, you can use a custom `IAuthorizationPolicyProvider` to fully control how authorization policies are supplied.
+Typically when using [policy-based authorization](xref:security/authorization/policies), policies are registered by calling `AuthorizationOptions.AddPolicy` as part of authorization service configuration. In some scenarios, it may not be possible (or desirable) to register all authorization policies in this way. In those cases, you can use a custom `IAuthorizationPolicyProvider` to fully control how authorization policies are supplied.
 
 Examples of scenarios where a custom `IAuthorizationPolicyProvider` may be useful include:
 
-* Creating policies at runtime based on information in an external data source (like a database) or determining authorization requirements dynamically through some other mechanism
-* Using a large range of policies (for different room numbers or ages, for example), so it doesn’t make sense to add each individual authorization policy with an `AuthorizationOptions.AddPolicy` call
+* Creating policies at runtime based on information in an external data source (like a database) or determining authorization requirements dynamically through some other mechanism.
+* Using a large range of policies (for different room numbers or ages, for example), so it doesn’t make sense to add each individual authorization policy with an `AuthorizationOptions.AddPolicy` call.
 
 ## Customizing Policy Retrieval
 

--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -37,11 +37,11 @@ By implementing these two APIs, you can customize how authorization policies are
 
 ## Parameterized authorize attribute example
 
-One scenario where `IAuthorizationPolicyProvider` is useful is enabling custom `[Authorize]` attributes whose requirements depend on a parameter. For example, in [policy-based authorization](xref:security/authorization/policies) documentation, an age-based (“AtLeast21”) policy was used as a sample. If different controller actions in an app should be made available to users of *different* ages, it might be useful to have many different age-based policies. Instead of registering all the different age-based policies that the application will need individually, you can generate the policies dynamically with a custom `IAuthorizationPolicyProvider` and annotate actions with an authorization attribute like `[MinimumAgeAuthorize(20)]`.
+One scenario where `IAuthorizationPolicyProvider` is useful is enabling custom `[Authorize]` attributes whose requirements depend on a parameter. For example, in [policy-based authorization](xref:security/authorization/policies) documentation, an age-based (“AtLeast21”) policy was used as a sample. If different controller actions in an app should be made available to users of *different* ages, it might be useful to have many different age-based policies. Instead of registering all the different age-based policies that the application will need in `AuthorizationOptions`, you can generate the policies dynamically with a custom `IAuthorizationPolicyProvider`. To make using the policies easier, you can annotate actions with custom authorization attribute like `[MinimumAgeAuthorize(20)]`.
 
 ## Custom Authorization Attributes
 
-Authorization policies are always identified by their names, so the custom `MinimumAgeAuthorizeAttribute` described previously needs to map incoming parameters into a string that can be used to retrieve the corresponding authorization policy. You can do this by deriving from `AuthorizeAttribute` and making the `Age` property wrap the
+Authorization policies are identified by their names. The custom `MinimumAgeAuthorizeAttribute` described previously needs to map arguments into a string that can be used to retrieve the corresponding authorization policy. You can do this by deriving from `AuthorizeAttribute` and making the `Age` property wrap the
 `AuthorizeAttribute.Policy` property.
 
 ```CSharp
@@ -117,7 +117,10 @@ internal class MinimumAgePolicyProvider : IAuthorizationPolicyProvider
 
 When using custom `IAuthorizationPolicyProvider` implementations, keep in mind that ASP.NET Core only uses one instance of `IAuthorizationPolicyProvider`. If a custom provider isn't able to provide authorization policies for all policy names, it should fall back to a backup provider. Policy names might include those that come from a default policy for `[Authorize]` attributes without a name.
 
-For example, if an application needed both custom age policies (as demonstrated previously) and more traditional role-based policy retrieval, it could use a custom authorization policy provider that attempts to parse policy names first and then calls into a different policy provider (like `DefaultAuthorizationPolicyProvider`) if the policy name doesn't contain an age.
+For example, consider an application needed both custom age policies and more traditional role-based policy retrieval. Such an app could use a custom authorization policy provider that:
+
+* Attempts to parse policy names. 
+* Calls into a different policy provider (like `DefaultAuthorizationPolicyProvider`) if the policy name doesn't contain an age.
 
 ## Default policy
 
@@ -130,7 +133,7 @@ public Task<AuthorizationPolicy> GetDefaultPolicyAsync() =>
     Task.FromResult(new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build());
 ```
 
-As with all aspects of custom `IAuthorizationPolicyProvider`s, though, you can customize this, as needed. In some cases:
+As with all aspects of a custom `IAuthorizationPolicyProvider`, you can customize this, as needed. In some cases:
 
 * Default authorization policies might not be used.
 * Retrieving the default policy can be delegated to a fallback `IAuthorizationPolicyProvider`.
@@ -139,7 +142,7 @@ As with all aspects of custom `IAuthorizationPolicyProvider`s, though, you can c
 
 To use custom policies from an `IAuthorizationPolicyProvider`, you must:
 
-* Register appropriate `AuthorizationHandler`s with dependency injection (described in [policy-based authorization](xref:security/authorization/policies#authorization-handlers)), as with all policy-based authorization scenarios.
+* Register the appropriate `AuthorizationHandler` types with dependency injection (described in [policy-based authorization](xref:security/authorization/policies#authorization-handlers)), as with all policy-based authorization scenarios.
 * Register the custom `IAuthorizationPolicyProvider` type in the app's dependency injection service collection (in `Startup.ConfigureServices`) to replace the default policy provider.
 
 ```CSharp

--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -15,18 +15,18 @@ uid: security/authorization/iauthorizationpolicyprovider
 
 By [Mike Rousos](https://github.com/mjrousos)
 
-Typically when using [policy-based authorization](xref:security/authorization/policies), policies are registered by calling `AuthorizationOptions.AddPolicy` as part of authorization service configuration. In some scenarios, though, it may not be possible (or desirable) to register all authorization policies in this way. In those cases, a custom `IAuthorizationPolicyProvider` can be used to fully control how authorization policies are supplied.
+Typically when using [policy-based authorization](xref:security/authorization/policies), policies are registered by calling `AuthorizationOptions.AddPolicy` as part of authorization service configuration. In some scenarios, though, it may not be possible (or desirable) to register all authorization policies in this way. In those cases, you can use a custom `IAuthorizationPolicyProvider` to fully control how authorization policies are supplied.
 
 Examples of scenarios where a custom `IAuthorizationPolicyProvider` may be useful include:
 
-* Policies are created at runtime based on information in an external data source (like a database) or authorization requirements are dynamically determined through some other mechanism
-* A range of policies are needed (for different room numbers or ages, for example), so it doesn’t make sense to add each individual authorization policy with an `AuthorizationOptions.AddPolicy` call
+* Creating policies at runtime based on information in an external data source (like a database) or determining authorization requirements dynamically through some other mechanism
+* Using a large range of policies (for different room numbers or ages, for example), so it doesn’t make sense to add each individual authorization policy with an `AuthorizationOptions.AddPolicy` call
 
 ## Customizing Policy Retrieval
 
-ASP.NET Core apps use an implementation of the `IAuthorizationPolicyProvider` interface to retrieve authorization policies. By default, an instance of `DefaultAuthorizationPolicyProvider` is registered and used. `DefaultAuthorizationPolicyProvider` returns policies from the `AuthorizationOptions` provided in an `IServiceCollection.AddAuthorization` call.
+ASP.NET Core apps use an implementation of the `IAuthorizationPolicyProvider` interface to retrieve authorization policies. By default, `DefaultAuthorizationPolicyProvider` is registered and used. `DefaultAuthorizationPolicyProvider` returns policies from the `AuthorizationOptions` provided in an `IServiceCollection.AddAuthorization` call.
 
-This behavior can be customized by registering a different `IAuthorizationPolicyProvider` implementation in the app’s dependency injection container. 
+You can customize this behavior by registering a different `IAuthorizationPolicyProvider` implementation in the app’s dependency injection container. 
 
 The `IAuthorizationPolicyProvider` interface contains two APIs. `GetPolicyAsync(string policyName)` returns an authorization policy for a given name and `GetDefaultPolicyAsync` returns the default authorization policy (the policy used for `[Authorize]` attributes without a policy specified). By implementing these two APIs, it’s possible to customize how authorization policies are provided.
 
@@ -36,8 +36,7 @@ One scenario where `IAuthorizationPolicyProvider` is useful is enabling custom `
 
 ## Custom Authorization Attributes
 
-Authorization policies are always identified by their names, so the custom `MinimumAgeAuthorizeAttribute` described previously needs to map incoming parameters into a string that can be used to retrieve the corresponding authorization policy. This can be 
-done by deriving from `AuthorizeAttribute` and making the `Age` property wrap 
+Authorization policies are always identified by their names, so the custom `MinimumAgeAuthorizeAttribute` described previously needs to map incoming parameters into a string that can be used to retrieve the corresponding authorization policy. You can do this by deriving from `AuthorizeAttribute` and making the `Age` property wrap 
 `AuthorizeAttribute`'s `Policy` property.
 
 ```CSharp
@@ -66,9 +65,9 @@ internal class MinimumAgeAuthorizeAttribute : AuthorizeAttribute
 }
 ```
 
-This attribute type will have a `Policy` string based on the hard-coded prefix (`"MinimumAge"`) and the integer passed in via the constructor.
+This attribute type has a `Policy` string based on the hard-coded prefix (`"MinimumAge"`) and the integer passed in via the constructor.
 
-It can be applied to actions in the same way as other `Authorize` attributes except that it will take an integer as a parameter.
+You can apply it to actions in the same way as other `Authorize` attributes except that it takes an integer as a parameter.
 
 ```CSharp
 [MinimumAgeAuthorize(10)]
@@ -115,18 +114,18 @@ For example, if a particular application needed both custom age policies (as dem
 
 In addition to providing named authorization policies, a custom `IAuthorizationPolicyProvider` also needs to implement `GetDefaultPolicyAsync` to provide an authorization policy for `[Authorize]` attributes without a policy name specified.
 
-In many cases, this authorization attribute only requires an authenticated user, so the necessary policy can be constructed simply:
+In many cases, this authorization attribute only requires an authenticated user, so you can make the necessary policy with a call to `RequireAuthenticatedUser`:
 
 ```CSharp
 public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => 
     Task.FromResult(new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build());
 ```
 
-As with all aspects of custom `IAuthorizationPolicyProvider`s, though, this can be customized, as needed. In some cases, default authorization policies might not be used or retrieving the default policy can be delegated to a fallback `IAuthorizationPolicyProvider`.
+As with all aspects of custom `IAuthorizationPolicyProvider`s, though, you can customize this, as needed. In some cases, default authorization policies might not be used or retrieving the default policy can be delegated to a fallback `IAuthorizationPolicyProvider`.
 
 ## Using a Custom IAuthorizationPolicyProvider
 
-A custom `IAuthorizationPolicyProvider` allows extensibility in how ASP.NET Core applications find authorization policies for given policy names. As with other policy-based authorization scenarios, the policies returned from a custom `IAuthorizationPolicyProvider` will need to have requirements (likely using custom `IAuthorizationRequirement`s). If `IAuthorizationRequirement`s are used, then appropriate `AuthorizationHandler`s will need to be registered with dependency injection as always (and as described in [policy-based authorization](xref:security/authorization/policies#authorization-handlers) documentation).
+A custom `IAuthorizationPolicyProvider` allows extensibility in how ASP.NET Core applications find authorization policies for given policy names. As with other policy-based authorization scenarios, the policies returned from a custom `IAuthorizationPolicyProvider` will need to have requirements (likely using custom `IAuthorizationRequirement`s). If you use `IAuthorizationRequirement`s, then you will need to register appropriate `AuthorizationHandler`s with dependency injection as always (and as described in [policy-based authorization](xref:security/authorization/policies#authorization-handlers) documentation).
 
 Custom `IAuthorizationPolicyProvider` types must be registered in the application's dependency injection service collection (in `Startup.ConfigureServices`), as well, to replace the default policy provider.
 

--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -15,7 +15,7 @@ uid: security/authorization/iauthorizationpolicyprovider
 
 By [Mike Rousos](https://github.com/mjrousos)
 
-Typically when using [policy-based authorization](https://docs.microsoft.com/aspnet/core/security/authorization/policies), policies are registered by calling `AuthorizationOptions.AddPolicy` as part of authorization service configuration. In some scenarios, though, it may not be possible (or desirable) to register all authorization policies in this way. In those cases, a custom `IAuthorizationPolicyProvider` can be used to fully control how authorization policies are supplied.
+Typically when using [policy-based authorization](xref:security/authorization/policies), policies are registered by calling `AuthorizationOptions.AddPolicy` as part of authorization service configuration. In some scenarios, though, it may not be possible (or desirable) to register all authorization policies in this way. In those cases, a custom `IAuthorizationPolicyProvider` can be used to fully control how authorization policies are supplied.
 
 Examples of scenarios where a custom `IAuthorizationPolicyProvider` may be useful include:
 
@@ -32,7 +32,7 @@ The `IAuthorizationPolicyProvider` interface contains two APIs. `GetPolicyAsync(
 
 ## Parameterized Authorize Attribute Example
 
-One scenario where `IAuthorizationPolicyProvider` is useful is enabling custom `[Authorize]` attributes whose requirements depend on a parameter. For example, in [policy-based authorization](https://docs.microsoft.com/aspnet/core/security/authorization/policies) documentation, an age-based (“AtLeast21”) policy was used as a sample. If different controller actions in an application should be made available to users of *different* ages, though, it might be useful to have many different age-based policies. An alternative to registering all the different age-based policies that the application will need would be to generate the policies dynamically with a custom `IAuthorizationPolicyProvider` and annotate actions with an authorization attribute like `[MinimumAgeAuthorize(20)]`.
+One scenario where `IAuthorizationPolicyProvider` is useful is enabling custom `[Authorize]` attributes whose requirements depend on a parameter. For example, in [policy-based authorization](xref:security/authorization/policies) documentation, an age-based (“AtLeast21”) policy was used as a sample. If different controller actions in an application should be made available to users of *different* ages, though, it might be useful to have many different age-based policies. An alternative to registering all the different age-based policies that the application will need would be to generate the policies dynamically with a custom `IAuthorizationPolicyProvider` and annotate actions with an authorization attribute like `[MinimumAgeAuthorize(20)]`.
 
 ## Custom Authorization Attributes
 
@@ -126,7 +126,7 @@ As with all aspects of custom `IAuthorizationPolicyProvider`s, though, this can 
 
 ## Using a Custom IAuthorizationPolicyProvider
 
-A custom `IAuthorizationPolicyProvider` allows extensibility in how ASP.NET Core applications find authorization policies for given policy names. As with other policy-based authorization scenarios, the policies returned from a custom `IAuthorizationPolicyProvider` will need to have requirements (likely using custom `IAuthorizationRequirement`s). If `IAuthorizationRequirement`s are used, then appropriate `AuthorizationHandler`s will need to be registered with dependency injection as always (and as described in [policy-based authorization](https://docs.microsoft.com/aspnet/core/security/authorization/policies#authorization-handlers) documentation).
+A custom `IAuthorizationPolicyProvider` allows extensibility in how ASP.NET Core applications find authorization policies for given policy names. As with other policy-based authorization scenarios, the policies returned from a custom `IAuthorizationPolicyProvider` will need to have requirements (likely using custom `IAuthorizationRequirement`s). If `IAuthorizationRequirement`s are used, then appropriate `AuthorizationHandler`s will need to be registered with dependency injection as always (and as described in [policy-based authorization](xref:security/authorization/policies#authorization-handlers) documentation).
 
 Custom `IAuthorizationPolicyProvider` types must be registered in the application's dependency injection service collection (in `Startup.ConfigureServices`), as well, to replace the default policy provider.
 

--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -1,0 +1,137 @@
+---
+title: Custom Authorization Policy Providers in ASP.NET Core
+author: mjrousos
+description: Learn how to use a custom IAuthorizationPolicyProvider in an ASP.NET Core app to dynamically generate authorization policies.
+manager: wpickett
+ms.author: riande
+ms.custom: mvc
+ms.date: 05/02/2018
+ms.prod: asp.net-core
+ms.technology: aspnet
+ms.topic: article
+uid: security/authorization/iauthorizationpolicyprovider
+---
+# IAuthorizationPolicyProvider
+
+By [Mike Rousos](https://github.com/mjrousos)
+
+Typically when using [policy-based authorization](https://docs.microsoft.com/aspnet/core/security/authorization/policies), policies are registered by calling `AuthorizationOptions.AddPolicy` as part of authorization service configuration. In some scenarios, though, it may not be possible (or desirable) to register all authorization policies in this way. In those cases, a custom `IAuthorizationPolicyProvider` can be used to fully control how authorization policies are supplied.
+
+Examples of scenarios where a custom `IAuthorizationPolicyProvider` may be useful include:
+
+* Policies are created at runtime based on information in an external data source (like a database) or authorization requirements are dynamically determined through some other mechanism
+* A range of policies are needed (for different room numbers or ages, for example), so it doesn’t make sense to add each individual authorization policy with an `AuthorizationOptions.AddPolicy` call
+
+## Customizing Policy Retrieval
+
+ASP.NET Core apps use an implementation of the `IAuthorizationPolicyProvider` interface to retrieve authorization policies. By default, an instance of `DefaultAuthorizationPolicyProvider` is registered and used. `DefaultAuthorizationPolicyProvider` returns policies from the `AuthorizationOptions` provided in an `IServiceCollection.AddAuthorization` call.
+
+This behavior can be customized by registering a different `IAuthorizationPolicyProvider` implementation in the app’s dependency injection container. 
+
+The `IAuthorizationPolicyProvider` interface contains two APIs. `GetPolicyAsync(string policyName)` returns an authorization policy for a given name and `GetDefaultPolicyAsync` returns the default authorization policy (the policy used for `[Authorize]` attributes without a policy specified). By implementing these two APIs, it’s possible to customize how authorization policies are provided.
+
+## Parameterized Authorize Attribute Example
+
+One scenario where `IAuthorizationPolicyProvider` is useful is enabling custom `[Authorize]` attributes whose requirements depend on a parameter. For example, in [policy-based authorization](https://docs.microsoft.com/aspnet/core/security/authorization/policies) documentation, an age-based (“AtLeast21”) policy was used as a sample. If different controller actions in an application should be made available to users of *different* ages, though, it might be useful to have many different age-based policies. An alternative to registering all the different age-based policies that the application will need would be to generate the policies dynamically with a custom `IAuthorizationPolicyProvider` and annotate actions with an authorization attribute like `[MinimumAgeAuthorize(20)]`.
+
+## Custom Authorization Attributes
+
+Authorization policies are always identified by their names, so the custom `MinimumAgeAuthorizeAttribute` described previously needs to map incoming parameters into a string that can be used to retrieve the corresponding authorization policy. This can be 
+done by deriving from `AuthorizeAttribute` and making the `Age` property wrap 
+`AuthorizeAttribute`'s `Policy` property.
+
+```CSharp
+internal class MinimumAgeAuthorizeAttribute : AuthorizeAttribute
+{
+    const string POLICY_PREFIX = "MinimumAge";
+
+    public MinimumAgeAuthorizeAttribute(int age) => Age = age;
+
+    // Get or set the Age property by manipulating the underlying Policy property
+    public int Age
+    {
+        get
+        {
+            if (int.TryParse(Policy.Substring(POLICY_PREFIX.Length), out var age))
+            {
+                return age;
+            }
+            return default(int);
+        }
+        set
+        {
+            Policy = $"{POLICY_PREFIX}{value.ToString()}";
+        }
+    }
+}
+```
+
+This attribute type will have a `Policy` string based on the hard-coded prefix (`"MinimumAge"`) and the integer passed in via the constructor.
+
+It can be applied to actions in the same way as other `Authorize` attributes except that it will take an integer as a parameter.
+
+```CSharp
+[MinimumAgeAuthorize(10)]
+public IActionResult RequiresMinimumAge10()
+```
+
+## Custom IAuthorizationPolicyProvider
+
+The custom `MinimumAgeAuthorizeAttribute` makes it easy to request authorization policies for any minimum age desired. The next problem to solve is making sure that authorization policies are available for all of those different ages. This is where an `IAuthorizationPolicyProvider` is useful.
+
+When using `MinimumAgeAuthorizationAttribute`, the authorizaton policy names will follow the pattern `"MinimumAge" + Age`, so the custom `IAuthorizationPolicyProvider` should generate authorization policies by parsing apart the policy name. The policy provider should create `AuthorizationPolicy` objects (using `AuthorizationPolicyBuilder`) and populate them with appropriate authorization requirements (using `AddRequirements` or, perhaps, `RequireClaim`, `RequireRole`, or `RequireUserName`).
+
+```CSharp
+internal class MinimumAgePolicyProvider : IAuthorizationPolicyProvider
+{
+    const string POLICY_PREFIX = "MinimumAge";
+
+    // Policies are looked up by string name, so expect 'parameters' (like age)
+    // to be embedded in the policy names. This is abstracted away from developers
+    // by the more strongly-typed attributes derived from AuthorizeAttribute
+    // (like [MinimumAgeAuthorize()] in this sample)
+    public Task<AuthorizationPolicy> GetPolicyAsync(string policyName)
+    {
+        if (policyName.StartsWith(POLICY_PREFIX, StringComparison.OrdinalIgnoreCase) &&
+            int.TryParse(policyName.Substring(POLICY_PREFIX.Length), out var age))
+        {
+            var policy = new AuthorizationPolicyBuilder();
+            policy.AddRequirements(new MinimumAgeRequirement(age));
+            return Task.FromResult(policy.Build());
+        }
+
+        return Task.FromResult<AuthorizationPolicy>(null);
+    }
+}
+```
+
+## Multiple Authorization Policy Providers
+
+When using custom `IAuthorizationPolicyProvider` implementations, keep in mind that ASP.NET Core only uses one instance of `IAuthorizationPolicyProvider`. So if a custom provider isn't able to provide authorization policies for all policy names that will be used (including, potentially, a default policy for `[Authorize]` attributes without a name), it should fall back to a backup provider.
+
+For example, if a particular application needed both custom age policies (as demonstrated previously) and more traditional role-based policy retrieval, the custom `IAuthorizationPolicyProvider` could attempt to create policies for a given policy name (again, as shown above) and then call `GetPolicyAsync` on an instance of `DefaultAuthorizationPolicyProvider` if that fails (instead of returning null).
+
+## Default Policy
+
+In addition to providing named authorization policies, a custom `IAuthorizationPolicyProvider` also needs to implement `GetDefaultPolicyAsync` to provide an authorization policy for `[Authorize]` attributes without a policy name specified.
+
+In many cases, this authorization attribute only requires an authenticated user, so the necessary policy can be constructed simply:
+
+```CSharp
+public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => 
+    Task.FromResult(new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build());
+```
+
+As with all aspects of custom `IAuthorizationPolicyProvider`s, though, this can be customized, as needed. In some cases, default authorization policies might not be used or retrieving the default policy can be delegated to a fallback `IAuthorizationPolicyProvider`.
+
+## Using a Custom IAuthorizationPolicyProvider
+
+A custom `IAuthorizationPolicyProvider` allows extensibility in how ASP.NET Core applications find authorization policies for given policy names. As with other policy-based authorization scenarios, the policies returned from a custom `IAuthorizationPolicyProvider` will need to have requirements (likely using custom `IAuthorizationRequirement`s). If `IAuthorizationRequirement`s are used, then appropriate `AuthorizationHandler`s will need to be registered with dependency injection as always (and as described in [policy-based authorization](https://docs.microsoft.com/aspnet/core/security/authorization/policies#authorization-handlers) documentation).
+
+Custom `IAuthorizationPolicyProvider` types must be registered in the application's dependency injection service collection (in `Startup.ConfigureServices`), as well, to replace the default policy provider.
+
+```CSharp
+services.AddTransient<IAuthorizationPolicyProvider, MinimumAgePolicyProvider>();
+```
+
+A complete custom `IAuthorizationPolicyProvider` sample is available in the [aspnet/AuthSamples GitHub repository](https://github.com/aspnet/AuthSamples/tree/dev/samples/CustomPolicyProvider).

--- a/aspnetcore/security/authorization/index.md
+++ b/aspnetcore/security/authorization/index.md
@@ -28,6 +28,8 @@ uid: security/authorization/index
 
 * [Policy-based authorization](xref:security/authorization/policies)
 
+* [Custom authorization policy providers](xref:security/authorization/iauthorizationpolicyprovider)
+
 * [Dependency injection in requirement handlers](xref:security/authorization/dependencyinjection)
 
 * [Resource-based authorization](xref:security/authorization/resourcebased)


### PR DESCRIPTION
Adds a page to ASP.NET Core Security/Authorization docs covering how to use `IAuthorizationPolicyProvider` to dynamically generate authorization policies.

Fixes #6111 

`[rick edit]` [Review URL](https://review.docs.microsoft.com/en-us/aspnet/core/security/authorization/iauthorizationpolicyprovider?view=aspnetcore-1.0&branch=pr-en-us-6185)
