### PR TITLE
Fixing client method return type

### DIFF
--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample12.cs
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample12.cs
@@ -1,12 +1,12 @@
 public class StrongHub : Hub<IClient>
 {
-    public void Send(string message)
+    public async Task Send(string message)
     {
-        Clients.All.NewMessage(message);
+        await Clients.All.NewMessage(message);
     }
 }
 
 public interface IClient
 {
-    void NewMessage(string message);
+    Task NewMessage(string message);
 }


### PR DESCRIPTION
With this sample for strongly typed hub, we get the error "All client proxy methods must return 'System.Threading.Tasks.Task'"

This PR fixes that error.