### PR TITLE
Repair Enforcing SSL topic moniker range

### DIFF
--- a/aspnetcore/mvc/razor-pages/ui-class.md
+++ b/aspnetcore/mvc/razor-pages/ui-class.md
@@ -183,8 +183,6 @@ Run the app.
 
 Create a Razor Pages web app and a solution file containing the Razor Pages app and the Razor Class Library:
 
-::: moniker range=">= aspnetcore-2.1"
-
 ```console
 dotnet new webapp -o WebApp1
 dotnet new sln
@@ -192,20 +190,6 @@ dotnet sln add WebApp1
 dotnet sln add RazorUIClassLib
 dotnet add WebApp1 reference RazorUIClassLib
 ```
-
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.0"
-
-```console
-dotnet new razor -o WebApp1
-dotnet new sln
-dotnet sln add WebApp1
-dotnet sln add RazorUIClassLib
-dotnet add WebApp1 reference RazorUIClassLib
-```
-
-::: moniker-end
 
 Build and run the web app:
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -112,21 +112,9 @@ Uncheck the **Configure for HTTPS** checkbox.
 
 Use the `--no-https` option. For example
 
-::: moniker range=">= aspnetcore-2.1"
-
 ```console
 dotnet new webapp --no-https
 ```
-
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.0"
-
-```console
-dotnet new razor --no-https
-```
-
-::: moniker-end
 
 ---
 

--- a/aspnetcore/signalr/get-started.md
+++ b/aspnetcore/signalr/get-started.md
@@ -75,21 +75,9 @@ Visual Studio includes the `Microsoft.AspNetCore.SignalR` package containing its
 
 1. From the **Integrated Terminal**, run the following command:
 
-::: moniker range=">= aspnetcore-2.1"
-
     ```console
     dotnet new webapp -o SignalRChat
     ```
-
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.0"
-
-    ```console
-    dotnet new razor -o SignalRChat
-    ```
-
-::: moniker-end
 
 2. Install the JavaScript client library using *npm*.
 


### PR DESCRIPTION
The original changes for these three topics were safe because the `dotnet new` commands were either already inside a moniker-range for 2.1+ or the whole topic was set for 2.1+.