### PR TITLE
Those methods are not defined at the Hub class

### DIFF
--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -50,11 +50,6 @@ Each instance of the `Hub` class has a property named `Clients` that contains th
 | `All` | Calls a method on all connected clients |
 | `Caller` | Calls a method on the client that invoked the hub method |
 | `Others` | Calls a method on all connected clients except the client that invoked the method |
-
-Additionally, the `Hub` class contains the following methods:
-
-| Method | Description |
-| ------ | ----------- |
 | `AllExcept` | Calls a method on all connected clients except for the specified connections |
 | `Client` | Calls a method on a specific connected client |
 | `Clients` | Calls a method on specific connected clients |

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -50,6 +50,12 @@ Each instance of the `Hub` class has a property named `Clients` that contains th
 | `All` | Calls a method on all connected clients |
 | `Caller` | Calls a method on the client that invoked the hub method |
 | `Others` | Calls a method on all connected clients except the client that invoked the method |
+
+
+Additionally, `Hub.Clients` contains the following methods:
+
+| Method | Description |
+| ------ | ----------- |
 | `AllExcept` | Calls a method on all connected clients except for the specified connections |
 | `Client` | Calls a method on a specific connected client |
 | `Clients` | Calls a method on specific connected clients |


### PR DESCRIPTION
The methods below aren't defined at the `Hub` class but accessible through `Clients` property like the first three properties (`All`, `Caller`, `Others`) :

| `AllExcept` | Calls a method on all connected clients except for the specified connections |
| `Client` | Calls a method on a specific connected client |
| `Clients` | Calls a method on specific connected clients |
| `Group` | Sends a message to all connections in the specified group  |
| `GroupExcept` | Sends a message to all connections in the specified group, except the specified connections |
| `Groups` | Sends a message to multiple groups of connections  |
| `OthersInGroup` | Sends a message to a group of connections, excluding the client that invoked the hub method  |
| `User` | Sends a message to all connections associated with a specific user |
| `Users` | Sends a message to all connections associated with the specified users |

So I think it might be good to move all those methods descriptions to the first table which just talk about `Clients` property.