### PR TITLE
Simplify 2.1 metapackage reference

### DIFF
--- a/aspnetcore/tutorials/first-web-api/samples/2.1/TodoApi/TodoApi.csproj
+++ b/aspnetcore/tutorials/first-web-api/samples/2.1/TodoApi/TodoApi.csproj
@@ -7,7 +7,7 @@
 
   <!-- <snippet_Metapackage> -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <!-- </snippet_Metapackage> -->
 


### PR DESCRIPTION
Remove the `Version` attribute from the ASP.NET Core 2.1 metapackage reference element. This is the sample app used by the 3 web API tutorials.