### PR TITLE
C19396: Missing hyperlink due to incorrect redenring

### DIFF
--- a/aspnet/mvc/overview/security/create-an-aspnet-mvc-5-app-with-facebook-and-google-oauth2-and-openid-sign-on.md
+++ b/aspnet/mvc/overview/security/create-an-aspnet-mvc-5-app-with-facebook-and-google-oauth2-and-openid-sign-on.md
@@ -169,7 +169,7 @@ For Facebook OAuth2 authentication, you need to copy to your project some settin
     ![Create new app](create-an-aspnet-mvc-5-app-with-facebook-and-google-oauth2-and-openid-sign-on/_static/image22.png)
 4. Enter an **App Name** and **Category**, then click **Create App**.
 
-    This must be unique across Facebook. The <strong>App Namespace</strong> is the part of the URL that your App will use to access the Facebook application for authentication (for example, https://apps.facebook.com/{App Namespace}). If you don't specify an <strong>App Namespace</strong>, the <strong>App ID</strong> will be used for the URL. The <strong>App ID</strong> is a long system-generated number that you will see in the next step.
+    The <strong>App Namespace</strong> is the part of the URL that your App will use to access the Facebook application for authentication (for example, https\://apps.facebook.com/{App Namespace}). If you don't specify an <strong>App Namespace</strong>, the <strong>App ID</strong> will be used for the URL. The <strong>App ID</strong> is a long system-generated number that you will see in the next step.
 
     ![Create New App dialog](create-an-aspnet-mvc-5-app-with-facebook-and-google-oauth2-and-openid-sign-on/_static/image23.png)
 5. Submit the standard security check.


### PR DESCRIPTION
Hello, @Rick-Anderson,

Localization team has reported source content issue that causes localized version to have broken format compared to en-us version.  
From the context of this source string, we can assume that writer did not intend this example URL to be rendered as hyperlink, and that text "App Namespace" within brackets {} is expected to be translated.

We found out that OPS is using a Markdig flavor called "Markdig (DocFX)" which does render URL surrounded by space to be rendered as hyperlink. 

To avoid this, suggested fix to source string is add an escape char (\) to part of the URL.
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.

Many thanks in advance.

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
