### PR TITLE
Minor changes in Get Started guide for SignalR

### DIFF
--- a/aspnetcore/signalr/get-started.md
+++ b/aspnetcore/signalr/get-started.md
@@ -126,9 +126,9 @@ The SignalR server must be configured so that it knows to pass requests to Signa
 
    `services.AddSignalR` adds SignalR as part of the [middleware](xref:fundamentals/middleware/index) pipeline.
 
-2. Before you can use the code sample shown in the Startup.cs file, you will also need to add the BrowserLink package via Nuget. Simply right-click on your project in Solution Explorer, and click Manage NuGet Packages to browse for and install the package named "Microsoft.VisualStudio.Web.BrowserLink".
+1. To use the sample, BrowserLink is required. Add the BrowserLink package with NuGet by right-clicking on the project in **Solution Explorer** > **Manage NuGet Packages**. Browse to and install the package named `Microsoft.VisualStudio.Web.BrowserLink`.
 
-3. Configure routes to your hubs using `UseSignalR`.
+1. Configure routes to your hubs using `UseSignalR`.
 
 
    [!code-csharp[Startup](get-started/sample/Startup.cs?highlight=37,57-60)]

--- a/aspnetcore/signalr/get-started.md
+++ b/aspnetcore/signalr/get-started.md
@@ -126,7 +126,7 @@ The SignalR server must be configured so that it knows to pass requests to Signa
 
    `services.AddSignalR` adds SignalR as part of the [middleware](xref:fundamentals/middleware/index) pipeline.
 
-1. Add the BrowserLink package with NuGet by right-clicking on the project in **Solution Explorer** > **Manage NuGet Packages**. Browse to and install the package named `Microsoft.VisualStudio.Web.BrowserLink`.
+1. Add the BrowserLink package with NuGet by right-clicking on the project in **Solution Explorer** > **Manage NuGet Packages**. Browse to and install the `Microsoft.VisualStudio.Web.BrowserLink` package.
 
 1. Configure routes to your hubs using `UseSignalR`.
 

--- a/aspnetcore/signalr/get-started.md
+++ b/aspnetcore/signalr/get-started.md
@@ -69,7 +69,7 @@ Visual Studio includes the `Microsoft.AspNetCore.SignalR` package containing its
     npm install @aspnet/signalr
     ```     
 
-4. Copy the *signalr.js* file from *node_modules\\@aspnet\signalr\dist\browser* to the *lib* folder in your project.
+4. Copy the *signalr.js* file from *node_modules\\@aspnet\signalr\dist\browser* to the *lib\signalr* folder in your project.
 
 # [Visual Studio Code](#tab/visual-studio-code/)
 
@@ -86,7 +86,7 @@ Visual Studio includes the `Microsoft.AspNetCore.SignalR` package containing its
     npm install @aspnet/signalr
     ```
 
-3. Copy the *signalr.js* file from *node_modules\\@aspnet\signalr\dist\browser* to the *lib* folder in your project.
+3. Copy the *signalr.js* file from *node_modules\\@aspnet\signalr\dist\browser* to the *lib\signalr* folder in your project.
 
 -----
 
@@ -126,7 +126,9 @@ The SignalR server must be configured so that it knows to pass requests to Signa
 
    `services.AddSignalR` adds SignalR as part of the [middleware](xref:fundamentals/middleware/index) pipeline.
 
-2. Configure routes to your hubs using `UseSignalR`.
+2. Before you can use the code sample shown in the Startup.cs file, you will also need to add the BrowserLink package via Nuget. Simply right-click on your project in Solution Explorer, and click Manage NuGet Packages to browse for and install the package named "Microsoft.VisualStudio.Web.BrowserLink".
+
+3. Configure routes to your hubs using `UseSignalR`.
 
 
    [!code-csharp[Startup](get-started/sample/Startup.cs?highlight=37,57-60)]

--- a/aspnetcore/signalr/get-started.md
+++ b/aspnetcore/signalr/get-started.md
@@ -126,7 +126,7 @@ The SignalR server must be configured so that it knows to pass requests to Signa
 
    `services.AddSignalR` adds SignalR as part of the [middleware](xref:fundamentals/middleware/index) pipeline.
 
-1. To use the sample, BrowserLink is required. Add the BrowserLink package with NuGet by right-clicking on the project in **Solution Explorer** > **Manage NuGet Packages**. Browse to and install the package named `Microsoft.VisualStudio.Web.BrowserLink`.
+1. Add the BrowserLink package with NuGet by right-clicking on the project in **Solution Explorer** > **Manage NuGet Packages**. Browse to and install the package named `Microsoft.VisualStudio.Web.BrowserLink`.
 
 1. Configure routes to your hubs using `UseSignalR`.
 


### PR DESCRIPTION
1. Following the instructions as is, the code app.UseBrowserLink() doesn’t compile in the Startup class. I had to add the BrowserLink package via NuGet to get the project to compile. (This package is included in the .csproj file in the Github sample, so only the doc needs to be updated for this.)

2. The “signalr.js” should be in a "signalr" subfolder, not directly in the "lib" folder, as it says in the docs. “Copy the signalr.js file from node_modules\@aspnet\signalr\dist\browser to the lib folder in your project.”
