### PR TITLE
Display SPA docs for 2.0+ and display banners for 2.0 ONLY

### DIFF
--- a/aspnetcore/spa/angular.md
+++ b/aspnetcore/spa/angular.md
@@ -3,6 +3,7 @@ title: Use the Angular project template with ASP.NET Core
 author: SteveSandersonMS
 description: Learn how to get started with the ASP.NET Core Single Page Application (SPA) project template for Angular and the Angular CLI.
 manager: wpickett
+monikerRange: '>= aspnetcore-2.0'
 ms.author: scaddie
 ms.custom: mvc
 ms.date: 02/21/2018
@@ -14,8 +15,12 @@ uid: spa/angular
 ---
 # Use the Angular project template with ASP.NET Core
 
+::: moniker range="= aspnetcore-2.0"
+
 > [!NOTE]
 > This documentation isn't about the Angular project template included in ASP.NET Core 2.0. It's about the newer Angular template to which you can update manually. The template is included in ASP.NET Core 2.1 by default.
+
+::: moniker-end
 
 The updated Angular project template provides a convenient starting point for ASP.NET Core apps using Angular and the Angular CLI to implement a rich, client-side user interface (UI).
 
@@ -54,7 +59,8 @@ Now listening on: http://localhost:<port>
 
 Navigate to this URL in a browser.
 
-The app starts up an instance of the Angular CLI server in the background. A message similar to the following is logged: <em>NG Live Development Server is listening on localhost:&lt;otherport&gt;, open your browser on http://localhost:&lt;otherport&gt;/</em>. Ignore this message&mdash;it's <strong>not</strong> the URL for the combined ASP.NET Core and Angular CLI app.
+The app starts up an instance of the Angular CLI server in the background. A message similar to the following is logged: 
+*NG Live Development Server is listening on localhost:&lt;otherport&gt;, open your browser on http://localhost:&lt;otherport&gt;/*. Ignore this message&mdash;it's **not** the URL for the combined ASP.NET Core and Angular CLI app.
 
 ---
 
