### PR TITLE
Code ref incorrect, use line 38 instead => services.AddSignalR();

### DIFF
--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -27,7 +27,7 @@ The SignalR Hubs API enables you to call methods on connected clients from the s
 
 The SignalR middleware requires some services, which are configured by calling `services.AddSignalR`.
 
-[!code-csharp[Configure service](hubs/sample/startup.cs?range=37)]
+[!code-csharp[Configure service](hubs/sample/startup.cs?range=38)]
 
 When adding SignalR functionality to an ASP.NET Core app, setup SignalR routes by calling `app.UseSignalR` in the `Startup.Configure` method.
 


### PR DESCRIPTION
Ref to the wrong line in the code example, required is

line 38 => services.AddSignalR();

https://github.com/aspnet/Docs/blob/master/aspnetcore/signalr/hubs.md

page

https://docs.microsoft.com/en-us/aspnet/core/signalr/hubs?view=aspnetcore-2.1

@rachelappel