### PR TITLE
Move env var config down in Generic Host sample

### DIFF
--- a/aspnetcore/fundamentals/host/generic-host/samples/2.x/GenericHostSample/Program.cs
+++ b/aspnetcore/fundamentals/host/generic-host/samples/2.x/GenericHostSample/Program.cs
@@ -14,18 +14,18 @@ namespace GenericHostSample
             var host = new HostBuilder()
                 .ConfigureHostConfiguration(configHost =>
                 {
-                    configHost.AddEnvironmentVariables(prefix: "ASPNETCORE_");
                     configHost.SetBasePath(Directory.GetCurrentDirectory());
                     configHost.AddJsonFile("hostsettings.json", optional: true);
+                    configHost.AddEnvironmentVariables(prefix: "ASPNETCORE_");
                     configHost.AddCommandLine(args);
                 })
                 .ConfigureAppConfiguration((hostContext, configApp) =>
                 {
-                    configApp.AddEnvironmentVariables(prefix: "ASPNETCORE_");
                     configApp.AddJsonFile("appsettings.json", optional: true);
                     configApp.AddJsonFile(
                         $"appsettings.{hostContext.HostingEnvironment.EnvironmentName}.json", 
                         optional: true);
+                    configApp.AddEnvironmentVariables(prefix: "ASPNETCORE_");
                     configApp.AddCommandLine(args);
                 })
                 .ConfigureServices((hostContext, services) =>


### PR DESCRIPTION
Fixes #6765 
Cross-ref: https://github.com/aspnet/Hosting/issues/1440#issuecomment-393698716

More closely matches `CreateDefaultBuilder` for the Web Host, where settings files go first, then env vars, followed by command line args.

cc/ @chrisckc