### PR TITLE
Remove difficult consecutive contractions

### DIFF
--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -478,7 +478,7 @@ Using the preceding code, the URL path that submits to `OnPostJoinListAsync` is 
 
 ## Customizing Routing
 
-You can change the query string `?handler=JoinList` in the URL to a route segment `/JoinList` by specifying the route template @page "{handler?}".
+You can change the query string `?handler=JoinList` in the URL to a route segment `/JoinList` by specifying the route template `@page "{handler?}"`.
 If you don't like the query string `?handler=JoinList` in the URL, you can change the route to put the handler name in the path portion of the URL.  You can customize the route by adding a route template enclosed in double quotes after the `@page` directive.
 
 [!code-cshtml[](index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml?highlight=1)]

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -476,15 +476,16 @@ The preceding code uses *named handler methods*. Named handler methods are creat
 
 Using the preceding code, the URL path that submits to `OnPostJoinListAsync` is `http://localhost:5000/Customers/CreateFATH?handler=JoinList`. The URL path that submits to `OnPostJoinListUCAsync` is `http://localhost:5000/Customers/CreateFATH?handler=JoinListUC`.
 
-
-
 ## Customizing Routing
 
-If you don't like the query string `?handler=JoinList` in the URL, you can change the route to put the handler name in the path portion of the URL. You can customize the route by adding a route template enclosed in double quotes after the `@page` directive.
+You can change the query string `?handler=JoinList` in the URL to a route segment `/JoinList` by specifying the route template @page "{handler?}".
+If you don't like the query string `?handler=JoinList` in the URL, you can change the route to put the handler name in the path portion of the URL.  You can customize the route by adding a route template enclosed in double quotes after the `@page` directive.
 
 [!code-cshtml[](index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml?highlight=1)]
 
-The preceding route puts the handler name in the URL path instead of the query string. The `?` following `handler` means the route parameter is optional.
+Using the preceding code, the URL path that submits to `OnPostJoinListAsync` is `http://localhost:5000/Customers/CreateFATH/JoinList`. The URL path that submits to `OnPostJoinListUCAsync` is `http://localhost:5000/Customers/CreateFATH/JoinListUC`.
+
+The `?` following `handler` means the route parameter is optional.
 
 You can use `@page` to add additional segments and parameters to a page's route. Whatever's there is **appended** to the default route of the page. Using an absolute or virtual path to change the page's route (like `"~/Some/Other/Path"`) isn't supported.
 

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -486,7 +486,7 @@ If you don't like the query string `?handler=JoinList` in the URL, you can chang
 
 The preceding route puts the handler name in the URL path instead of the query string. The `?` following `handler` means the route parameter is optional.
 
-You can use `@page` to add additional segments and parameters to a page's route. Whatever's there's **appended** to the default route of the page. Using an absolute or virtual path to change the page's route (like `"~/Some/Other/Path"`) isn't supported.
+You can use `@page` to add additional segments and parameters to a page's route. Whatever's there is **appended** to the default route of the page. Using an absolute or virtual path to change the page's route (like `"~/Some/Other/Path"`) isn't supported.
 
 ## Configuration and settings
 

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -487,7 +487,7 @@ Using the preceding code, the URL path that submits to `OnPostJoinListAsync` is 
 
 The `?` following `handler` means the route parameter is optional.
 
-You can use `@page` to add additional segments and parameters to a page's route. Whatever's there is **appended** to the default route of the page. Using an absolute or virtual path to change the page's route (like `"~/Some/Other/Path"`) isn't supported.
+You can use `@page` to append segments and parameters to a page's default route. Using an absolute or virtual path to change the page's route (like `"~/Some/Other/Path"`) isn't supported.
 
 ## Configuration and settings
 

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -480,7 +480,7 @@ Using the preceding code, the URL path that submits to `OnPostJoinListAsync` is 
 
 You can change the query string `?handler=JoinList` in the URL to a route segment `/JoinList` by specifying the route template `@page "{handler?}"`.
 
-If you don't like the query string `?handler=JoinList` in the URL, you can change the route to put the handler name in the path portion of the URL.  You can customize the route by adding a route template enclosed in double quotes after the `@page` directive.
+If you don't like the query string `?handler=JoinList` in the URL, you can change the route to put the handler name in the path portion of the URL. You can customize the route by adding a route template enclosed in double quotes after the `@page` directive.
 
 [!code-cshtml[](index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml?highlight=1)]
 

--- a/aspnetcore/mvc/razor-pages/index.md
+++ b/aspnetcore/mvc/razor-pages/index.md
@@ -479,6 +479,7 @@ Using the preceding code, the URL path that submits to `OnPostJoinListAsync` is 
 ## Customizing Routing
 
 You can change the query string `?handler=JoinList` in the URL to a route segment `/JoinList` by specifying the route template `@page "{handler?}"`.
+
 If you don't like the query string `?handler=JoinList` in the URL, you can change the route to put the handler name in the path portion of the URL.  You can customize the route by adding a route template enclosed in double quotes after the `@page` directive.
 
 [!code-cshtml[](index/sample/RazorPagesContacts2/Pages/Customers/CreateRoute.cshtml?highlight=1)]


### PR DESCRIPTION
"Whatever's there's appended to" sounds odd and, more importantly, take longer to understand than "whatever's there is appended to".

When first reading this page, I had to stop and re-read several times before I understood what was trying to be said. Dropping the contraction on "there's" helped a lot, while leaving the contraction on "whatever's" keeps the tone conversational.
