### PR TITLE
Remove RC1 text from 2.1 SDK download link

### DIFF
--- a/aspnetcore/includes/2.1-SDK.md
+++ b/aspnetcore/includes/2.1-SDK.md
@@ -1,1 +1,1 @@
-[.NET Core SDK 2.1 RC1 or later](https://www.microsoft.com/net/download/all)
+[.NET Core SDK 2.1 or later](https://www.microsoft.com/net/download/all)


### PR DESCRIPTION
Addresses https://github.com/aspnet/Docs/issues/6700

Now that 2.1 has released, the RC1 text should be removed from the download link.