### PR TITLE
Enforce HTTPS update

### DIFF
--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -192,13 +192,15 @@ ASP.NET Core ships with the following middleware components, as well as a descri
 | [CORS](xref:security/cors) | Configures Cross-Origin Resource Sharing. | Before components that use CORS. |
 | [Diagnostics](xref:fundamentals/error-handling) | Configures diagnostics. | Before components that generate errors. |
 | [ForwardedHeaders/HttpOverrides](/dotnet/api/microsoft.aspnetcore.builder.forwardedheadersextensions) | Forwards proxied headers onto the current request. | Before components that consume the updated fields (examples: Scheme, Host, ClientIP, Method). |
+| [HTTPS Redirection Middleware](xref:security/enforcing-ssl#require-https) | Redirect all HTTP requests to HTTPS (ASP.NET Core 2.1 or later). | Before components that consume the URL. |
+| [HTTP Strict Transport Security (HSTS) Middleware](xref:security/enforcing-ssl#http-strict-transport-security-protocol-hsts) | Security enhancement middleware (ASP.NET Core 2.1 or later). | Before components that consume the URL. When called with HTTPS Redirection Middleware, call HSTS Middleware before [UseHttpsRedirection](/dotnet/api/microsoft.aspnetcore.builder.httpspolicybuilderextensions.usehttpsredirection). |
 | [Response Caching](xref:performance/caching/middleware) | Provides support for caching responses. | Before components that require caching. |
 | [Response Compression](xref:performance/response-compression) | Provides support for compressing responses. | Before components that require compression. |
 | [RequestLocalization](xref:fundamentals/localization) | Provides localization support. | Before localization sensitive components. |
 | [Routing](xref:fundamentals/routing) | Defines and constrains request routes. | Terminal for matching routes. |
 | [Session](xref:fundamentals/app-state) | Provides support for managing user sessions. | Before components that require Session. |
 | [Static Files](xref:fundamentals/static-files) | Provides support for serving static files and directory browsing. | Terminal if a request matches files. |
-| [URL Rewriting ](xref:fundamentals/url-rewriting) | Provides support for rewriting URLs and redirecting requests. | Before components that consume the URL. |
+| [URL Rewriting](xref:fundamentals/url-rewriting) | Provides support for rewriting URLs and redirecting requests. | Before components that consume the URL. |
 | [WebSockets](xref:fundamentals/websockets) | Enables the WebSockets protocol. | Before components that are required to accept WebSocket requests. |
 
 <a name="middleware-writing-middleware"></a>

--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -191,12 +191,12 @@ ASP.NET Core ships with the following middleware components, as well as a descri
 | [Authentication](xref:security/authentication/identity) | Provides authentication support. | Before `HttpContext.User` is needed. Terminal for OAuth callbacks. |
 | [CORS](xref:security/cors) | Configures Cross-Origin Resource Sharing. | Before components that use CORS. |
 | [Diagnostics](xref:fundamentals/error-handling) | Configures diagnostics. | Before components that generate errors. |
-| [ForwardedHeaders/HttpOverrides](/dotnet/api/microsoft.aspnetcore.builder.forwardedheadersextensions) | Forwards proxied headers onto the current request. | Before components that consume the updated fields (examples: Scheme, Host, ClientIP, Method). |
-| [HTTPS Redirection Middleware](xref:security/enforcing-ssl#require-https) | Redirect all HTTP requests to HTTPS (ASP.NET Core 2.1 or later). | Before components that consume the URL. |
-| [HTTP Strict Transport Security (HSTS) Middleware](xref:security/enforcing-ssl#http-strict-transport-security-protocol-hsts) | Security enhancement middleware (ASP.NET Core 2.1 or later). | Before components that consume the URL. When called with HTTPS Redirection Middleware, call HSTS Middleware before [UseHttpsRedirection](/dotnet/api/microsoft.aspnetcore.builder.httpspolicybuilderextensions.usehttpsredirection). |
+| [Forwarded Headers/HTTP Overrides](/dotnet/api/microsoft.aspnetcore.builder.forwardedheadersextensions) | Forwards proxied headers onto the current request. | Before components that consume the updated fields (examples: Scheme, Host, ClientIP, Method). |
+| [HTTPS Redirection](xref:security/enforcing-ssl#require-https) | Redirect all HTTP requests to HTTPS (ASP.NET Core 2.1 or later). | Before components that consume the URL. |
+| [HTTP Strict Transport Security (HSTS)](xref:security/enforcing-ssl#http-strict-transport-security-protocol-hsts) | Security enhancement middleware that adds a special response header (ASP.NET Core 2.1 or later). | Before responses are sent and after components that modify requests (for example, Forwarded Headers, URL Rewriting). |
 | [Response Caching](xref:performance/caching/middleware) | Provides support for caching responses. | Before components that require caching. |
 | [Response Compression](xref:performance/response-compression) | Provides support for compressing responses. | Before components that require compression. |
-| [RequestLocalization](xref:fundamentals/localization) | Provides localization support. | Before localization sensitive components. |
+| [Request Localization](xref:fundamentals/localization) | Provides localization support. | Before localization sensitive components. |
 | [Routing](xref:fundamentals/routing) | Defines and constrains request routes. | Terminal for matching routes. |
 | [Session](xref:fundamentals/app-state) | Provides support for managing user sessions. | Before components that require Session. |
 | [Static Files](xref:fundamentals/static-files) | Provides support for serving static files and directory browsing. | Terminal if a request matches files. |

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -40,6 +40,8 @@ The following code calls [AddHttpsRedirection](/dotnet/api/microsoft.aspnetcore.
 
 [!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet2&highlight=14-99)]
 
+The preceding highlighted code:
+
 * Sets [HttpsRedirectionOptions.RedirectStatusCode](/dotnet/api/microsoft.aspnetcore.httpspolicy.httpsredirectionoptions.redirectstatuscode).
 * Sets the HTTPS port to 5001.
 
@@ -55,12 +57,12 @@ The following mechanisms set the port automatically:
 > [!NOTE]
 > When an app is run behind a reverse proxy (for example, IIS, IIS Express), `IServerAddressesFeature` isn't available. The port must be manually configured.
 
-The port is configured manually using any of the following approaches:
+The port can be configured by setting the:
 
-* The `ASPNETCORE_HTTPS_PORT` environment variable is set.
-* The URL is set with the `ASPNETCORE_URLS` environment variable.
-* The `http_port` host configuration key is set (for example, via *hostsettings.json* or a command line argument).
-* The [HttpsRedirectionOptions.HttpsPort](/dotnet/api/microsoft.aspnetcore.httpspolicy.httpsredirectionoptions.httpsport) is set. See the preceding example that shows how to set the port to 5001.
+* `ASPNETCORE_HTTPS_PORT` environment variable.
+* URL with the `ASPNETCORE_URLS` environment variable.
+* `http_port` host configuration key (for example, via *hostsettings.json* or a command line argument).
+* [HttpsRedirectionOptions.HttpsPort](/dotnet/api/microsoft.aspnetcore.httpspolicy.httpsredirectionoptions.httpsport). See the preceding example that shows how to set the port to 5001.
 
 If no port is set:
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -55,7 +55,7 @@ The following mechanisms set the port automatically:
   - *launchSettings.json* sets the `sslPort` for IIS Express.
 
 > [!NOTE]
-> When an app is run behind a reverse proxy (for example, IIS, IIS Express), `IServerAddressesFeature` isn't available. The port must be manually configured.
+> When an app is run behind a reverse proxy (for example, IIS, IIS Express), `IServerAddressesFeature` isn't available. The port must be manually configured. When the port isn't set, requests aren't redirected.
 
 The port can be configured by setting the:
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -55,7 +55,7 @@ The following mechanisms set the port automatically:
 > [!NOTE]
 > When an app is run behind a reverse proxy (for example, IIS, IIS Express), `IServerAddressesFeature` isn't available. The port must be manually configured.
 
-The port is configured manually via the following approaches:
+The port is configured manually using any of the following approaches:
 
 * The `ASPNETCORE_HTTPS_PORT` environment variable is set.
 * The `http_port` host configuration key is set (for example, via *hostsettings.json* or a command line argument).

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -60,15 +60,16 @@ The following mechanisms set the port automatically:
 The port can be configured by setting the:
 
 * `ASPNETCORE_HTTPS_PORT` environment variable.
-* URL with the `ASPNETCORE_URLS` environment variable.
 * `http_port` host configuration key (for example, via *hostsettings.json* or a command line argument).
 * [HttpsRedirectionOptions.HttpsPort](/dotnet/api/microsoft.aspnetcore.httpspolicy.httpsredirectionoptions.httpsport). See the preceding example that shows how to set the port to 5001.
+
+> [!NOTE]
+> The port can be configured indirectly by setting the URL with the `ASPNETCORE_URLS` environment variable. The environment variable configures the server, and then the middleware indirectly discovers the HTTPS port via `IServerAddressesFeature`.
 
 If no port is set:
 
 * Requests aren't redirected.
 * The middleware logs a warning.
-* The middleware is disabled.
 
 ::: moniker-end
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -48,8 +48,8 @@ The following mechanisms set the port automatically:
 * The middleware can discover the ports via [IServerAddressesFeature](/dotnet/api/microsoft.aspnetcore.hosting.server.features.iserveraddressesfeature) when the following conditions apply:
   - Kestrel or HTTP.sys is used directly with HTTPS endpoints.
   - Only **one port** is used by the app.
-* Visual Studio is used with:
-  - The `ASPNETCORE_HTTPS_PORT` environment variable set.
+* Visual Studio is used:
+  - *launchSettings.json* sets the `ASPNETCORE_HTTPS_PORT` environment variable.
   - IIS Express has HTTPS enabled.
 
 > [!NOTE]

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -1,5 +1,5 @@
 ---
-title: Enforce HTTPS in an ASP.NET Core
+title: Enforce HTTPS in ASP.NET Core
 author: rick-anderson
 description: Shows how to require HTTPS/TLS in a ASP.NET Core web app.
 manager: wpickett
@@ -10,45 +10,56 @@ ms.technology: aspnet
 ms.topic: article
 uid: security/enforcing-ssl
 ---
-# Enforce HTTPS in an ASP.NET Core
+# Enforce HTTPS in ASP.NET Core
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
 This document shows how to:
 
-- Require HTTPS for all requests.
-- Redirect all HTTP requests to HTTPS.
+* Require HTTPS for all requests.
+* Redirect all HTTP requests to HTTPS.
 
 > [!WARNING]
-> Do **not** use `RequireHttpsAttribute` on Web APIs that receive sensitive information. `RequireHttpsAttribute` uses HTTP status codes to redirect browsers from HTTP to HTTPS. API clients may not understand or obey redirects from HTTP to HTTPS. Such clients may send information over HTTP. Web APIs should either:
+> Do **not** use [RequireHttpsAttribute](/dotnet/api/microsoft.aspnetcore.mvc.requirehttpsattribute) on Web APIs that receive sensitive information. `RequireHttpsAttribute` uses HTTP status codes to redirect browsers from HTTP to HTTPS. API clients may not understand or obey redirects from HTTP to HTTPS. Such clients may send information over HTTP. Web APIs should either:
 >
->* Not listen on HTTP.
->* Close the connection with status code 400 (Bad Request) and not serve the request.
+> * Not listen on HTTP.
+> * Close the connection with status code 400 (Bad Request) and not serve the request.
 
 <a name="require"></a>
 ## Require HTTPS
 
 ::: moniker range=">= aspnetcore-2.1"
-We recommend all ASP.NET Core web apps call `UseHttpsRedirection` to redirect all HTTP requests to HTTPS. If `UseHsts` is called in the app, it must be called before `UseHttpsRedirection`.
+
+We recommend all ASP.NET Core web apps call HTTPS Redirection Middleware ([UseHttpsRedirection](/dotnet/api/microsoft.aspnetcore.builder.httpspolicybuilderextensions.usehttpsredirection)) to redirect all HTTP requests to HTTPS. If HTTP Strict Transport Security (HSTS) Middleware ([UseHsts](/dotnet/api/microsoft.aspnetcore.builder.hstsbuilderextensions.usehsts)) is called in the app, it must be called before `UseHttpsRedirection`.
 
 The following code calls `UseHttpsRedirection` in the `Startup` class:
 
-[!code-csharp[sample](enforcing-ssl/sample/Startup.cs?name=snippet1&highlight=13)]
+[!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet1&highlight=13)]
 
+The following code calls [AddHttpsRedirection](/dotnet/api/microsoft.aspnetcore.builder.httpsredirectionservicesextensions.addhttpsredirection) to configure middleware options:
 
-The following code:
+[!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet2&highlight=14-99)]
 
-[!code-csharp[sample](enforcing-ssl/sample/Startup.cs?name=snippet2&highlight=14-99)]
-
-* Sets `RedirectStatusCode`.
+* Sets [HttpsRedirectionOptions.RedirectStatusCode](/dotnet/api/microsoft.aspnetcore.httpspolicy.httpsredirectionoptions.redirectstatuscode).
 * Sets the HTTPS port to 5001.
+
+To specify an HTTPS port:
+
+* Set [HttpsRedirectionOptions.HttpsPort](/dotnet/api/microsoft.aspnetcore.httpspolicy.httpsredirectionoptions.httpsport). See the preceding example that shows how to set the port to 5001.
+* Set the `HTTPS_PORT` environment variable.
+* The middleware uses the port or ports defined by [IServerAddressesFeature.Addresses](/dotnet/api/microsoft.aspnetcore.hosting.server.features.iserveraddressesfeature.addresses).
+
+If no port is set:
+
+* Requests aren't redirected.
+* The middleware logs a warning.
+* The middleware is disabled.
 
 ::: moniker-end
 
-
 ::: moniker range="< aspnetcore-2.1"
 
-The [RequireHttpsAttribute](/dotnet/api/Microsoft.AspNetCore.Mvc.RequireHttpsAttribute) is used to require HTTPS. `[RequireHttpsAttribute]` can decorate controllers or methods, or can be applied globally. To apply the attribute globally, add the following code to `ConfigureServices` in `Startup`:
+The [RequireHttpsAttribute](/dotnet/api/microsoft.aspnetcore.mvc.requirehttpsattribute) is used to require HTTPS. `[RequireHttpsAttribute]` can decorate controllers or methods, or can be applied globally. To apply the attribute globally, add the following code to `ConfigureServices` in `Startup`:
 
 [!code-csharp[](authentication/accconfirm/sample/WebApp1/Startup.cs?name=snippet2&highlight=4-999)]
 
@@ -64,6 +75,7 @@ Requiring HTTPS globally (`options.Filters.Add(new RequireHttpsAttribute());`) i
 ::: moniker-end
 
 ::: moniker range=">= aspnetcore-2.1"
+
 <a name="hsts"></a>
 ## HTTP Strict Transport Security Protocol (HSTS)
 
@@ -71,13 +83,13 @@ Per [OWASP](https://www.owasp.org/index.php/About_The_Open_Web_Application_Secur
 
 ASP.NET Core 2.1 or later implements HSTS with the `UseHsts` extension method. The following code calls `UseHsts` when the app isn't in [development mode](xref:fundamentals/environments):
 
-[!code-csharp[sample](enforcing-ssl/sample/Startup.cs?name=snippet1&highlight=10)]
+[!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet1&highlight=10)]
 
 `UseHsts` is not recommend in development because the HSTS header is highly cachable by browsers. By default, UseHsts excludes the local loopback address.
 
 The following code:
 
-[!code-csharp[sample](enforcing-ssl/sample/Startup.cs?name=snippet2&highlight=5-12)]
+[!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet2&highlight=5-12)]
 
 * Sets the preload parameter of the Strict-Transport-Security header. Preload is not part of the [RFC HSTS specification](https://tools.ietf.org/html/rfc6797), but is supported by web browsers to preload HSTS sites on fresh install. See [https://hstspreload.org/](https://hstspreload.org/) for more information.
 * Enables [includeSubDomain](https://tools.ietf.org/html/rfc6797#section-6.1.2), which applies the HSTS policy to Host subdomains. 
@@ -93,12 +105,12 @@ The following code:
 The preceding example shows how to add additional hosts.
 ::: moniker-end
 
-
 ::: moniker range=">= aspnetcore-2.1"
+
 <a name="https"></a>
 ## Opt-out of HTTPS on project creation
 
-The ASP.NET Core 2.1 and later web application templates (from Visual Studio or the dotnet command line) enable [HTTPS redirection](#require) and [HSTS](#hsts). For deployments that don't require HTTPS, you can opt-out of HTTPS. For example, some backend services where HTTPS is being handled externally at the edge, using HTTPS at each node is not needed.
+The ASP.NET Core 2.1 or later web application templates (from Visual Studio or the dotnet command line) enable [HTTPS redirection](#require) and [HSTS](#hsts). For deployments that don't require HTTPS, you can opt-out of HTTPS. For example, some backend services where HTTPS is being handled externally at the edge, using HTTPS at each node is not needed.
 
 To opt-out of HTTPS:
 
@@ -121,6 +133,7 @@ dotnet new webapp --no-https
 ::: moniker-end
 
 ::: moniker range=">= aspnetcore-2.1"
+
 ## How to setup a developer certificate for Docker
 
 See [this GitHub issue](https://github.com/aspnet/Docs/issues/6199).

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -49,7 +49,7 @@ The following mechanisms set the port automatically:
 
 * The middleware can discover the ports via [IServerAddressesFeature](/dotnet/api/microsoft.aspnetcore.hosting.server.features.iserveraddressesfeature) when the following conditions apply:
   - Kestrel or HTTP.sys is used directly with HTTPS endpoints (also applies to running the app with Visual Studio Code's debugger).
-  - Only **one port** is used by the app.
+  - Only **one HTTPS port** is used by the app.
 * Visual Studio is used:
   - IIS Express has HTTPS enabled.
   - *launchSettings.json* sets the `sslPort` for IIS Express.

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -46,7 +46,7 @@ The following code calls [AddHttpsRedirection](/dotnet/api/microsoft.aspnetcore.
 The following mechanisms set the port automatically:
 
 * The middleware can discover the ports via [IServerAddressesFeature](/dotnet/api/microsoft.aspnetcore.hosting.server.features.iserveraddressesfeature) when the following conditions apply:
-  - Kestrel or HTTP.sys is used directly with HTTPS endpoints.
+  - Kestrel or HTTP.sys is used directly with HTTPS endpoints (also applies to running the app with Visual Studio Code's debugger).
   - Only **one port** is used by the app.
 * Visual Studio is used:
   - *launchSettings.json* sets the `ASPNETCORE_HTTPS_PORT` environment variable.

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -49,8 +49,8 @@ The following mechanisms set the port automatically:
   - Kestrel or HTTP.sys is used directly with HTTPS endpoints (also applies to running the app with Visual Studio Code's debugger).
   - Only **one port** is used by the app.
 * Visual Studio is used:
-  - *launchSettings.json* sets the `ASPNETCORE_HTTPS_PORT` environment variable.
   - IIS Express has HTTPS enabled.
+  - *launchSettings.json* sets the `sslPort` for IIS Express.
 
 > [!NOTE]
 > When an app is run behind a reverse proxy (for example, IIS, IIS Express), `IServerAddressesFeature` isn't available. The port must be manually configured.
@@ -58,6 +58,7 @@ The following mechanisms set the port automatically:
 The port is configured manually using any of the following approaches:
 
 * The `ASPNETCORE_HTTPS_PORT` environment variable is set.
+* The URL is set with the `ASPNETCORE_URLS` environment variable.
 * The `http_port` host configuration key is set (for example, via *hostsettings.json* or a command line argument).
 * The [HttpsRedirectionOptions.HttpsPort](/dotnet/api/microsoft.aspnetcore.httpspolicy.httpsredirectionoptions.httpsport) is set. See the preceding example that shows how to set the port to 5001.
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -30,7 +30,7 @@ This document shows how to:
 
 ::: moniker range=">= aspnetcore-2.1"
 
-We recommend all ASP.NET Core web apps call HTTPS Redirection Middleware ([UseHttpsRedirection](/dotnet/api/microsoft.aspnetcore.builder.httpspolicybuilderextensions.usehttpsredirection)) to redirect all HTTP requests to HTTPS. If HTTP Strict Transport Security (HSTS) Middleware ([UseHsts](/dotnet/api/microsoft.aspnetcore.builder.hstsbuilderextensions.usehsts)) is called in the app, it must be called before `UseHttpsRedirection`.
+We recommend all ASP.NET Core web apps call HTTPS Redirection Middleware ([UseHttpsRedirection](/dotnet/api/microsoft.aspnetcore.builder.httpspolicybuilderextensions.usehttpsredirection)) to redirect all HTTP requests to HTTPS.
 
 The following code calls `UseHttpsRedirection` in the `Startup` class:
 
@@ -43,11 +43,23 @@ The following code calls [AddHttpsRedirection](/dotnet/api/microsoft.aspnetcore.
 * Sets [HttpsRedirectionOptions.RedirectStatusCode](/dotnet/api/microsoft.aspnetcore.httpspolicy.httpsredirectionoptions.redirectstatuscode).
 * Sets the HTTPS port to 5001.
 
-To specify an HTTPS port:
+The following mechanisms set the port automatically:
 
-* Set [HttpsRedirectionOptions.HttpsPort](/dotnet/api/microsoft.aspnetcore.httpspolicy.httpsredirectionoptions.httpsport). See the preceding example that shows how to set the port to 5001.
-* Set the `HTTPS_PORT` environment variable.
-* The middleware uses the port or ports defined by [IServerAddressesFeature.Addresses](/dotnet/api/microsoft.aspnetcore.hosting.server.features.iserveraddressesfeature.addresses).
+* The middleware can discover the ports via [IServerAddressesFeature](/dotnet/api/microsoft.aspnetcore.hosting.server.features.iserveraddressesfeature) when the following conditions apply:
+  - Kestrel or HTTP.sys is used directly with HTTPS endpoints.
+  - Only **one port** is used by the app.
+* Visual Studio is used with:
+  - The `ASPNETCORE_HTTPS_PORT` environment variable set.
+  - IIS Express has HTTPS enabled.
+
+> [!NOTE]
+> When an app is run behind a reverse proxy (for example, IIS, IIS Express), `IServerAddressesFeature` isn't available. The port must be manually configured.
+
+The port is configured manually via the following approaches:
+
+* The `ASPNETCORE_HTTPS_PORT` environment variable is set.
+* The `http_port` host configuration key is set (for example, via *hostsettings.json* or a command line argument).
+* The [HttpsRedirectionOptions.HttpsPort](/dotnet/api/microsoft.aspnetcore.httpspolicy.httpsredirectionoptions.httpsport) is set. See the preceding example that shows how to set the port to 5001.
 
 If no port is set:
 


### PR DESCRIPTION
Fixes #6792 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-1.0&branch=pr-en-us-6793)

One thing right off the bat. The third entry is *terribad* ...

> To specify an HTTPS port:
>
> * Set [HttpsRedirectionOptions.HttpsPort](/dotnet/api/microsoft.aspnetcore.httpspolicy.httpsredirectionoptions.httpsport). See the preceding example that shows how to set the port to 5001.
> * Set the `HTTPS_PORT` environment variable.
> * The middleware uses the port or ports defined by [IServerAddressesFeature.Addresses](/dotnet/api/microsoft.aspnetcore.hosting.server.features.iserveraddressesfeature.addresses).

What should it say about port discovery from the `IServerAddressesFeature.Addresses`?

cc/ @k3davis