### PR TITLE
Added documentation for IHttpContextAccessor to describe its use in c…

### DIFF
--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -33,7 +33,7 @@ public class AboutModel : PageModel
 
 ## Use HttpContext from a controller
 
-Controllers expose the `HttpContext` property from the [ControllerBase](/dotnet/api/microsoft.aspnetcore.mvc.controllerbase):
+Controllers expose the [ControllerBase.HttpContext](/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.httpcontext) property:
 
 ```csharp
 public IActionResult About()

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -1,15 +1,20 @@
 ---
 title: Accessing HttpContext in .NET Core
 author: coderandhiker
+ms.author: riande
+manager: wpickett
 description: Learn how to access HttpContext using .NET Core
+ms.date: 05/22/2018
 ms.topic: article
+ms.prod: aspnet-core
+uid: fundamentals/http-context
 ---
 
-# Using IHttpContextAccessor to manage HttpContext
+# Use IHttpContextAccessor to manage HttpContext
 
-Working with the current HttpContext within a .NET Core application is made possible through the `IHttpContextAccessor` interface and its default implementation `HttpContextAccessor`.  
+ASP.NET Core applications access the HttpContext hrough the [IHttpContextAccessor](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.ihttpcontextaccessor?view=aspnetcore-2.0) interface and its default implementation [HttpContextAccessor](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.httpcontextaccessor.httpcontext?view=aspnetcore-2.0). 
 
-## Using HttpContext ASP.NET Core MVC from controllers and middleware
+## Use the HttpContext from Razor Pages, controllers, and middleware
 
 If you need to access the current context from a controller, you can access it by using the `HttpContext` property exposed by the `ControllerBase` class from which the `Controller` class is derived.
 

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -1,0 +1,113 @@
+---
+title: Accessing HttpContext in .NET Core
+author: coderandhiker
+description: Learn how to access HttpContext using .NET Core
+ms.topic: article
+---
+
+# Using IHttpContextAccessor to manage HttpContext
+
+Working with the current HttpContext within a .NET Core application is made possible through the `IHttpContextAccessor` interface and its default implementation `HttpContextAccessor`.  
+
+## Using HttpContext ASP.NET Core MVC from controllers and middleware
+
+If you need to access the current context from a controller, you can access it by using the `HttpContext` property exposed by the `ControllerBase` class from which the `Controller` class is derived.
+
+When working with custom middleware components, `HttpContext` is passed into the Invoke method and can be accessed when the middleware is being configured.
+
+```csharp
+public class MyCustomMiddleware
+{
+    public async Task Invoke(HttpContext context)
+    {
+        // Middleware initialization optionally using HttpContext
+    }
+    ...
+}
+```
+
+## Using HttpContext from custom components
+
+For other framework and custom components that need access to `HttpContext`, the recommended approach is to register a dependency using the built-in dependency injection framework.  This will suplly the `IHttpContextAccessor` to any classes that declare it as a dependency in their constructors.
+
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+     services.AddMvc();
+     services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+     services.AddTransient<IUserRepository, UserRepository>();
+}
+```
+
+In this example `UserRepository` declares its dependency on `IHttpContextAccessor`, which is supplied when the dependency injection framework resolves the dependency chain and creates an instance of `UserRepository`.
+
+```csharp
+public class UserRepository : IUserRepository
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public UserRepository(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public void LogCurrentUser()
+    {
+        var username = _httpContextAccessor.HttpContext.User.Identity.Name;
+        service.LogAccessRequest(username);            
+    }
+
+    ...
+```
+
+## Working with libraries and ported code
+Registering IHttpContextAccessor in the application startup using the built-in dependency injection framework is the preferred approach to accessing HttpContext.  In scenarios where it is not feasible to refactor to this approach, it is possible to simulate the behavior of `System.Web.HttpContext` from ASP.NET 4.x.
+
+Begin by registering `IHttpContextAccessor` as a dependency in your `ConfigureServices` method in your startup class.
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+}
+```
+
+Create a wrapper class for `HttpContext` and provide a method to invoke to pass an instance of `IHttpContextAccessor`.
+
+```csharp
+public static class HttpContext
+{
+    private static IHttpContextAccessor _httpContextAccessor;
+
+    public static Microsoft.AspNetCore.Http.HttpContext Current => _httpContextAccessor.HttpContext;
+
+    public static void RegisterContextAccessor(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+}
+```
+
+Introduce an extension method to resolve the `IHttpContextAccessor` dependency and set the `HttpContext` property.
+
+```csharp   
+public static IApplicationBuilder UseStaticHttpContext(this IApplicationBuilder app)
+{
+     var httpContextAccessor = app.ApplicationServices.GetRequiredService<IHttpContextAccessor>();
+            
+     HttpContext.RegisterContextAccessor(httpContextAccessor);
+     return app;
+}
+```
+
+Configure the application to use the static `HttpContext` object.
+
+```csharp
+public void Configure(IApplicationBuilder app)
+{
+     app.UseStaticHttpContext();
+}
+```
+
+You will now be able to access the current HttpContext through the static `HttpContext.Current`. When porting code to ASP.NET Core, it may be helpful to place the static `HttpContext` class in the `System.Web` namespace.

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -9,9 +9,11 @@ uid: fundamentals/httpcontext
 ---
 # Access HttpContext in ASP.NET Core
 
-ASP.NET Core apps access the HttpContext through the [IHttpContextAccessor](/dotnet/api/microsoft.aspnetcore.http.ihttpcontextaccessor) interface and its default implementation [HttpContextAccessor](/dotnet/api/microsoft.aspnetcore.http.httpcontextaccessor).
+ASP.NET Core apps access the `HttpContext` through the [IHttpContextAccessor](/dotnet/api/microsoft.aspnetcore.http.ihttpcontextaccessor) interface and its default implementation [HttpContextAccessor](/dotnet/api/microsoft.aspnetcore.http.httpcontextaccessor).
 
-## Use the HttpContext from Razor Pages, controllers, and middleware
+::: moniker range=">= aspnetcore-2.0"
+
+## Use HttpContext from Razor Pages
 
 The Razor Pages [PageModel](/dotnet/api/microsoft.aspnetcore.mvc.razorpages.pagemodel) exposes the [HttpContext](/dotnet/api/microsoft.aspnetcore.mvc.razorpages.pagemodel.httpcontext) property:
 
@@ -27,6 +29,10 @@ public class AboutModel : PageModel
 }
 ```
 
+::: moniker-end
+
+## Use HttpContext from a controller
+
 Controllers expose the `HttpContext` property from the [ControllerBase](/dotnet/api/microsoft.aspnetcore.mvc.controllerbase):
 
 ```csharp
@@ -38,6 +44,8 @@ public IActionResult About()
     return View();
 }
 ```
+
+## Use HttpContext from middleware
 
 When working with custom middleware components, `HttpContext` is passed into the `Invoke` or `InvokeAsync` method and can be accessed when the middleware is configured:
 

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -9,16 +9,39 @@ ms.topic: article
 ms.prod: aspnet-core
 uid: fundamentals/http-context
 ---
-
 # Use IHttpContextAccessor to manage HttpContext
 
-ASP.NET Core applications access the HttpContext hrough the [IHttpContextAccessor](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.ihttpcontextaccessor?view=aspnetcore-2.0) interface and its default implementation [HttpContextAccessor](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.httpcontextaccessor.httpcontext?view=aspnetcore-2.0). 
+ASP.NET Core applications access the HttpContext through the [IHttpContextAccessor](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.ihttpcontextaccessor?view=aspnetcore-2.0) interface and its default implementation [HttpContextAccessor](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.httpcontextaccessor.httpcontext?view=aspnetcore-2.0).
 
 ## Use the HttpContext from Razor Pages, controllers, and middleware
 
-If you need to access the current context from a controller, you can access it by using the `HttpContext` property exposed by the `ControllerBase` class from which the `Controller` class is derived.
+The Razor Pages `PageModel` exposes the `HttpContext` property:
 
-When working with custom middleware components, `HttpContext` is passed into the Invoke method and can be accessed when the middleware is being configured.
+```csharp
+public class AboutModel : PageModel
+{
+    public string Message { get; set; }
+
+    public void OnGet()
+    {
+        Message = HttpContext.Request.PathBase;
+    }
+}
+```
+
+Controllers expose the `HttpContext` property from the `ControllerBase`:
+
+```csharp
+public IActionResult About()
+{
+    var pathBase = HttpContext.Request.PathBase;
+    // Do something with the PathBase.
+
+    return View();
+}
+```
+
+When working with custom middleware components, `HttpContext` is passed into the `Invoke` method and can be accessed when the middleware is being configured.
 
 ```csharp
 public class MyCustomMiddleware
@@ -31,10 +54,9 @@ public class MyCustomMiddleware
 }
 ```
 
-## Using HttpContext from custom components
+## Use HttpContext from custom components
 
-For other framework and custom components that need access to `HttpContext`, the recommended approach is to register a dependency using the built-in dependency injection framework.  This will suplly the `IHttpContextAccessor` to any classes that declare it as a dependency in their constructors.
-
+For other framework and custom components that need access to `HttpContext`, the recommended approach is to register a dependency using the built-in [dependency injection](xref:fundamentals/dependency-injection) container.  The dependency injection container will supply the `IHttpContextAccessor` to any classes that declare it as a dependency in their constructors.
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
@@ -45,7 +67,10 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-In this example `UserRepository` declares its dependency on `IHttpContextAccessor`, which is supplied when the dependency injection framework resolves the dependency chain and creates an instance of `UserRepository`.
+In the preceding example:
+
+* `UserRepository` declares its dependency on `IHttpContextAccessor`.
+* The dependency is supplied when dependency injection resolves the dependency chain and creates an instance of `UserRepository`.
 
 ```csharp
 public class UserRepository : IUserRepository
@@ -60,16 +85,17 @@ public class UserRepository : IUserRepository
     public void LogCurrentUser()
     {
         var username = _httpContextAccessor.HttpContext.User.Identity.Name;
-        service.LogAccessRequest(username);            
+        service.LogAccessRequest(username);
     }
 
     ...
 ```
 
-## Working with libraries and ported code
+## Work with libraries and ported code
+
 Registering IHttpContextAccessor in the application startup using the built-in dependency injection framework is the preferred approach to accessing HttpContext.  In scenarios where it is not feasible to refactor to this approach, it is possible to simulate the behavior of `System.Web.HttpContext` from ASP.NET 4.x.
 
-Begin by registering `IHttpContextAccessor` as a dependency in your `ConfigureServices` method in your startup class.
+Register `IHttpContextAccessor` as a dependency in the `ConfigureServices` method.
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
@@ -96,11 +122,11 @@ public static class HttpContext
 
 Introduce an extension method to resolve the `IHttpContextAccessor` dependency and set the `HttpContext` property.
 
-```csharp   
+```csharp
 public static IApplicationBuilder UseStaticHttpContext(this IApplicationBuilder app)
 {
      var httpContextAccessor = app.ApplicationServices.GetRequiredService<IHttpContextAccessor>();
-            
+
      HttpContext.RegisterContextAccessor(httpContextAccessor);
      return app;
 }

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -59,7 +59,6 @@ public class MyCustomMiddleware
     {
         // Middleware initialization optionally using HttpContext
     }
-    ...
 }
 ```
 
@@ -73,7 +72,7 @@ For other framework and custom components that require access to `HttpContext`, 
 public void ConfigureServices(IServiceCollection services)
 {
      services.AddMvc()
-             .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+         .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
      services.AddHttpContextAccessor();
      services.AddTransient<IUserRepository, UserRepository>();
 }
@@ -114,7 +113,5 @@ public class UserRepository : IUserRepository
         var username = _httpContextAccessor.HttpContext.User.Identity.Name;
         service.LogAccessRequest(username);
     }
-
-    ...
 }
 ```

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -1,13 +1,15 @@
 ---
