### PR TITLE
remove not for production

### DIFF
--- a/aspnetcore/fundamentals/http-requests.md
+++ b/aspnetcore/fundamentals/http-requests.md
@@ -16,8 +16,6 @@ uid: fundamentals/http-requests
 
 By [Glenn Condron](https://github.com/glennc), [Ryan Nowak](https://github.com/rynowak), and [Steve Gordon](https://github.com/stevejgordon)
 
-
-
 An `IHttpClientFactory` can be registered and used to configure and create [HttpClient](/dotnet/api/system.net.http.httpclient) instances in an app. It offers the following benefits:
 
 * Provides a central location for naming and configuring logical `HttpClient` instances. For example, a "github" client can be registered and configured to access GitHub. A default client can be registered for other purposes.

--- a/aspnetcore/fundamentals/http-requests.md
+++ b/aspnetcore/fundamentals/http-requests.md
@@ -16,7 +16,7 @@ uid: fundamentals/http-requests
 
 By [Glenn Condron](https://github.com/glennc), [Ryan Nowak](https://github.com/rynowak), and [Steve Gordon](https://github.com/stevejgordon)
 
-[!INCLUDE[](~/includes/2.1.md)]
+
 
 An `IHttpClientFactory` can be registered and used to configure and create [HttpClient](/dotnet/api/system.net.http.httpclient) instances in an app. It offers the following benefits:
 

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -191,8 +191,6 @@ var host = new WebHostBuilder()
 ```
 ::: moniker-end
 ::: moniker range=">= aspnetcore-2.1"
-
-
 By default, ASP.NET Core binds to:
 
 * `http://localhost:5000`

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -191,7 +191,7 @@ var host = new WebHostBuilder()
 ```
 ::: moniker-end
 ::: moniker range=">= aspnetcore-2.1"
-[!INCLUDE[](~/includes/2.1.md)]
+
 
 By default, ASP.NET Core binds to:
 

--- a/aspnetcore/includes/2.1.md
+++ b/aspnetcore/includes/2.1.md
@@ -1,2 +1,0 @@
-> [!NOTE]
-> ASP.NET Core 2.1 is in preview and not recommended for production use.

--- a/aspnetcore/mvc/razor-pages/razor-pages-conventions.md
+++ b/aspnetcore/mvc/razor-pages/razor-pages-conventions.md
@@ -100,7 +100,7 @@ Request the sample's About page at `localhost:5000/About` and inspect the header
 ::: moniker range=">= aspnetcore-2.1"
 **Add a handler model convention to all pages**
 
-[!INCLUDE[](~/includes/2.1.md)]
+
 
 Use [Conventions](/dotnet/api/microsoft.aspnetcore.mvc.razorpages.razorpagesoptions.conventions) to create and add an [IPageHandlerModelConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipagehandlermodelconvention) to the collection of [IPageConvention](/dotnet/api/microsoft.aspnetcore.mvc.applicationmodels.ipageconvention) instances that are applied during page handler model construction.
 

--- a/aspnetcore/mvc/razor-pages/sdk.md
+++ b/aspnetcore/mvc/razor-pages/sdk.md
@@ -15,7 +15,7 @@ uid: mvc/razor-pages/sdk
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
-[!INCLUDE[](~/includes/2.1.md)]
+
 
 The [!INCLUDE[](~/includes/2.1-SDK.md)] includes the `Microsoft.NET.Sdk.Razor` MSBuild SDK (Razor SDK). The Razor SDK:
 

--- a/aspnetcore/mvc/razor-pages/sdk.md
+++ b/aspnetcore/mvc/razor-pages/sdk.md
@@ -15,8 +15,6 @@ uid: mvc/razor-pages/sdk
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
-
-
 The [!INCLUDE[](~/includes/2.1-SDK.md)] includes the `Microsoft.NET.Sdk.Razor` MSBuild SDK (Razor SDK). The Razor SDK:
 
 * Standardizes the experience around building, packaging, and publishing projects containing [Razor](xref:mvc/views/razor) files for ASP.NET Core MVC-based projects.

--- a/aspnetcore/mvc/razor-pages/ui-class.md
+++ b/aspnetcore/mvc/razor-pages/ui-class.md
@@ -19,8 +19,6 @@ Razor views, pages, controllers, page models, and data models can be built into 
 
 This feature requires [!INCLUDE[](~/includes/2.1-SDK.md)]
 
-
-
 [View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/mvc/razor-pages/ui-class/samples) ([how to download](xref:tutorials/index#how-to-download-a-sample))
 
 ## Create a class library containing Razor UI

--- a/aspnetcore/mvc/razor-pages/ui-class.md
+++ b/aspnetcore/mvc/razor-pages/ui-class.md
@@ -19,7 +19,7 @@ Razor views, pages, controllers, page models, and data models can be built into 
 
 This feature requires [!INCLUDE[](~/includes/2.1-SDK.md)]
 
-[!INCLUDE[](~/includes/2.1.md)]
+
 
 [View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/mvc/razor-pages/ui-class/samples) ([how to download](xref:tutorials/index#how-to-download-a-sample))
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -30,7 +30,7 @@ This document shows how to:
 
 ::: moniker range=">= aspnetcore-2.1"
 
-[!INCLUDE[](~/includes/2.1.md)]
+
 
 We recommend all ASP.NET Core web apps call `UseHttpsRedirection` to redirect all HTTP requests to HTTPS. If `UseHsts` is called in the app, it must be called before `UseHttpsRedirection`.
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -29,9 +29,6 @@ This document shows how to:
 ## Require HTTPS
 
 ::: moniker range=">= aspnetcore-2.1"
-
-
-
 We recommend all ASP.NET Core web apps call `UseHttpsRedirection` to redirect all HTTP requests to HTTPS. If `UseHsts` is called in the app, it must be called before `UseHttpsRedirection`.
 
 The following code calls `UseHttpsRedirection` in the `Startup` class:

--- a/aspnetcore/tutorials/first-web-api-mac.md
+++ b/aspnetcore/tutorials/first-web-api-mac.md
@@ -16,10 +16,6 @@ uid: tutorials/first-web-api-mac
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT) and [Mike Wasson](https://github.com/mikewasson)
 
-::: moniker range="= aspnetcore-2.1"
-
-::: moniker-end
-
 In this tutorial, build a web API for managing a list of "to-do" items. The UI isn't constructed.
 
 There are three versions of this tutorial:

--- a/aspnetcore/tutorials/first-web-api-mac.md
+++ b/aspnetcore/tutorials/first-web-api-mac.md
@@ -17,7 +17,7 @@ uid: tutorials/first-web-api-mac
 By [Rick Anderson](https://twitter.com/RickAndMSFT) and [Mike Wasson](https://github.com/mikewasson)
 
 ::: moniker range="= aspnetcore-2.1"
-[!INCLUDE[](~/includes/2.1.md)]
+
 ::: moniker-end
 
 In this tutorial, build a web API for managing a list of "to-do" items. The UI isn't constructed.

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -16,7 +16,7 @@ uid: tutorials/first-web-api
 By [Rick Anderson](https://twitter.com/RickAndMSFT) and [Mike Wasson](https://github.com/mikewasson)
 
 ::: moniker range="= aspnetcore-2.1"
-[!INCLUDE[](~/includes/2.1.md)]
+
 ::: moniker-end
 
 This tutorial builds a web API for managing a list of "to-do" items. A user interface (UI) isn't created.

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -15,10 +15,6 @@ uid: tutorials/first-web-api
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT) and [Mike Wasson](https://github.com/mikewasson)
 
-::: moniker range="= aspnetcore-2.1"
-
-::: moniker-end
-
 This tutorial builds a web API for managing a list of "to-do" items. A user interface (UI) isn't created.
 
 There are three versions of this tutorial:

--- a/aspnetcore/tutorials/web-api-vsc.md
+++ b/aspnetcore/tutorials/web-api-vsc.md
@@ -16,7 +16,7 @@ uid: tutorials/web-api-vsc
 By [Rick Anderson](https://twitter.com/RickAndMSFT) and [Mike Wasson](https://github.com/mikewasson)
 
 ::: moniker range="= aspnetcore-2.1"
-[!INCLUDE[](~/includes/2.1.md)]
+
 ::: moniker-end
 
 In this tutorial, build a web API for managing a list of "to-do" items. A UI isn't constructed.

--- a/aspnetcore/tutorials/web-api-vsc.md
+++ b/aspnetcore/tutorials/web-api-vsc.md
@@ -15,10 +15,6 @@ uid: tutorials/web-api-vsc
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT) and [Mike Wasson](https://github.com/mikewasson)
 
-::: moniker range="= aspnetcore-2.1"
-
-::: moniker-end
-
 In this tutorial, build a web API for managing a list of "to-do" items. A UI isn't constructed.
 
 There are three versions of this tutorial:


### PR DESCRIPTION
2.1 RC1 has a run live licence
remove
-> [!NOTE]
-> ASP.NET Core 2.1 is in preview and not recommended for production use.