### PR TITLE
Update razor-pa

### DIFF
--- a/aspnetcore/tutorials/razor-pages-vsc/razor-pages-start.md
+++ b/aspnetcore/tutorials/razor-pages-vsc/razor-pages-start.md
@@ -28,7 +28,7 @@ From a terminal, run the following commands:
 ::: moniker range=">= aspnetcore-2.1"
 
 ```console
-dotnet new webapp -o RazorPagesMovie
+dotnet new web -o RazorPagesMovie
 cd RazorPagesMovie
 dotnet run
 ```


### PR DESCRIPTION

  > change from webapp to web, as there is no template with name in dotnet core version 2.1.2