-title: Accessing HttpContext in .NET Core
+title: Accessing HttpContext in ASP.NET Core
 author: coderandhiker
-ms.author: riande
+description: Learn how to access HttpContext in ASP.NET Core.
 manager: wpickett
-description: Learn how to access HttpContext using .NET Core
+ms.author: riande
+ms.custom: mvc
 ms.date: 05/22/2018
-ms.topic: article
 ms.prod: aspnet-core
-uid: fundamentals/http-context
+ms.technology: aspnet
+ms.topic: article
+uid: fundamentals/httpcontext
 ---
 # Use IHttpContextAccessor to manage HttpContext
 
@@ -56,7 +58,7 @@ public class MyCustomMiddleware
 
 ## Use HttpContext from custom components
 
-For other framework and custom components that need access to `HttpContext`, the recommended approach is to register a dependency using the built-in [dependency injection](xref:fundamentals/dependency-injection) container.  The dependency injection container will supply the `IHttpContextAccessor` to any classes that declare it as a dependency in their constructors.
+For other framework and custom components that need access to `HttpContext`, the recommended approach is to register a dependency using the built-in [dependency injection](xref:fundamentals/dependency-injection) container. The dependency injection container will supply the `IHttpContextAccessor` to any classes that declare it as a dependency in their constructors.
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
@@ -93,7 +95,7 @@ public class UserRepository : IUserRepository
 
 ## Work with libraries and ported code
 
