### PR TITLE
Change .NET Core SDK version text when 2.1 is selected

### DIFF
--- a/aspnetcore/getting-started.md
+++ b/aspnetcore/getting-started.md
@@ -15,7 +15,7 @@ uid: getting-started
 
 ::: moniker range=">= aspnetcore-2.1"
 
-1. Install the [!INCLUDE[](~/includes/net-core-sdk-download-link.md)].
+1. Install the [!INCLUDE[](~/includes/2.1-SDK.md)].
 
 2. Create a new .NET Core project.
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/Docs/issues/6700

[Internal Review Page](https://review.docs.microsoft.com/en-us/aspnet/core/getting-started?branch=pr-en-us-6748&view=aspnetcore-2.1)