### PR TITLE
SignalR stream sample fix. Link to sample updated in related article.

### DIFF
--- a/aspnetcore/signalr/streaming.md
+++ b/aspnetcore/signalr/streaming.md
@@ -24,7 +24,7 @@ A hub method automatically becomes a streaming hub method when it returns a `Cha
 > [!NOTE]
 > Write to the `ChannelReader` on a background thread and return the `ChannelReader` as soon as possible. Other hub invocations will be blocked until a `ChannelReader` is returned.
 
-[!code-csharp[Streaming hub method](streaming/sample/hubs/streamhub.cs?range=10-34)]
+[!code-csharp[Streaming hub method](streaming/sample/Hubs/StreamHub.cs?range=10-34)]
 
 ## .NET client
 

--- a/aspnetcore/signalr/streaming/sample/Hubs/StreamHub.cs
+++ b/aspnetcore/signalr/streaming/sample/Hubs/StreamHub.cs
@@ -25,11 +25,11 @@ namespace SignalRChat.Hubs
         {
             for (var i = 0; i < count; i++)
             {
-                await channel.Writer.WriteAsync(i);
+                await writer.WriteAsync(i);
                 await Task.Delay(delay);
             }
 
-            channel.Writer.TryComplete();
+            writer.TryComplete();
         }
     }
 }


### PR DESCRIPTION

- Fixed sample for SignalR stream usage.
- Link to this code sample updated as well, because of 404 error when opening it from aspnetcore/signalr/streaming.md