### PR TITLE
C26449: escaping URL to display it as text

### DIFF
--- a/aspnet/web-forms/overview/deployment/configuring-team-foundation-server-for-web-deployment/creating-a-team-project-in-tfs.md
+++ b/aspnet/web-forms/overview/deployment/configuring-team-foundation-server-for-web-deployment/creating-a-team-project-in-tfs.md
@@ -106,7 +106,7 @@ Next, you need to give the user permission to create new team sites in the Share
    > You may receive an <strong>HTTP 404 Not Found</strong> error due to a double HTTP encoding bug. If this occurs, replace the URL with this:   
    > [<em>site collection URL</em>]/\_layouts/permsetup.aspx  
    > For example:  
-   > http://tfs/sites/Fabrikam%20Web%20Projects/\_layouts/permsetup.aspx
+   >  ` http://tfs/sites/Fabrikam%20Web%20Projects/\_layouts/permsetup.aspx ` 
 8. On the **Set Up Groups for this Site** page, add the user who will create team projects to the **Owners** group, and then click **OK**.
 
     ![](creating-a-team-project-in-tfs/_static/image10.png)

--- a/aspnet/web-forms/overview/deployment/configuring-team-foundation-server-for-web-deployment/creating-a-team-project-in-tfs.md
+++ b/aspnet/web-forms/overview/deployment/configuring-team-foundation-server-for-web-deployment/creating-a-team-project-in-tfs.md
@@ -104,9 +104,9 @@ Next, you need to give the user permission to create new team sites in the Share
 
    > [!NOTE]
    > You may receive an <strong>HTTP 404 Not Found</strong> error due to a double HTTP encoding bug. If this occurs, replace the URL with this:   
-   > [<em>site collection URL</em>]/\_layouts/permsetup.aspx  
+   > `[site_collection_URL]/_layouts/permsetup.aspx`
    > For example:  
-   >  ` http://tfs/sites/Fabrikam%20Web%20Projects/\_layouts/permsetup.aspx ` 
+   > `http://tfs/sites/Fabrikam%20Web%20Projects/_layouts/permsetup.aspx` 
 8. On the **Set Up Groups for this Site** page, add the user who will create team projects to the **Owners** group, and then click **OK**.
 
     ![](creating-a-team-project-in-tfs/_static/image10.png)


### PR DESCRIPTION
Hello, @jrjlee ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
"Example URL at line 109 is displayed as a link, it must be escaped in order to be displayed as text"

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR then share your PR number so we can confirm and close this PR.
Many thanks in advance.