### PR TITLE
Create a "What's new" ToC node

### DIFF
--- a/aspnetcore/aspnetcore-2.0.md
+++ b/aspnetcore/aspnetcore-2.0.md
@@ -3,7 +3,7 @@ title: What's new in ASP.NET Core 2.0
 author: rick-anderson
 description: Learn about the new features in ASP.NET Core 2.0.
 manager: wpickett
-monikerRange: '>= aspnetcore-2.0'
+monikerRange: '= aspnetcore-2.0'
 ms.author: riande
 ms.date: 07/10/2017
 ms.prod: aspnet-core

--- a/aspnetcore/aspnetcore-2.1.md
+++ b/aspnetcore/aspnetcore-2.1.md
@@ -3,7 +3,7 @@ title: What's new in ASP.NET Core 2.1
 author: isaac2004
 description: Learn about the new features in ASP.NET Core 2.1.
 manager: wpickett
-monikerRange: '>= aspnetcore-2.1'
+monikerRange: '= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
 ms.date: 5/29/2018

--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -1,3 +1,5 @@
+# [What's new](xref:aspnetcore-2.1)
+
 # [Introduction](index.md)
 
 # [Get started](getting-started.md)
@@ -362,7 +364,6 @@
 
 # [Migration](xref:migration/index)
 ## [ASP.NET Core 2.0 to 2.1](xref:migration/20_21)
-## [What's new in ASP.NET Core 2.1](xref:aspnetcore-2.1)
 ## [ASP.NET to ASP.NET Core](xref:migration/proper-to-2x/index)
 ### [MVC](xref:migration/mvc)
 ### [Web API](xref:migration/webapi)

--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -1,6 +1,8 @@
 # [Introduction](index.md)
 
 # [What's new](xref:aspnetcore-2.1)
+# [What's new](xref:aspnetcore-2.0)
+# [What's new](xref:aspnetcore-1.1)
 
 # [Get started](getting-started.md)
 ## [Create a web app](xref:mvc/razor-pages/index)
@@ -375,11 +377,6 @@
 ## [ASP.NET Core 1.x to 2.0](xref:migration/1x-to-2x/index)
 ### [Authentication and Identity](xref:migration/1x-to-2x/identity-2x)
 
-# [API Reference](/dotnet/api/?view=aspnetcore-2.0)
-
-# [2.0 release notes](aspnetcore-2.0.md)
-## [1.1 release notes](aspnetcore-1.1.md)
-## [Earlier release notes](https://github.com/aspnet/home/releases)
-## [VS 2015/project.json docs](https://docs.microsoft.com/dotnet/articles/project-json)
+# [API reference](/dotnet/api/?view=aspnetcore-2.0)
 
 # [Contribute](https://github.com/aspnet/Docs/blob/master/CONTRIBUTING.md)

--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -1,6 +1,6 @@
-# [What's new](xref:aspnetcore-2.1)
-
 # [Introduction](index.md)
+
+# [What's new](xref:aspnetcore-2.1)
 
 # [Get started](getting-started.md)
 ## [Create a web app](xref:mvc/razor-pages/index)


### PR DESCRIPTION
Per Dan, create a top-level "What's new" ToC node. This node will ONLY display when version 2.1 is selected. Also, convert the release notes links into "What's new" links. The two external release notes links can be removed.

**Internal Review Pages**
[2.1](https://review.docs.microsoft.com/en-us/aspnet/core/?view=aspnetcore-2.1&branch=pr-en-us-6690)
[2.0](https://review.docs.microsoft.com/en-us/aspnet/core/?view=aspnetcore-2.0&branch=pr-en-us-6690)
[1.1](https://review.docs.microsoft.com/en-us/aspnet/core/?view=aspnetcore-1.1&branch=pr-en-us-6690)