### PR TITLE
Fix logger type in LifetimeEventsHostedService example

### DIFF
--- a/aspnetcore/fundamentals/host/generic-host/samples/2.x/GenericHostSample/LifetimeEventsHostedService.cs
+++ b/aspnetcore/fundamentals/host/generic-host/samples/2.x/GenericHostSample/LifetimeEventsHostedService.cs
@@ -12,7 +12,7 @@ namespace GenericHostSample
         private readonly IApplicationLifetime _appLifetime;
 
         public LifetimeEventsHostedService(
-            ILogger<TimedHostedService> logger, IApplicationLifetime appLifetime)
+            ILogger<LifetimeEventsHostedService> logger, IApplicationLifetime appLifetime)
         {
             _logger = logger;
             _appLifetime = appLifetime;


### PR DESCRIPTION
Going  through the docs for the new .NET Core 2.1 IHostService examples. 

Found a small bug (most likely a copy/paste issue) where ILogger type was incorrect. 