### PR TITLE
Add webapp alias notice

### DIFF
--- a/aspnetcore/getting-started.md
+++ b/aspnetcore/getting-started.md
@@ -23,6 +23,8 @@ uid: getting-started
     dotnet new webapp -o aspnetcoreapp
     ```
 
+    [!INCLUDE[](~/includes/webapp-alias-notice.md)]
+
 3. Trust the HTTPS development certificate:
 
 # [Windows](#tab/windows)

--- a/aspnetcore/includes/webapp-alias-notice.md
+++ b/aspnetcore/includes/webapp-alias-notice.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> With the release of ASP.NET Core 2.1, `webapp` replaces the `razor` Razor Pages template name when creating a project with the [dotnet new](/dotnet/core/tools/dotnet-new) command. If executing `dotnet new webapp <OPTIONS>` doesn't result in the generation of a new Razor Pages app, install the [.NET Core 2.1 SDK](https://www.microsoft.com/net/download/all).
+> With the release of ASP.NET Core 2.1, `webapp` is an alias of the `razor` Razor Pages template name when creating a project with the [dotnet new](/dotnet/core/tools/dotnet-new) command. If executing `dotnet new webapp <OPTIONS>` doesn't result in the generation of a new Razor Pages app, install the [.NET Core 2.1 SDK](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300).

--- a/aspnetcore/includes/webapp-alias-notice.md
+++ b/aspnetcore/includes/webapp-alias-notice.md
@@ -1,0 +1,2 @@
+> [!NOTE]
+> With the release of ASP.NET Core 2.1, `webapp` replaces the `razor` Razor Pages template name when creating a project with the [dotnet new](/dotnet/core/tools/dotnet-new) command. If executing `dotnet new webapp <OPTIONS>` doesn't result in the generation of a new Razor Pages app, install the [.NET Core 2.1 SDK](https://www.microsoft.com/net/download/all).

--- a/aspnetcore/includes/webapp-alias-notice.md
+++ b/aspnetcore/includes/webapp-alias-notice.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> With the release of ASP.NET Core 2.1, `webapp` is an alias of the `razor` Razor Pages template name when creating a project with the [dotnet new](/dotnet/core/tools/dotnet-new) command. If executing `dotnet new webapp <OPTIONS>` doesn't result in the generation of a new Razor Pages app, install the [.NET Core 2.1 SDK](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300).
+> In ASP.NET Core 2.1 or later, `webapp` is an alias of the `razor` argument. If the `dotnet new webapp <OPTIONS>` command loads the [dotnet new](/dotnet/core/tools/dotnet-new) command help instead of creating a new Razor Pages app, install the [.NET Core 2.1 SDK](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300).

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -39,6 +39,8 @@ See [Get started with Razor Pages](xref:tutorials/razor-pages/razor-pages-start)
 
 Run `dotnet new webapp` from the command line.
 
+[!INCLUDE[](~/includes/webapp-alias-notice.md)]
+
 ::: moniker-end
 
 ::: moniker range="= aspnetcore-2.0"
@@ -55,6 +57,8 @@ Open the generated *.csproj* file from Visual Studio for Mac.
 
 Run `dotnet new webapp` from the command line.
 
+[!INCLUDE[](~/includes/webapp-alias-notice.md)]
+
 ::: moniker-end
 
 ::: moniker range="= aspnetcore-2.0"
@@ -68,6 +72,8 @@ Run `dotnet new razor` from the command line.
 ::: moniker range=">= aspnetcore-2.1"
 
 Run `dotnet new webapp` from the command line.
+
+[!INCLUDE[](~/includes/webapp-alias-notice.md)]
 
 ::: moniker-end
 

--- a/aspnetcore/mvc/razor-pages/ui-class.md
+++ b/aspnetcore/mvc/razor-pages/ui-class.md
@@ -186,6 +186,8 @@ dotnet sln add RazorUIClassLib
 dotnet add WebApp1 reference RazorUIClassLib
 ```
 
+[!INCLUDE[](~/includes/webapp-alias-notice.md)]
+
 Build and run the web app:
 
 ```console

--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -38,6 +38,8 @@ dotnet new webapp --auth Individual -o WebPWrecover
 cd WebPWrecover
 ```
 
+[!INCLUDE[](~/includes/webapp-alias-notice.md)]
+
 ::: moniker-end
 
 ::: moniker range="= aspnetcore-2.0"

