### PR TITLE
Add HubContext doc to SignalR ToC

### DIFF
--- a/aspnetcore/signalr/hubcontext.md
+++ b/aspnetcore/signalr/hubcontext.md
@@ -10,7 +10,7 @@ ms.date: 06/13/2018
 ms.prod: aspnet-core
 ms.technology: aspnet
 ms.topic: article
-uid: signalr/HubContext
+uid: signalr/hubcontext
 ---
 # Send messages from outside a hub
 

--- a/aspnetcore/signalr/index.md
+++ b/aspnetcore/signalr/index.md
@@ -5,7 +5,7 @@ description: Discover topics that pertain to ASP.NET Core SignalR.
 manager: wpickett
 monikerRange: '>= aspnetcore-2.1'
 ms.author: rachelap
-ms.date: 05/25/2018
+ms.date: 06/18/2018
 ms.prod: asp.net-core
 ms.technology: aspnet
 ms.topic: article
@@ -18,6 +18,7 @@ uid: signalr/index
 * [Hubs](xref:signalr/hubs)
 * [JavaScript client](xref:signalr/javascript-client)
 * [.NET client](xref:signalr/dotnet-client)
+* [HubContext](xref:signalr/hubcontext)
 * [Users and Groups](xref:signalr/groups)
 * [MessagePack Hub Protocol](xref:signalr/messagepackhubprotocol)
 * [Publish to Azure](xref:signalr/publish-to-azure-web-app)


### PR DESCRIPTION
Add an entry to the SignalR ToC for the new HubContext doc.