### PR TITLE
UE edit of Razor file compilation doc

### DIFF
--- a/aspnetcore/fundamentals/metapackage.md
+++ b/aspnetcore/fundamentals/metapackage.md
@@ -35,7 +35,7 @@ You can use the package trimming process to remove packages that you don't use. 
 
 The following *.csproj* file references the `Microsoft.AspNetCore.All` metapackage for ASP.NET Core:
 
-[!code-xml[](../mvc/views/view-compilation/sample/MvcRazorCompileOnPublish2.csproj?highlight=9)]
+[!code-xml[](metapackage/samples/Metapackage.All.Example.csproj?highlight=6)]
 
 <a name="migrate"></a>
 ## Migrating from Microsoft.AspNetCore.All to Microsoft.AspNetCore.App

--- a/aspnetcore/fundamentals/metapackage/samples/Metapackage.All.Example.csproj
+++ b/aspnetcore/fundamentals/metapackage/samples/Metapackage.All.Example.csproj
@@ -1,12 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <MvcRazorCompileOnPublish>true</MvcRazorCompileOnPublish>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
   </ItemGroup>
-
 </Project>

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -3,6 +3,7 @@ title: Razor file compilation and precompilation in ASP.NET Core
 author: rick-anderson
 description: Learn about the benefits of precompiling Razor files and how to accomplish Razor file precompilation in an ASP.NET Core app.
 manager: wpickett
+monikerRange: '>= aspnetcore-1.1'
 ms.author: riande
 ms.custom: mvc
 ms.date: 05/17/2018
@@ -15,7 +16,15 @@ uid: mvc/views/view-compilation
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
-A Razor file is compiled at runtime, when the associated Razor Page or view is invoked. ASP.NET Core 2.1 and later compile views at build and publish time using the [Razor SDK](xref:mvc/razor-pages/sdk). In ASP.NET Core 1.1 and ASP.NET Core 2.0, views can optionally be compiled at publish and deployed with the app&mdash;using the precompilation tool.
+::: moniker range="= aspnetcore-1.1"
+A Razor file is compiled at runtime, when the associated MVC view is invoked. Build-time Razor file publishing is unsupported. Razor files can optionally be compiled at publish time and deployed with the app&mdash;using the precompilation tool.
+::: moniker-end
+::: moniker range="= aspnetcore-2.0"
+A Razor file is compiled at runtime, when the associated Razor Page or MVC view is invoked. Build-time Razor file publishing is unsupported. Razor files can optionally be compiled at publish time and deployed with the app&mdash;using the precompilation tool.
+::: moniker-end
+::: moniker range=">= aspnetcore-2.1"
+A Razor file is compiled at runtime, when the associated Razor Page or MVC view is invoked. Razor files are compiled at both build and publish time using the [Razor SDK](xref:mvc/razor-pages/sdk).
+::: moniker-end
 
 ## Precompilation considerations
 
@@ -23,9 +32,9 @@ The following are side effects of precompiling Razor files:
 
 * A smaller published bundle
 * A faster startup time
-* You can't edit Razor files&mdash;the associated Razor Pages or views are absent from the published bundle.
+* You can't edit Razor files&mdash;the associated content is absent from the published bundle.
 
-## Deploy precompiled views
+## Deploy precompiled files
 
 ::: moniker range="= aspnetcore-2.1"
 Build- and publish-time compilation of Razor files is enabled by default by the Razor SDK. Editing Razor files after they're updated is supported at build time. By default, only the compiled *Views.dll* and no *.cshtml* files are deployed with your app.