-Registering IHttpContextAccessor in the application startup using the built-in dependency injection framework is the preferred approach to accessing HttpContext.  In scenarios where it is not feasible to refactor to this approach, it is possible to simulate the behavior of `System.Web.HttpContext` from ASP.NET 4.x.
+Registering IHttpContextAccessor in the application startup using the built-in dependency injection framework is the preferred approach to accessing HttpContext. In scenarios where it is not feasible to refactor to this approach, it is possible to simulate the behavior of `System.Web.HttpContext` from ASP.NET 4.x.
 
 Register `IHttpContextAccessor` as a dependency in the `ConfigureServices` method.
 

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -1,17 +1,13 @@
 ---
-title: Accessing HttpContext in ASP.NET Core
+title: Access HttpContext in ASP.NET Core
 author: coderandhiker
 description: Learn how to access HttpContext in ASP.NET Core.
-manager: wpickett
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/22/2018
-ms.prod: aspnet-core
-ms.technology: aspnet
-ms.topic: article
+ms.date: 07/10/2018
 uid: fundamentals/httpcontext
 ---
-# Accessing HttpContext in ASP.NET Core
+# Access HttpContext in ASP.NET Core
 
 ASP.NET Core apps access the HttpContext through the [IHttpContextAccessor](/dotnet/api/microsoft.aspnetcore.http.ihttpcontextaccessor) interface and its default implementation [HttpContextAccessor](/dotnet/api/microsoft.aspnetcore.http.httpcontextaccessor).
 

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -56,6 +56,8 @@ public class MyCustomMiddleware
 
 For other framework and custom components that need access to `HttpContext`, the recommended approach is to register a dependency using the built-in [dependency injection](xref:fundamentals/dependency-injection) container. The dependency injection container supplies the `IHttpContextAccessor` to any classes that declare it as a dependency in their constructors.
 
