### PR TITLE
Remove confusing statement about namespace directive.

### DIFF
--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -336,7 +336,7 @@ The *Pages/_ViewImports.cshtml* file sets the following namespace:
 
 [!code-cshtml[](index/sample/RazorPagesContacts2/Pages/_ViewImports.cshtml?highlight=1)]
 
-The generated namespace for the *Pages/Customers/Edit.cshtml* Razor Page is the same as the `PageModel` class. The `@namespace` directive was designed so the C# classes added to a project and pages-generated code *just work* without having to add an `@using` directive to the `PageModel` class.
+The generated namespace for the *Pages/Customers/Edit.cshtml* Razor Page is the same as the `PageModel` class.
 
 `@namespace` *also works with conventional Razor views.*
 


### PR DESCRIPTION
The statement at the end of this paragraph added a level of confusion around the `@namespace` directive. Some on stackoverflow took the meaning to be they didn't need to ever include `using` statements. I felt that we were clear enough in the article already in regards to what the `namespace` directive accomplished and therefore didn't need this extra tid bit.

aspnet/Mvc#7932
