### PR TITLE
C26453: escaping URL to display it as text

### DIFF
--- a/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks.md
+++ b/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks.md
@@ -21,7 +21,7 @@ Cross-Site Request Forgery (CSRF) is an attack where a malicious site sends a re
 
 Here is an example of a CSRF attack:
 
-1. A user logs into www.example.com, using forms authentication.
+1. A user logs into `www.example.com` , using forms authentication.
 2. The server authenticates the user. The response from the server includes an authentication cookie.
 3. Without logging out, the user visits a malicious web site. This malicious site contains the following HTML form: 
 

--- a/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks.md
+++ b/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks.md
@@ -21,7 +21,7 @@ Cross-Site Request Forgery (CSRF) is an attack where a malicious site sends a re
 
 Here is an example of a CSRF attack:
 
-1. A user logs into `www.example.com` , using forms authentication.
+1. A user logs into `www.example.com` using forms authentication.
 2. The server authenticates the user. The response from the server includes an authentication cookie.
 3. Without logging out, the user visits a malicious web site. This malicious site contains the following HTML form: 
 


### PR DESCRIPTION
Hello, @MikeWasson  ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
"Example URL at line 24 is displayed as a link, it must be escaped in order to be displayed as text"

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR then share your PR number so we can confirm and close this PR.
Many thanks in advance.