### PR TITLE
Added missing AllowAnonymous to ForgotPassword and ForgotPasswordConfirmation

### DIFF
--- a/aspnetcore/security/authorization/secure-data/samples/final2/Pages/Account/ForgotPassword.cshtml.cs
+++ b/aspnetcore/security/authorization/secure-data/samples/final2/Pages/Account/ForgotPassword.cshtml.cs
@@ -7,9 +7,11 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using ContactManager.Data;
 using ContactManager.Services;
+using Microsoft.AspNetCore.Authorization;
 
 namespace ContactManager.Pages.Account
 {
+    [AllowAnonymous]
     public class ForgotPasswordModel : PageModel
     {
         private readonly UserManager<ApplicationUser> _userManager;

--- a/aspnetcore/security/authorization/secure-data/samples/final2/Pages/Account/ForgotPasswordConfirmation.cshtml.cs
+++ b/aspnetcore/security/authorization/secure-data/samples/final2/Pages/Account/ForgotPasswordConfirmation.cshtml.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace ContactManager.Pages.Account
 {
+    [AllowAnonymous]
     public class ForgotPasswordConfirmation : PageModel
     {
         public void OnGet()


### PR DESCRIPTION
Previously it was impossible to navigate to these pages unless logged in which makes no sense if you are trying to reset your password.
