### PR TITLE
Add Publish to Azure link to SignalR index page

### DIFF
--- a/aspnetcore/signalr/index.md
+++ b/aspnetcore/signalr/index.md
@@ -5,7 +5,7 @@ description: Discover topics that pertain to ASP.NET Core SignalR.
 manager: wpickett
 monikerRange: '>= aspnetcore-2.1'
 ms.author: rachelap
-ms.date: 04/20/2018
+ms.date: 05/09/2018
 ms.prod: asp.net-core
 ms.technology: aspnet
 ms.topic: article
@@ -13,8 +13,9 @@ uid: signalr/index
 ---
 # ASP.NET Core SignalR
 
-* [Get started](xref:signalr/get-started)
 * [Introduction](xref:signalr/introduction)
+* [Get started](xref:signalr/get-started)
 * [Hubs](xref:signalr/hubs)
 * [JavaScript client](xref:signalr/javascript-client)
+* [Publish to Azure](xref:signalr/publish-to-azure-web-app)
 * [Supported platforms](xref:signalr/supported-platforms)


### PR DESCRIPTION
The **Publish to Azure** link, which is present in the ToC, was missing from the index page.