### PR TITLE
Update intro.md for views->pages and removing mention of auth

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/intro.md
+++ b/aspnetcore/mvc/views/tag-helpers/intro.md
@@ -66,11 +66,11 @@ Tag Helpers scope is controlled by a combination of `@addTagHelper`, `@removeTag
 
 ### `@addTagHelper` makes Tag Helpers available
 
-If you create a new ASP.NET Core web app named *AuthoringTagHelpers* (with no authentication), the following *Views/_ViewImports.cshtml* file will be added to your project:
+If you create a new ASP.NET Core web app named *AuthoringTagHelpers*, the following *Views/_ViewImports.cshtml* file will be added to your project:
 
 [!code-cshtml[](../../../mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImportsCopy.cshtml?highlight=2&range=2-3)]
 
-The `@addTagHelper` directive makes Tag Helpers available to the view. In this case, the view file is *Views/_ViewImports.cshtml*, which by default is inherited by all view files in the *Views* folder and sub-directories; making Tag Helpers available. The code above uses the wildcard syntax ("\*") to specify that all Tag Helpers in the specified assembly (*Microsoft.AspNetCore.Mvc.TagHelpers*) will be available to every view file in the *Views* directory or sub-directory. The first parameter after `@addTagHelper` specifies the Tag Helpers to load (we are using "\*" for all Tag Helpers), and the second parameter "Microsoft.AspNetCore.Mvc.TagHelpers" specifies the assembly containing the Tag Helpers. *Microsoft.AspNetCore.Mvc.TagHelpers* is the assembly for the built-in ASP.NET Core Tag Helpers.
+The `@addTagHelper` directive makes Tag Helpers available to the view. In this case, the view file is *Pages/_ViewImports.cshtml*, which by default is inherited by all files in the *Pages* folder and sub-folders; making Tag Helpers available. The code above uses the wildcard syntax ("\*") to specify that all Tag Helpers in the specified assembly (*Microsoft.AspNetCore.Mvc.TagHelpers*) will be available to every view file in the *Views* directory or sub-directory. The first parameter after `@addTagHelper` specifies the Tag Helpers to load (we are using "\*" for all Tag Helpers), and the second parameter "Microsoft.AspNetCore.Mvc.TagHelpers" specifies the assembly containing the Tag Helpers. *Microsoft.AspNetCore.Mvc.TagHelpers* is the assembly for the built-in ASP.NET Core Tag Helpers.
 
 To expose all of the Tag Helpers in this project (which creates an assembly named *AuthoringTagHelpers*), you would use the following:
 


### PR DESCRIPTION
I just tested and it does not matter whether the project in vs2017 is created with or without authentication regarding the _viewimports file. Seems odd it mentions that making the reader think that there is a difference or why would it be mentioned.  Second ,and not sure if this should be addressed because it might be the tip of the iceberg, the files are no longer in views/ but are now in pages/

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