@@ -132,7 +138,7 @@ In the *Startup* class, *after* the line that configures `spa.Options.SourcePath
 
 [!code-csharp[](sample/AngularServerSideRendering/Startup.cs?name=snippet_Call_UseSpa&highlight=5-12)]
 
-In development mode, this code attempts to build the SSR bundle by running the script `build:ssr`, which is defined in *ClientApp\package.json*. This builds an Angular app named `ssr`, which isn't yet defined. 
+In development mode, this code attempts to build the SSR bundle by running the script `build:ssr`, which is defined in *ClientApp\package.json*. This builds an Angular app named `ssr`, which isn't yet defined.
 
 At the end of the `apps` array in *ClientApp/.angular-cli.json*, define an extra app with name `ssr`. Use the following options:
 
@@ -144,7 +150,7 @@ Add a new file called *tsconfig.server.json* inside *ClientApp/src* (alongside t
 
 [!code-json[](sample/AngularServerSideRendering/ClientApp/src/tsconfig.server.json)]
 
-This file configures Angular's AoT compiler to look for a module called `app.server.module`. Add this by creating a new file at *ClientApp/src/app/app.server.module.ts* (alongside the existing *app.module.ts*) containing the following: 
+This file configures Angular's AoT compiler to look for a module called `app.server.module`. Add this by creating a new file at *ClientApp/src/app/app.server.module.ts* (alongside the existing *app.module.ts*) containing the following:
 
 [!code-typescript[](sample/AngularServerSideRendering/ClientApp/src/app/app.server.module.ts)]
 
@@ -154,7 +160,7 @@ Recall that the new `ssr` entry in *.angular-cli.json* referenced an entry point
 
 [!code-typescript[](sample/AngularServerSideRendering/ClientApp/src/main.server.ts)]
 
-This file's code is what ASP.NET Core executes for each request when it runs the `UseSpaPrerendering` middleware that you added to the *Startup* class. It deals with receiving `params` from the .NET code (such as the URL being requested), and making calls to Angular SSR APIs to get the resulting HTML. 
+This file's code is what ASP.NET Core executes for each request when it runs the `UseSpaPrerendering` middleware that you added to the *Startup* class. It deals with receiving `params` from the .NET code (such as the URL being requested), and making calls to Angular SSR APIs to get the resulting HTML.
 
 Strictly-speaking, this is sufficient to enable SSR in development mode. It's essential to make one final change so that your app works correctly when published. In your app's main *.csproj* file, set the `BuildServerSideRenderer` property value to `true`:
 

--- a/aspnetcore/spa/index.md
+++ b/aspnetcore/spa/index.md
@@ -3,6 +3,7 @@ title: Use the Single Page Application templates with ASP.NET Core
 author: SteveSandersonMS
 description: Learn how to install and get started with the ASP.NET Core Single Page Application (SPA) project templates.
 manager: wpickett
+monikerRange: '>= aspnetcore-2.0'
 ms.author: scaddie
 ms.custom: mvc
 ms.date: 02/21/2018
@@ -14,8 +15,12 @@ uid: spa/index
 ---
 # Use the Single Page Application templates with ASP.NET Core
 
+::: moniker range="= aspnetcore-2.0"
+
 > [!NOTE]
 > The released .NET Core 2.0.x SDK includes older project templates for Angular, React, and React with Redux. This documentation isn't about those older project templates. This documentation is for the latest Angular, React, and React with Redux templates, which can be installed manually into ASP.NET Core 2.0. The templates are included by default with ASP.NET Core 2.1.
+
+::: moniker-end
 
 ## Prerequisites
 
@@ -24,14 +29,24 @@ uid: spa/index
 
 ## Installation
 
+::: moniker range=">= aspnetcore-2.1"
+
+The templates are already installed with ASP.NET Core 2.1.
+
+::: moniker-end
+
+::: moniker range="= aspnetcore-2.0"
+
 If you have ASP.NET Core 2.0, run the following command to install the updated ASP.NET Core templates for Angular, React, and React with Redux:
 
 ```console
 dotnet new --install Microsoft.DotNet.Web.Spa.ProjectTemplates::2.0.0
 ```
 
+::: moniker-end
+
 ## Use the templates
 
-- [Use the Angular project template](xref:spa/angular)
-- [Use the React project template](xref:spa/react)
-- [Use the React with Redux project template](xref:spa/react-with-redux)
+* [Use the Angular project template](xref:spa/angular)
+* [Use the React project template](xref:spa/react)
+* [Use the React with Redux project template](xref:spa/react-with-redux)

--- a/aspnetcore/spa/react-with-redux.md
+++ b/aspnetcore/spa/react-with-redux.md
@@ -3,6 +3,7 @@ title: Use the React-with-Redux project template with ASP.NET Core
 author: SteveSandersonMS
 description: Learn how to get started with the ASP.NET Core Single Page Application (SPA) project template for React with Redux and create-react-app.
 manager: wpickett
+monikerRange: '>= aspnetcore-2.0'
 ms.author: scaddie
 ms.custom: mvc
 ms.date: 02/21/2018
@@ -14,8 +15,12 @@ uid: spa/react-with-redux
 ---
 # Use the React-with-Redux project template with ASP.NET Core
 
+::: moniker range="= aspnetcore-2.0"
+
 > [!NOTE]
 > This documentation isn't about the React-with-Redux project template included in ASP.NET Core 2.0. It's about the newer React-with-Redux template to which you can update manually. The template is included in ASP.NET Core 2.1 by default.
+
+::: moniker-end
 
 The updated React-with-Redux project template provides a convenient starting point for ASP.NET Core apps using React, Redux, and [create-react-app](https://github.com/facebookincubator/create-react-app) (CRA) conventions to implement a rich, client-side user interface (UI).
 

--- a/aspnetcore/spa/react.md
+++ b/aspnetcore/spa/react.md
@@ -3,6 +3,7 @@ title: Use the React project template with ASP.NET Core
 author: SteveSandersonMS
 description: Learn how to get started with the ASP.NET Core Single Page Application (SPA) project template for React and create-react-app.
 manager: wpickett
+monikerRange: '>= aspnetcore-2.0'
 ms.author: scaddie
 ms.custom: mvc
 ms.date: 02/21/2018
@@ -14,8 +15,12 @@ uid: spa/react
 ---
 # Use the React project template with ASP.NET Core
 
+::: moniker range="= aspnetcore-2.0"
+
 > [!NOTE]
 > This documentation isn't about the React project template included in ASP.NET Core 2.0. It's about the newer React template to which you can update manually. The template is included in ASP.NET Core 2.1 by default.
+
+::: moniker-end
 
 The updated React project template provides a convenient starting point for ASP.NET Core apps using React and [create-react-app](https://github.com/facebookincubator/create-react-app) (CRA) conventions to implement a rich, client-side user interface (UI).
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/Docs/issues/6603

**Changes**:
- Make the SPA template docs available for ASP.NET Core 2.0+ only
- Display the template inclusion banner in each doc for 2.0 only

**Internal Review Pages**:
- [ASP.NET Core 2.0](https://review.docs.microsoft.com/en-us/aspnet/core/spa/?branch=pr-en-us-6604&view=aspnetcore-2.0)
- [ASP.NET Core 2.1](https://review.docs.microsoft.com/en-us/aspnet/core/spa/?branch=pr-en-us-6604&view=aspnetcore-2.1)
