### PR TITLE
C19395: Missing hyperlink due to incorrect format

### DIFF
--- a/aspnet/web-forms/overview/deployment/configuring-server-environments-for-web-deployment/configuring-a-web-server-for-web-deploy-publishing-remote-agent.md
+++ b/aspnet/web-forms/overview/deployment/configuring-server-environments-for-web-deployment/configuring-a-web-server-for-web-deploy-publishing-remote-agent.md
@@ -212,7 +212,7 @@ You can check whether a service is running in multiple different ways, using var
 
 By default, the Remote Agent Service listens on TCP port 80, at this URL:
 
-http://[<em>server name</em>]/MSDEPLOYAGENTSERVICE
+<http://servername.com/MSDEPLOYAGENTSERVICE>
 
 In most cases, you won't need to configure any additional firewall rules for the Remote Agent Service because web servers typically listen for HTTP requests on port 80. If you customized your installation to listen on a nonstandard port, you'll need to configure firewall exceptions as required.
 


### PR DESCRIPTION
Hello, @jrjlee,

Localization team has reported source content issue that causes localized version to have broken format compared to en-us version.  
 
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.

Many thanks in advance.

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
