### PR TITLE
Add CreateDefaultBuilder content to app secrets

### DIFF
--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -185,7 +185,16 @@ As of ASP.NET Core 2.0, the user secrets configuration source is automatically a
 ::: moniker range="<= aspnetcore-1.1"
 The [ASP.NET Core Configuration API](xref:fundamentals/configuration/index) provides access to Secret Manager secrets. Install the [Microsoft.Extensions.Configuration.UserSecrets](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.UserSecrets) NuGet package.
 
-Add the user secrets configuration source to the `Startup` constructor:
+Add the user secrets configuration source with a call to [AddUserSecrets](/dotnet/api/microsoft.extensions.configuration.usersecretsconfigurationextensions.addusersecrets) in the `Startup` constructor:
+
+[!code-csharp[](app-secrets/samples/1.1/UserSecrets/Startup.cs?name=snippet_StartupConstructor&highlight=5-8)]
+::: moniker-end
+::: moniker range=">= aspnetcore-2.0"
+When a project calls [CreateDefaultBuilder](/dotnet/api/microsoft.aspnetcore.webhost.createdefaultbuilder) to initialize a new instance of the host with preconfigured defaults, [AddUserSecrets](/dotnet/api/microsoft.extensions.configuration.usersecretsconfigurationextensions.addusersecrets) is called when the [EnvironmentName](/dotnet/api/microsoft.aspnetcore.hosting.ihostingenvironment.environmentname) is [Development](/dotnet/api/microsoft.aspnetcore.hosting.environmentname.development):
+
+[!code-csharp[](app-secrets/samples/2.1/UserSecrets/Program.cs?name=snippet_CreateWebHostBuilder&highlight=2)]
+
+When `CreateDefaultBuilder` isn't called during host construction, add the user secrets configuration source with a call to [AddUserSecrets](/dotnet/api/microsoft.extensions.configuration.usersecretsconfigurationextensions.addusersecrets) in the `Startup` constructor:
 
 [!code-csharp[](app-secrets/samples/1.1/UserSecrets/Startup.cs?name=snippet_StartupConstructor&highlight=5-8)]
 ::: moniker-end

--- a/aspnetcore/security/app-secrets/samples/2.1/UserSecrets/Program.cs
+++ b/aspnetcore/security/app-secrets/samples/2.1/UserSecrets/Program.cs
@@ -10,8 +10,10 @@ namespace UserSecrets
             CreateWebHostBuilder(args).Build().Run();
         }
 
+        #region snippet_CreateWebHostBuilder
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>();
+        #endregion
     }
 }


### PR DESCRIPTION
Fixes #6523 

@Rick-Anderson @scottaddie The samps here don't quite follow the convention we established earlier for folder naming. They exist explicitly as "1.1" and "2.1" samps, but we decided to continue with "1.x" and "2.x" folder names. If you'd like me to fix it on this PR, let me know, and I'll square it away.