@@ -40,10 +49,10 @@ If your project targets .NET Framework, install the [Microsoft.AspNetCore.Mvc.Ra
 
 If your project targets .NET Core, no changes are necessary.
 
-The ASP.NET Core 2.x project templates implicitly set `MvcRazorCompileOnPublish` to `true` by default, which means this node can be safely removed from the *.csproj* file.
+The ASP.NET Core 2.x project templates implicitly set `MvcRazorCompileOnPublish` to `true` by default. Consequently, this node can be safely removed from the *.csproj* file.
 
 > [!IMPORTANT]
-> Razor view precompilation is unavailable when performing a [self-contained deployment (SCD)](/dotnet/core/deploying/#self-contained-deployments-scd) in ASP.NET Core 2.0.
+> Razor file precompilation is unavailable when performing a [self-contained deployment (SCD)](/dotnet/core/deploying/#self-contained-deployments-scd) in ASP.NET Core 2.0.
 
 Prepare the app for a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd) with the [.NET Core CLI publish command](/dotnet/core/tools/dotnet-publish). For example, execute the following command at the project root:
 
@@ -63,4 +72,6 @@ Set the `MvcRazorCompileOnPublish` property to `true`, and install the [Microsof
 
 ## Additional resources
 
+* <xref:mvc/razor-pages/index>
 * <xref:mvc/razor-pages/sdk>
+* <xref:mvc/views/overview>

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -34,13 +34,9 @@ Build- and publish-time compilation of Razor files is enabled by default by the 
 > The Razor SDK is effective only when no precompilation-specific properties are set in the project file. For instance, setting the *.csproj* file's `MvcRazorCompileOnPublish` property to `true` disables the Razor SDK.
 ::: moniker-end
 ::: moniker range="= aspnetcore-2.0"
-If your project targets .NET Framework, include a package reference to [Microsoft.AspNetCore.Mvc.Razor.ViewCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/):
+If your project targets .NET Framework, install the [Microsoft.AspNetCore.Mvc.Razor.ViewCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/) NuGet package:
 
-```xml
-<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation"
-                  Version="2.0.0"
-                  PrivateAssets="All" />
-```
+[!code-xml[](view-compilation/sample/DotNetFrameworkProject.csproj?name=snippet_ViewCompilationPackage)]
 
 If your project targets .NET Core, no changes are necessary.
 

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -1,50 +1,51 @@
 ---
-title: Razor view compilation and precompilation in ASP.NET Core
+title: Razor file compilation and precompilation in ASP.NET Core
 author: rick-anderson
-description: Learn how to enable MVC Razor view compilation and precompilation in ASP.NET Core apps.
+description: Learn how to enable Razor file compilation and precompilation in ASP.NET Core apps.
 manager: wpickett
 ms.author: riande
-ms.date: 12/13/2017
+ms.date: 05/17/2018
 ms.prod: asp.net-core
 ms.technology: aspnet
 ms.topic: article
 uid: mvc/views/view-compilation
 ---
-# Razor file (.cshtml) compilation in ASP.NET Core
+# Razor file compilation in ASP.NET Core
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
-Razor views are compiled at runtime when the view is invoked. ASP.NET Core 2.1.0 or later compile views at build and publish time using [Razor Sdk](/aspnetcore/mvc/razor-pages/sdk). In ASP.NET Core 1.1, and ASP.NET Core 2.0, views can optionally be compiled at publish and deployed with the app &mdash; using the precompilation tool. 
+A Razor file is compiled at runtime when the associated Razor Page or view is invoked. ASP.NET Core 2.1 and later compile views at build and publish time using the [Razor SDK](xref:mvc/razor-pages/sdk). In ASP.NET Core 1.1, and ASP.NET Core 2.0, views can optionally be compiled at publish and deployed with the app&mdash;using the precompilation tool.
 
+## Precompilation considerations
 
-
-Precompilation considerations:
+The following are side effects of precompiling Razor files:
 
 * Precompiling views results in a smaller published bundle and faster startup time.
-* You can't edit Razor files after you precompile views. The edited views won't be present in the published bundle. 
+* You can't edit Razor files after you precompile views. The edited views won't be present in the published bundle.
 
-To deploy precompiled views:
+## Deploy precompiled views
 
-# [ASP.NET Core 2.1](#tab/aspnetcore21/)
-Build and publish time compilation of Razor files is enabled by default by the Razor Sdk. Editing Razor files after they are updated is supported at build time. By default, only the compiled *Views.dll* and no cshtml files are deployed with your application. 
-    
+::: moniker range="= aspnetcore-2.1"
+Build- and publish-time compilation of Razor files is enabled by default by the Razor SDK. Editing Razor files after they're updated is supported at build time. By default, only the compiled *Views.dll* and no *.cshtml* files are deployed with your app.
+
 > [!IMPORTANT]
-> The Razor Sdk is only effective when no precompilation specific properties are set in your project file. For instance, setting `MvcRazorCompileOnPublish` in your *.csproj* file will disable the Razor Sdk.
-
-# [ASP.NET Core 2.0](#tab/aspnetcore20/)
-
+> The Razor SDK is effective only when no precompilation-specific properties are set in the project file. For instance, setting the *.csproj* file's `MvcRazorCompileOnPublish` property to `true` disables the Razor SDK.
+::: moniker-end
+::: moniker range="= aspnetcore-2.0"
 If your project targets .NET Framework, include a package reference to [Microsoft.AspNetCore.Mvc.Razor.ViewCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/):
 
 ```xml
-<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="2.0.0" PrivateAssets="All" />
+<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation"
+                  Version="2.0.0"
+                  PrivateAssets="All" />
 ```
 
 If your project targets .NET Core, no changes are necessary.
 
-The ASP.NET Core 2.x project templates implicitly sets `MvcRazorCompileOnPublish` to `true` by default, which means this node can be safely removed from the *.csproj* file.
-    
+The ASP.NET Core 2.x project templates implicitly set `MvcRazorCompileOnPublish` to `true` by default, which means this node can be safely removed from the *.csproj* file.
+
 > [!IMPORTANT]
-> Razor view precompilation in not available when performing a [self-contained deployment (SCD)](/dotnet/core/deploying/#self-contained-deployments-scd) in ASP.NET Core 2.0. 
+> Razor view precompilation is unavailable when performing a [self-contained deployment (SCD)](/dotnet/core/deploying/#self-contained-deployments-scd) in ASP.NET Core 2.0.
 
 Prepare the app for a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd) with the [.NET Core CLI publish command](/dotnet/core/tools/dotnet-publish). For example, execute the following command at the project root:
 
@@ -52,15 +53,12 @@ Prepare the app for a [framework-dependent deployment](/dotnet/core/deploying/#f
 dotnet publish -c Release
 ```
 
-A *<project_name>.PrecompiledViews.dll* file, containing the compiled Razor views, is produced when precompilation succeeds. For example, the screenshot below depicts the contents of *Index.cshtml* inside of *WebApplication1.PrecompiledViews.dll*:
+A *<project_name>.PrecompiledViews.dll* file, containing the compiled Razor files, is produced when precompilation succeeds. For example, the screenshot below depicts the contents of *Index.cshtml* within *WebApplication1.PrecompiledViews.dll*:
 
 ![Razor views inside DLL](view-compilation/_static/razor-views-in-dll.png)
-
-# [ASP.NET Core 1.x](#tab/aspnetcore1x/)
-
+::: moniker-end
+::: moniker range="<= aspnetcore-1.1"
 Set `MvcRazorCompileOnPublish` to `true` and include a package reference to `Microsoft.AspNetCore.Mvc.Razor.ViewCompilation`. The following *.csproj* sample highlights these settings:
 
 [!code-xml[](view-compilation/sample/MvcRazorCompileOnPublish.csproj?highlight=5,12)]
-
----
-
+::: moniker-end

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -56,9 +56,9 @@ A *<project_name>.PrecompiledViews.dll* file, containing the compiled Razor file
 ![Razor views inside DLL](view-compilation/_static/razor-views-in-dll.png)
 ::: moniker-end
 ::: moniker range="<= aspnetcore-1.1"
-Set `MvcRazorCompileOnPublish` to `true` and include a package reference to `Microsoft.AspNetCore.Mvc.Razor.ViewCompilation`. The following *.csproj* sample highlights these settings:
+Set the `MvcRazorCompileOnPublish` property to `true`, and install the [Microsoft.AspNetCore.Mvc.Razor.ViewCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/) NuGet package. The following *.csproj* sample highlights these settings:
 
-[!code-xml[](view-compilation/sample/MvcRazorCompileOnPublish.csproj?highlight=5,12)]
+[!code-xml[](view-compilation/sample/MvcRazorCompileOnPublish.csproj?highlight=4,10)]
 ::: moniker-end
 
 ## Additional resources

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -36,12 +36,13 @@ The following are side effects of precompiling Razor files:
 
 ## Deploy precompiled files
 
-::: moniker range="= aspnetcore-2.1"
+::: moniker range=">= aspnetcore-2.1"
 Build- and publish-time compilation of Razor files is enabled by default by the Razor SDK. Editing Razor files after they're updated is supported at build time. By default, only the compiled *Views.dll* and no *.cshtml* files are deployed with your app.
 
 > [!IMPORTANT]
 > The Razor SDK is effective only when no precompilation-specific properties are set in the project file. For instance, setting the *.csproj* file's `MvcRazorCompileOnPublish` property to `true` disables the Razor SDK.
 ::: moniker-end
+
 ::: moniker range="= aspnetcore-2.0"
 If your project targets .NET Framework, install the [Microsoft.AspNetCore.Mvc.Razor.ViewCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/) NuGet package:
 
@@ -49,11 +50,19 @@ If your project targets .NET Framework, install the [Microsoft.AspNetCore.Mvc.Ra
 
 If your project targets .NET Core, no changes are necessary.
 
-The ASP.NET Core 2.x project templates implicitly set `MvcRazorCompileOnPublish` to `true` by default. Consequently, this node can be safely removed from the *.csproj* file.
+The ASP.NET Core 2.x project templates implicitly set the `MvcRazorCompileOnPublish` property to `true` by default. Consequently, this element can be safely removed from the *.csproj* file.
 
 > [!IMPORTANT]
 > Razor file precompilation is unavailable when performing a [self-contained deployment (SCD)](/dotnet/core/deploying/#self-contained-deployments-scd) in ASP.NET Core 2.0.
+::: moniker-end
 
+::: moniker range="= aspnetcore-1.1"
+Set the `MvcRazorCompileOnPublish` property to `true`, and install the [Microsoft.AspNetCore.Mvc.Razor.ViewCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/) NuGet package. The following *.csproj* sample highlights these settings:
+
+[!code-xml[](view-compilation/sample/MvcRazorCompileOnPublish.csproj?highlight=4,10)]
+::: moniker-end
+
+::: moniker range="<= aspnetcore-2.0"
 Prepare the app for a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd) with the [.NET Core CLI publish command](/dotnet/core/tools/dotnet-publish). For example, execute the following command at the project root:
 
 ```console
@@ -64,14 +73,20 @@ A *<project_name>.PrecompiledViews.dll* file, containing the compiled Razor file
 
 ![Razor views inside DLL](view-compilation/_static/razor-views-in-dll.png)
 ::: moniker-end
-::: moniker range="<= aspnetcore-1.1"
-Set the `MvcRazorCompileOnPublish` property to `true`, and install the [Microsoft.AspNetCore.Mvc.Razor.ViewCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/) NuGet package. The following *.csproj* sample highlights these settings:
-
-[!code-xml[](view-compilation/sample/MvcRazorCompileOnPublish.csproj?highlight=4,10)]
-::: moniker-end
 
 ## Additional resources
 
-* <xref:mvc/razor-pages/index>
-* <xref:mvc/razor-pages/sdk>
+::: moniker range="= aspnetcore-1.1"
 * <xref:mvc/views/overview>
+::: moniker-end
+
+::: moniker range="= aspnetcore-2.0"
+* <xref:mvc/razor-pages/index>
+* <xref:mvc/views/overview>
+::: moniker-end
+
+::: moniker range=">= aspnetcore-2.1"
+* <xref:mvc/razor-pages/index>
+* <xref:mvc/views/overview>
+* <xref:mvc/razor-pages/sdk>
+::: moniker-end

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -1,9 +1,10 @@
 ---
 title: Razor file compilation and precompilation in ASP.NET Core
 author: rick-anderson
-description: Learn how to enable Razor file compilation and precompilation in ASP.NET Core apps.
+description: Learn about the benefits of precompiling Razor files and how to accomplish Razor file precompilation in an ASP.NET Core app.
 manager: wpickett
 ms.author: riande
+ms.custom: mvc
 ms.date: 05/17/2018
 ms.prod: asp.net-core
 ms.technology: aspnet
@@ -14,14 +15,15 @@ uid: mvc/views/view-compilation
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
-A Razor file is compiled at runtime when the associated Razor Page or view is invoked. ASP.NET Core 2.1 and later compile views at build and publish time using the [Razor SDK](xref:mvc/razor-pages/sdk). In ASP.NET Core 1.1, and ASP.NET Core 2.0, views can optionally be compiled at publish and deployed with the app&mdash;using the precompilation tool.
+A Razor file is compiled at runtime, when the associated Razor Page or view is invoked. ASP.NET Core 2.1 and later compile views at build and publish time using the [Razor SDK](xref:mvc/razor-pages/sdk). In ASP.NET Core 1.1 and ASP.NET Core 2.0, views can optionally be compiled at publish and deployed with the app&mdash;using the precompilation tool.
 
 ## Precompilation considerations
 
 The following are side effects of precompiling Razor files:
 
-* Precompiling views results in a smaller published bundle and faster startup time.
-* You can't edit Razor files after you precompile views. The edited views won't be present in the published bundle.
+* A smaller published bundle
+* A faster startup time
+* You can't edit Razor files&mdash;the associated Razor Pages or views are absent from the published bundle.
 
 ## Deploy precompiled views
 
@@ -62,3 +64,7 @@ Set `MvcRazorCompileOnPublish` to `true` and include a package reference to `Mic
 
 [!code-xml[](view-compilation/sample/MvcRazorCompileOnPublish.csproj?highlight=5,12)]
 ::: moniker-end
+
+## Additional resources
+
+* <xref:mvc/razor-pages/sdk>

--- a/aspnetcore/mvc/views/view-compilation/sample/DotNetFrameworkProject.csproj
+++ b/aspnetcore/mvc/views/view-compilation/sample/DotNetFrameworkProject.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net471</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.4" />
+    <!-- <snippet_ViewCompilationPackage> -->
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation"
+                      Version="2.0.4"
+                      PrivateAssets="All" />
+    <!-- </snippet_ViewCompilationPackage> -->
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4" />
+  </ItemGroup>
+</Project>

--- a/aspnetcore/mvc/views/view-compilation/sample/MvcRazorCompileOnPublish.csproj
+++ b/aspnetcore/mvc/views/view-compilation/sample/MvcRazorCompileOnPublish.csproj
@@ -1,15 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <MvcRazorCompileOnPublish>true</MvcRazorCompileOnPublish>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="1.1.0-*" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Fixes #5408

**Changes**
- Make the doc unavailable for ASP.NET Core 1.0, where precompilation isn't supported
- Replace tabs with versioning monikers
- Move an unused *.csproj* file from the *sample* folder to a *samples* folder for the metapackage doc using it
- Address Acrolinx suggestions, Gauntlet warnings, and Markdownlint warnings
- Add headings to improve readability
- Add an **Additional resources** section

**Internal Review Pages**
* [ASP.NET Core 1.1](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/views/view-compilation?view=aspnetcore-1.1&branch=pr-en-us-6464)
* [ASP.NET Core 2.0](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/views/view-compilation?view=aspnetcore-2.0&branch=pr-en-us-6464)
* [ASP.NET Core 2.1](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/views/view-compilation?view=aspnetcore-2.1&branch=pr-en-us-6464)