--- a/aspnetcore/security/authentication/add-user-data.md
+++ b/aspnetcore/security/authentication/add-user-data.md
@@ -44,7 +44,9 @@ The project sample is created from a Razor Pages web app, but the instructions a
 dotnet new webapp -o WebApp1
 ```
 
-------
+[!INCLUDE[](~/includes/webapp-alias-notice.md)]
+
+---
 
 ## Run the Identity scaffolder
 

--- a/aspnetcore/security/authentication/individual.md
+++ b/aspnetcore/security/authentication/individual.md
@@ -24,6 +24,8 @@ dotnet new webapi -au Individual
 dotnet new webapp -au Individual
 ```
 
+[!INCLUDE[](~/includes/webapp-alias-notice.md)]
+
 ::: moniker-end
 
 ::: moniker range="= aspnetcore-2.0"

--- a/aspnetcore/security/authentication/scaffold-identity.md
+++ b/aspnetcore/security/authentication/scaffold-identity.md
@@ -84,6 +84,8 @@ cd RPauth
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
 dotnet restore
 dotnet aspnet-codegenerator identity -dc RPauth.Data.ApplicationDbContext --files Account.Register
+
+[!INCLUDE[](~/includes/webapp-alias-notice.md)]
 -->
 
 [!INCLUDE[](~/includes/scaffold-identity/id-scaffold-dlg-auth.md)]

--- a/aspnetcore/security/authorization/secure-data.md
+++ b/aspnetcore/security/authorization/secure-data.md
@@ -305,6 +305,8 @@ Create a contact in the administrator's browser. Copy the URL for delete and edi
   dotnet new webapp -o ContactManager -au Individual -uld
   ```
 
+  [!INCLUDE[](~/includes/webapp-alias-notice.md)]
+
 ::: moniker-end
 
 ::: moniker range="= aspnetcore-2.0"

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -144,6 +144,8 @@ Use the `--no-https` option. For example
 dotnet new webapp --no-https
 ```
 
+[!INCLUDE[](~/includes/webapp-alias-notice.md)]
+
 ---
 
 ::: moniker-end

--- a/aspnetcore/signalr/get-started.md
+++ b/aspnetcore/signalr/get-started.md
@@ -79,6 +79,8 @@ Visual Studio includes the `Microsoft.AspNetCore.SignalR` package containing its
     dotnet new webapp -o SignalRChat
     ```
 
+    [!INCLUDE[](~/includes/webapp-alias-notice.md)]
+
 2. Install the JavaScript client library using *npm*.
 
     ```console
@@ -88,7 +90,7 @@ Visual Studio includes the `Microsoft.AspNetCore.SignalR` package containing its
 
 3. Create a new folder named "signalr" inside the  *lib* folder in your project. Copy the *signalr.js* file from *node_modules\\@aspnet\signalr\dist\browser* to this folder.
 
------
+---
 
 ## Create the SignalR Hub
 

--- a/aspnetcore/tutorials/publish-to-azure-webapp-using-cli.md
+++ b/aspnetcore/tutorials/publish-to-azure-webapp-using-cli.md
@@ -55,6 +55,8 @@ REM Run the app
 dotnet run
 ```
 
+[!INCLUDE[](~/includes/webapp-alias-notice.md)]
+
 ::: moniker-end
 
 ::: moniker range="= aspnetcore-2.0"
@@ -86,6 +88,8 @@ cd MyApplication
 # Run the app
 dotnet run
 ```
+
+[!INCLUDE[](~/includes/webapp-alias-notice.md)]
 
 ::: moniker-end
 

--- a/aspnetcore/tutorials/razor-pages-mac/razor-pages-start.md
+++ b/aspnetcore/tutorials/razor-pages-mac/razor-pages-start.md
@@ -33,6 +33,8 @@ cd RazorPagesMovie
 dotnet run
 ```
 
+[!INCLUDE[](~/includes/webapp-alias-notice.md)]
+
 ::: moniker-end
 
 ::: moniker range="= aspnetcore-2.0"

--- a/aspnetcore/tutorials/razor-pages-vsc/razor-pages-start.md
+++ b/aspnetcore/tutorials/razor-pages-vsc/razor-pages-start.md
@@ -33,6 +33,8 @@ cd RazorPagesMovie
 dotnet run
 ```
 
+[!INCLUDE[](~/includes/webapp-alias-notice.md)]
+
 ::: moniker-end
 
 ::: moniker range="= aspnetcore-2.0"


### PR DESCRIPTION
Fixes #6937 

We may need to work with the note language, but I propose something like this temporarily (until 2.2?).

In spite of `webapp`'s alias status, I chose "replaces" in the wording to push the idea that this is what we recommend for everyone going forward.