### PR TITLE
How to trust ASP.NET Core dev cert on Win/MacOS

### DIFF
--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -124,7 +124,7 @@ dotnet new razor --no-https
 
 Install the [.NET Core SDK](https://www.microsoft.com/net/download/all). 
 
-The first time you create an ASP.NET Core project using `dotnet new`, the ASP.NET Core HTTPS development certificate will be installed, but not trusted. To trust the certificate on Windows or MacOS, run the following command:
+The first time you create an ASP.NET Core project using `dotnet new`, the ASP.NET Core HTTPS development certificate is installed, but not trusted. To trust the certificate on Windows or MacOS, run the following command:
 
 ```cli
 dotnet dev-certs https --trust

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -124,7 +124,7 @@ dotnet new razor --no-https
 
 Install the [.NET Core SDK](https://www.microsoft.com/net/download/all). 
 
-The first time you create a ASP.NET Core project, the ASP.NET Core HTTPS development certificate will be installed. The certificate is installed, but not trusted. To trust the certificate on Windows or MacOS, run the following command:
+The first time you create an ASP.NET Core project using `dotnet new`, the ASP.NET Core HTTPS development certificate will be installed, but not trusted. To trust the certificate on Windows or MacOS, run the following command:
 
 ```cli
 dotnet dev-certs https --trust

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -119,9 +119,19 @@ dotnet new razor --no-https
 
 ------
 
-::: moniker-end
+<a name="cert"></a>
+## Install and trust the ASP.NET Core HTTPS development certificate
 
-::: moniker range=">= aspnetcore-2.1"
+Install the [.NET Core SDK](https://www.microsoft.com/net/download/all). 
+
+The first time you create a ASP.NET Core project, the ASP.NET Core HTTPS development certificate will be installed. The certificate is installed, but not trusted. To trust the certificate on Windows or MacOS, run the following command:
+
+```cli
+dotnet dev-certs https --trust
+```
+
+To establishing trust on other platforms, refer to the platform specific documentation.
+
 ## How to setup a developer certificate for Docker
 
 See [this GitHub issue](https://github.com/aspnet/Docs/issues/6199).

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -130,7 +130,7 @@ The first time you create an ASP.NET Core project using `dotnet new`, the ASP.NE
 dotnet dev-certs https --trust
 ```
 
-To establish trust on other platforms, refer to the platform specific documentation.
+To establish trust on other platforms, refer to the platform specific documentation. Uninstalling the the NET Core SDK does not revoke the certificates trust.
 
 ## How to setup a developer certificate for Docker
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -130,7 +130,7 @@ The first time you create a ASP.NET Core project, the ASP.NET Core HTTPS develop
 dotnet dev-certs https --trust
 ```
 
-To establishing trust on other platforms, refer to the platform specific documentation.
+To establish trust on other platforms, refer to the platform specific documentation.
 
 ## How to setup a developer certificate for Docker
 


### PR DESCRIPTION
[Review URL](https://review.docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-2.1&branch=pr-en-us-6385&tabs=visual-studio#install-and-trust-the-aspnet-core-https-development-certificate)

Fixes #6383 and #5393
Here's the output after installing the SDK and creating an ASP.NET Core app:

ASP.NET Core
------------
Successfully installed the ASP.NET Core HTTPS Development Certificate.
To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.
Getting ready...
The template "ASP.NET Core Web App" was created successfully.

The fwlink 848054 points to this page. If you want a fwlink to the cert install/trust instructions, it's the same URL with `#cert`