### PR TITLE
Introducing CallbackPath Property

### DIFF
--- a/aspnetcore/security/authentication/social/facebook-logins.md
+++ b/aspnetcore/security/authentication/social/facebook-logins.md
@@ -43,7 +43,7 @@ This tutorial shows you how to enable your users to sign in with their Facebook 
 * Enter your development URI with */signin-facebook* appended into the **Valid OAuth Redirect URIs** field (for example: `https://localhost:44320/signin-facebook`). The Facebook authentication configured later in this tutorial will automatically handle requests at */signin-facebook* route to implement the OAuth flow.
 
 > [!NOTE]
-> The URI */signin-facebook*/ is set as the default callback for Facebook authentication Provider. You can change the default callback URI while configuring the Facebook authentication middleware via *CallbackPath* property of FacebookOptions class.
+> The URI */signin-facebook* is set as the default callback of the Facebook authentication provider. You can change the default callback URI while configuring the Facebook authentication middleware via the inherited [RemoteAuthenticationOptions.CallbackPath](/dotnet/api/microsoft.aspnetcore.authentication.remoteauthenticationoptions.callbackpath) property of the [FacebookOptions](/dotnet/api/microsoft.aspnetcore.authentication.facebook.facebookoptions) class.
 
 * Click **Save Changes**.
 

--- a/aspnetcore/security/authentication/social/facebook-logins.md
+++ b/aspnetcore/security/authentication/social/facebook-logins.md
@@ -42,6 +42,9 @@ This tutorial shows you how to enable your users to sign in with their Facebook 
 
 * Enter your development URI with */signin-facebook* appended into the **Valid OAuth Redirect URIs** field (for example: `https://localhost:44320/signin-facebook`). The Facebook authentication configured later in this tutorial will automatically handle requests at */signin-facebook* route to implement the OAuth flow.
 
+> [!NOTE]
+> The URI */signin-facebook*/ is set as the default callback for Facebook authentication Provider. You can change the default callback URI while configuring the Facebook authentication middleware via *CallbackPath* property of FacebookOptions class.
+
 * Click **Save Changes**.
 
 * Click the **Dashboard** link in the left navigation. 


### PR DESCRIPTION
I believe the current document conveys that developers have to use /signin-facebook as their callback URI. However, almost in every scenario, we need to set a different callback URI and this is easily possible via authentication middleware.

`Edit:` [Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/security/authentication/social/facebook-logins?view=aspnetcore-1.0&branch=pr-en-us-6964&tabs=aspnetcore2x)