### PR TITLE
Link to URL Rewriting Middleware

### DIFF
--- a/aspnetcore/fundamentals/url-rewriting.md
+++ b/aspnetcore/fundamentals/url-rewriting.md
@@ -150,7 +150,7 @@ public void Configure(IApplicationBuilder app)
 ```
 
 > [!NOTE]
-> When redirecting to HTTPS on port 443 without the requirement for additional redirect rules, we recommend using HTTPS Redirection Middleware. For more information, see the [Enforce HTTPS](xref:security/enforcing-ssl#require-https) topic.
+> When redirecting to HTTPS without the requirement for additional redirect rules, we recommend using HTTPS Redirection Middleware. For more information, see the [Enforce HTTPS](xref:security/enforcing-ssl#require-https) topic.
 
 The sample app is capable of demonstrating how to use `AddRedirectToHttps` or `AddRedirectToHttpsPermanent`. Add the extension method to the `RewriteOptions`. Make an insecure request to the app at any URL. Dismiss the browser security warning that the self-signed certificate is untrusted or create an exception to trust the certificate.
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -71,6 +71,11 @@ If no port is set:
 * Requests aren't redirected.
 * The middleware logs a warning.
 
+> [!NOTE]
+> An alternative to using HTTPS Redirection Middleware (`UseHttpsRedirection`) is to use URL Rewriting Middleware (`AddRedirectToHttps`). `AddRedirectToHttps` can also set the status code and port when the redirect is executed. For more information, see [URL Rewriting Middleware](xref:fundamentals/url-rewriting).
+>
+> When redirecting to HTTPS without the requirement for additional redirect rules, we recommend using HTTPS Redirection Middleware described in this topic.
+
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-2.1"
@@ -83,7 +88,7 @@ The preceding highlighted code requires all requests use `HTTPS`; therefore, HTT
 
 [!code-csharp[](authentication/accconfirm/sample/WebApp1/Startup.cs?name=snippet_AddRedirectToHttps&highlight=7-999)]
 
-For more information, see [URL Rewriting Middleware](xref:fundamentals/url-rewriting).
+For more information, see [URL Rewriting Middleware](xref:fundamentals/url-rewriting). The middleware also permits the app to set the status code or the status code and the port when the redirect is executed.
 
 Requiring HTTPS globally (`options.Filters.Add(new RequireHttpsAttribute());`) is a security best practice. Applying the
 `[RequireHttps]` attribute to all controllers/Razor Pages isn't considered as secure as requiring HTTPS globally. You can't guarantee the `[RequireHttps]` attribute is applied when new controllers and Razor Pages are added.

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -74,7 +74,7 @@ If no port is set:
 > [!NOTE]
 > An alternative to using HTTPS Redirection Middleware (`UseHttpsRedirection`) is to use URL Rewriting Middleware (`AddRedirectToHttps`). `AddRedirectToHttps` can also set the status code and port when the redirect is executed. For more information, see [URL Rewriting Middleware](xref:fundamentals/url-rewriting).
 >
-> When redirecting to HTTPS without the requirement for additional redirect rules, we recommend using HTTPS Redirection Middleware described in this topic.
+> When redirecting to HTTPS without the requirement for additional redirect rules, we recommend using HTTPS Redirection Middleware (`UseHttpsRedirection`) described in this topic.
 
 ::: moniker-end
 


### PR DESCRIPTION
Fixes #7059 

Killed the mention of 443 in the URL Rewriting Middleware topic NOTE because HTTPS Redirection Middleware options permit setting that. Using the redirection middleware is the recommendation if additional redirect rules aren't needed.

@Tratcher Side ❓ ... Why 307 for this middleware ... why not 308? It seems like you wouldn't want the insecure endpoint requested every time. It seems like you take a *forever perf hit* by issuing 307s for these redirects.