### PR TITLE
wrong api link

### DIFF
--- a/aspnetcore/fundamentals/configuration/options.md
+++ b/aspnetcore/fundamentals/configuration/options.md
@@ -172,7 +172,7 @@ Named options support with [IConfigureNamedOptions](/dotnet/api/microsoft.extens
 
 *Requires ASP.NET Core 2.0 or later.*
 
-*Named options* support allows the app to distinguish between named options configurations. In the sample app, named options are declared with the [ConfigureNamedOptions&lt;TOptions&gt;.Configure](/dotnet/api/microsoft.extensions.options.configurenamedoptions-1.configure) method:
+*Named options* support allows the app to distinguish between named options configurations. In the sample app, named options are declared with the [OptionsServiceCollectionExtensions.Configure&lt;TOptions&gt;(IServiceCollection, String, Action&lt;TOptions&gt;)](/dotnet/api/microsoft.extensions.dependencyinjection.optionsservicecollectionextensions.configure) which in turn calls the extension method [ConfigureNamedOptions&lt;TOptions&gt;.Configure](/dotnet/api/microsoft.extensions.options.configurenamedoptions-1.configure) method:
 
 [!code-csharp[](options/sample/Startup.cs?name=snippet_Example6)]
 


### PR DESCRIPTION
The extension method in the sample app is different from the linked api page. I was trying to figure something unrelated out, and got confused. Strangely, the same thing occurs in another above link (https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.options.iconfigureoptions-1) which is the wrong api but I didn't fix it because the autogenerated api doesn't have the correct extension method where it should [be] (https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.optionsservicecollectionextensions.configure?view=aspnetcore-2.0&viewFallbackFrom=aspnetcore-2.1#Microsoft_Extensions_DependencyInjection_OptionsServiceCollectionExtensions_Configure__1_Microsoft_Extensions_DependencyInjection_IServiceCollection_System_Action___0__)
