### PR TITLE
Fix link to metapackage

### DIFF
--- a/aspnetcore/fundamentals/metapackage.md
+++ b/aspnetcore/fundamentals/metapackage.md
@@ -15,7 +15,7 @@ uid: fundamentals/metapackage
 # Microsoft.AspNetCore.All metapackage for ASP.NET Core 2.0
 
 > [!NOTE]
-> We recommend applications targeting ASP.NET Core 2.1 and later use the [Microsoft.AspNetCore.App](xref:fundamentals/metapackage) rather than this package. See [Migrating from Microsoft.AspNetCore.All to Microsoft.AspNetCore.App](#migrate) in this article.
+> We recommend applications targeting ASP.NET Core 2.1 and later use the [Microsoft.AspNetCore.App](xref:fundamentals/metapackage-app) rather than this package. See [Migrating from Microsoft.AspNetCore.All to Microsoft.AspNetCore.App](#migrate) in this article.
 
 This feature requires ASP.NET Core 2.x targeting .NET Core 2.x.
 


### PR DESCRIPTION
The link in the note that was supposed to be to the new metapackage was instead to the same page that contained the note.