+::: moniker range=">= aspnetcore-2.1"
+
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
@@ -64,6 +66,21 @@ public void ConfigureServices(IServiceCollection services)
      services.AddTransient<IUserRepository, UserRepository>();
 }
 ```
+
+::: moniker-end
+
+::: moniker range="<= aspnetcore-2.0"
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+     services.AddMvc();
+     services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+     services.AddTransient<IUserRepository, UserRepository>();
+}
+```
+
+::: moniker-end
 
 In the preceding example:
 
@@ -89,4 +106,3 @@ public class UserRepository : IUserRepository
     ...
 }
 ```
-

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -62,7 +62,7 @@ public class MyCustomMiddleware
 
 ## Use HttpContext from custom components
 
-For other framework and custom components that need access to `HttpContext`, the recommended approach is to register a dependency using the built-in [dependency injection](xref:fundamentals/dependency-injection) container. The dependency injection container supplies the `IHttpContextAccessor` to any classes that declare it as a dependency in their constructors.
+For other framework and custom components that require access to `HttpContext`, the recommended approach is to register a dependency using the built-in [dependency injection](xref:fundamentals/dependency-injection) container. The dependency injection container supplies the `IHttpContextAccessor` to any classes that declare it as a dependency in their constructors.
 
 ::: moniker range=">= aspnetcore-2.1"
 

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -4,7 +4,7 @@ author: coderandhiker
 description: Learn how to access HttpContext in ASP.NET Core.
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/10/2018
+ms.date: 07/20/2018
 uid: fundamentals/httpcontext
 ---
 # Access HttpContext in ASP.NET Core

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -61,7 +61,8 @@ For other framework and custom components that need access to `HttpContext`, the
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-     services.AddMvc();
+     services.AddMvc()
+             .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
      services.AddHttpContextAccessor();
      services.AddTransient<IUserRepository, UserRepository>();
 }

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -36,12 +36,15 @@ public class AboutModel : PageModel
 Controllers expose the [ControllerBase.HttpContext](/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.httpcontext) property:
 
 ```csharp
-public IActionResult About()
+public class HomeController : Controller
 {
-    var pathBase = HttpContext.Request.PathBase;
-    // Do something with the PathBase.
+    public IActionResult About()
+    {
+        var pathBase = HttpContext.Request.PathBase;
+        // Do something with the PathBase.
 
-    return View();
+        return View();
+    }
 }
 ```
 

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -11,7 +11,7 @@ uid: fundamentals/http-context
 ---
 # Use IHttpContextAccessor to manage HttpContext
 
-ASP.NET Core applications access the HttpContext through the [IHttpContextAccessor](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.ihttpcontextaccessor?view=aspnetcore-2.0) interface and its default implementation [HttpContextAccessor](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.httpcontextaccessor.httpcontext?view=aspnetcore-2.0).
+ASP.NET Core applications access the HttpContext through the [IHttpContextAccessor](/dotnet/api/microsoft.aspnetcore.http.ihttpcontextaccessor?view=aspnetcore-2.0) interface and its default implementation [HttpContextAccessor](/dotnet/api/microsoft.aspnetcore.http.httpcontextaccessor.httpcontext?view=aspnetcore-2.0).
 
 ## Use the HttpContext from Razor Pages, controllers, and middleware
 


### PR DESCRIPTION
Fixes #6113 

Added documentation for IHttpContextAccessor to describe its use in controllers, middleware, libraries and ways to simplify porting legacy code that depend upon System.Web.HttpContext

**Internal Review Pages**
* [2.1](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/http-context?view=aspnetcore-2.1&branch=pr-en-us-6489)
* [1.1](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/http-context?view=aspnetcore-1.1&branch=pr-en-us-6489)