### PR TITLE
notes about HttpPost routing

### DIFF
--- a/aspnetcore/security/cors.md
+++ b/aspnetcore/security/cors.md
@@ -88,7 +88,7 @@ To specify the CORS policy for a specific controller add the `[EnableCors]` attr
 [!code-csharp[](cors/sample/CorsMVC/Controllers/ValuesController.cs?name=EnableOnController)]
 
 > [!NOTE]
-> Actions with a route defined by `[HttpGet]`, `[HttpPost]`, `[HttpHead]`, `[HttpPut]`, and `[HttpDelete]` don't function as expected with `[EnableCors]` due to the way these attributes create routes that restrict the method specified in the name of the attribute. `[EnableCors]` must be used along with `[Route]` on the action, controller, or both. For more information on action constraints, see [Understanding IActionConstraint](xref:mvc/controllers/routing#understanding-iactionconstraint). 
+> Actions that use the `[HttpGet]` attribute, and similar `[Http-VERB]` attributes, can result in unexpected behavior when using `[EnableCors]`. When a CORS preflight is required, these routes may not be matched and result in a *404 Not Found*. See [Understanding IActionConstraint](xref:mvc/controllers/routing#understanding-iactionconstraint). Instead of using `[Http-VERB]` attributes, use `[Route]` with `[EnableCors]`.
 
 It's also possible to define routes using [HttpMethodRouteConstraint](/dotnet/api/microsoft.aspnetcore.routing.constraints.httpmethodrouteconstraint) when [defining non-attribute routes](xref:fundamentals/routing) to enforce the desired regular HTTP method and the OPTIONS HTTP method. 
 

--- a/aspnetcore/security/cors.md
+++ b/aspnetcore/security/cors.md
@@ -89,8 +89,8 @@ To specify the CORS policy for a specific controller add the `[EnableCors]` attr
 
 > [!NOTE]
 > Actions that use the `[HttpGet]` attribute, and similar `[Http-VERB]` attributes, can result in unexpected behavior when using `[EnableCors]`. When a CORS preflight is required, these routes may not be matched and result in a *404 Not Found*. See [Understanding IActionConstraint](xref:mvc/controllers/routing#understanding-iactionconstraint). Instead of using `[Http-VERB]` attributes, use `[Route]` with `[EnableCors]`.
-
-It's also possible to define routes using [HttpMethodRouteConstraint](/dotnet/api/microsoft.aspnetcore.routing.constraints.httpmethodrouteconstraint) when [defining non-attribute routes](xref:fundamentals/routing) to enforce the desired regular HTTP method and the OPTIONS HTTP method. 
+>
+> It's also possible to define routes using [HttpMethodRouteConstraint](/dotnet/api/microsoft.aspnetcore.routing.constraints.httpmethodrouteconstraint) when [defining non-attribute routes](xref:fundamentals/routing) to enforce the desired regular HTTP method and the OPTIONS HTTP method. 
 
 ### Globally
 

--- a/aspnetcore/security/cors.md
+++ b/aspnetcore/security/cors.md
@@ -87,6 +87,11 @@ To specify the CORS policy for a specific controller add the `[EnableCors]` attr
 
 [!code-csharp[](cors/sample/CorsMVC/Controllers/ValuesController.cs?name=EnableOnController)]
 
+> [!NOTE]
+> Actions with a route defined by `[HttpGet]`, `[HttpPost]`, `[HttpHead]`, `[HttpPut]`, `[HttpDelete]` will not function as expected with `[EnableCors]` due to the way these attributes create Routes which restrict the Method specified in the name of the Attribute. Read more about [Action Constraints](https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/routing?view=aspnetcore-2.0#understanding-iactionconstraint]. `[EnableCors]` must be used along with `[Route]` on the action, controller, or both.
+
+It is also possible to define routes using [HttpMethodRouteConstraint](https://github.com/aspnet/Routing/blob/dev/src/Microsoft.AspNetCore.Routing/Constraints/HttpMethodRouteConstraint.cs) when [defining non-attribute routes](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/routing) to allow both the desired "regular" HTTP method, plus also the OPTIONS HTTP method. 
+
 ### Globally
 
 You can enable CORS globally for all controllers by adding the `CorsAuthorizationFilterFactory` filter to the global filter collection:

--- a/aspnetcore/security/cors.md
+++ b/aspnetcore/security/cors.md
@@ -88,9 +88,9 @@ To specify the CORS policy for a specific controller add the `[EnableCors]` attr
 [!code-csharp[](cors/sample/CorsMVC/Controllers/ValuesController.cs?name=EnableOnController)]
 
 > [!NOTE]
-> Actions with a route defined by `[HttpGet]`, `[HttpPost]`, `[HttpHead]`, `[HttpPut]`, `[HttpDelete]` will not function as expected with `[EnableCors]` due to the way these attributes create Routes which restrict the Method specified in the name of the Attribute. Read more about [Action Constraints](https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/routing?view=aspnetcore-2.0#understanding-iactionconstraint]. `[EnableCors]` must be used along with `[Route]` on the action, controller, or both.
+> Actions with a route defined by `[HttpGet]`, `[HttpPost]`, `[HttpHead]`, `[HttpPut]`, and `[HttpDelete]` don't function as expected with `[EnableCors]` due to the way these attributes create routes that restrict the method specified in the name of the attribute. `[EnableCors]` must be used along with `[Route]` on the action, controller, or both. For more information on action constraints, see [Understanding IActionConstraint](xref:mvc/controllers/routing#understanding-iactionconstraint). 
 
-It is also possible to define routes using [HttpMethodRouteConstraint](https://github.com/aspnet/Routing/blob/dev/src/Microsoft.AspNetCore.Routing/Constraints/HttpMethodRouteConstraint.cs) when [defining non-attribute routes](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/routing) to allow both the desired "regular" HTTP method, plus also the OPTIONS HTTP method. 
+It's also possible to define routes using [HttpMethodRouteConstraint](/dotnet/api/microsoft.aspnetcore.routing.constraints.httpmethodrouteconstraint) when [defining non-attribute routes](xref:fundamentals/routing) to enforce the desired regular HTTP method and the OPTIONS HTTP method. 
 
 ### Globally
 


### PR DESCRIPTION
aspnet/Docs/#6447 add notes about conflict between `[HttpPost]` and `[EnableCors]`

  Fixes aspnet/Docs#6447

