### PR TITLE
missing capture group in regex

### DIFF
--- a/aspnetcore/host-and-deploy/linux-apache.md
+++ b/aspnetcore/host-and-deploy/linux-apache.md
@@ -403,7 +403,7 @@ In the configuration file shown below, an additional instance of the `hellomvc` 
 <VirtualHost *:80>
     RewriteEngine On
     RewriteCond %{HTTPS} !=on
-    RewriteRule ^/?(.*) https://%{SERVER_NAME}/ [R,L]
+    RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/aspnetcore/host-and-deploy/linux-apache.md
+++ b/aspnetcore/host-and-deploy/linux-apache.md
@@ -319,7 +319,7 @@ Modify the *hellomvc.conf* file to enable URL rewriting and secure communication
 <VirtualHost *:80>
     RewriteEngine On
     RewriteCond %{HTTPS} !=on
-    RewriteRule ^/?(.*) https://%{SERVER_NAME}/ [R,L]
+    RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
 </VirtualHost>
 
 <VirtualHost *:443>


### PR DESCRIPTION
The URI captured was not re-added in the regex replacement. See [example](https://wiki.apache.org/httpd/RewriteHTTPToHTTPS). I also tested this in Apache to confirm. 