### PR TITLE
Capitalize search string 'Ghost' in URL segment

### DIFF
--- a/aspnetcore/tutorials/razor-pages/search.md
+++ b/aspnetcore/tutorials/razor-pages/search.md
@@ -42,7 +42,7 @@ Navigate to the Movies page and append a query string such as `?searchString=Gho
 
 ![Index view](search/_static/ghost.png)
 
-If the following route template is added to the Index page, the search string can be passed as a URL segment (for example, `http://localhost:5000/Movies/ghost`).
+If the following route template is added to the Index page, the search string can be passed as a URL segment (for example, `http://localhost:5000/Movies/Ghost`).
 
 ```cshtml
 @page "{searchString?}"


### PR DESCRIPTION
Since the searching method in SQLite is case-sensative, the example should pass the search string in the correct case.