### PR TITLE
Update sample13.cs

### DIFF
--- a/aspnet/web-api/overview/web-api-routing-and-actions/create-a-rest-api-with-attribute-routing/samples/sample13.cs
+++ b/aspnet/web-api/overview/web-api-routing-and-actions/create-a-rest-api-with-attribute-routing/samples/sample13.cs
@@ -3,7 +3,7 @@
 public async Task<IHttpActionResult> GetBookDetail(int id)
 {
     var book = await (from b in db.Books.Include(b => b.Author)
-                where b.AuthorId == id
+                where b.BookId == id
                 select new BookDetailDto
                 {
                     Title = b.Title,


### PR DESCRIPTION
I was reading the WebAPI 2 tutorial and found a mistake in this sample. The GetBookDetail action gets a parameter called id, and in the query, this id is checked against the AuthorId, which I think is wrong, it should be checked against the BookId property.

