### PR TITLE
C26454: escaping URL to display it as text

### DIFF
--- a/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-22.md
+++ b/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-22.md
@@ -125,7 +125,7 @@ For example, string literals can be used in the OData resource paths as paramete
 
 When services receive such requests the hosts will un-escape those escape sequences before passing them to the Web API runtime. This protects against attacks like the following:  
   
-`http://www.contoso.com/..%2F..%2F/Windows/System32/cmd.exe?/c+dir+c`
+`http://www.contoso.com/..%2F..%2F/Windows/System32/cmd.exe?/c+dir+c:`
 
 This causes the Web API OData stack to return a 404 error (Not Found). To prevent this error, your client should use the double escape sequences for slash (%252F) and backslash (%255C). This does not happen for query strings such as /Employees?$filter=Name eq 'Name%2F'
 

--- a/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-22.md
+++ b/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-22.md
@@ -125,7 +125,7 @@ For example, string literals can be used in the OData resource paths as paramete
 
 When services receive such requests the hosts will un-escape those escape sequences before passing them to the Web API runtime. This protects against attacks like the following:  
   
- http://www.contoso.com/..%2F..%2F/Windows/System32/cmd.exe?/c+dir+c:
+ ` http://www.contoso.com/..%2F..%2F/Windows/System32/cmd.exe?/c+dir+c ` :
 
 This causes the Web API OData stack to return a 404 error (Not Found). To prevent this error, your client should use the double escape sequences for slash (%252F) and backslash (%255C). This does not happen for query strings such as /Employees?$filter=Name eq 'Name%2F'
 

--- a/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-22.md
+++ b/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-22.md
@@ -125,7 +125,7 @@ For example, string literals can be used in the OData resource paths as paramete
 
 When services receive such requests the hosts will un-escape those escape sequences before passing them to the Web API runtime. This protects against attacks like the following:  
   
- ` http://www.contoso.com/..%2F..%2F/Windows/System32/cmd.exe?/c+dir+c ` :
+`http://www.contoso.com/..%2F..%2F/Windows/System32/cmd.exe?/c+dir+c`
 
 This causes the Web API OData stack to return a 404 error (Not Found). To prevent this error, your client should use the double escape sequences for slash (%252F) and backslash (%255C). This does not happen for query strings such as /Employees?$filter=Name eq 'Name%2F'
 


### PR DESCRIPTION
Hello, @tdykstra  ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
"Example URL at line 128 is displayed as a link, it must be escaped in order to be displayed as text"

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.