### PR TITLE
Update sample apps to 2.1 RTM

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/TagHelpersBuiltIn.csproj
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/TagHelpersBuiltIn.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/web-api/action-return-types/samples/WebApiSample.Api.21/WebApiSample.Api.21.csproj
+++ b/aspnetcore/web-api/action-return-types/samples/WebApiSample.Api.21/WebApiSample.Api.21.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
   </ItemGroup>
 

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/WebApiSample.Api.csproj
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.Api/WebApiSample.Api.csproj
@@ -6,12 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="WebApiSample.Api.csproj~RF6388722.TMP" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App"  />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Addresses https://github.com/aspnet/Docs/issues/5495

Updates 2 web API samples and a Partial Tag Helper sample from 2.1 RC1 to 2.1 RTM.