### PR TITLE
Remove nonexistent branch from publish config

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -19,10 +19,6 @@
     "master": [
       "Publish",
       "Pdf"
-    ],
-    "aspnetmigration": [
-      "Publish",
-      "Pdf"
     ]
   },
   "docsets_to_publish": [


### PR DESCRIPTION
The "aspnetmigration" branch doesn't exist, so this section of the publish config should be deleted.