### PR TITLE
Update connectionString for SQL 2014 or later

### DIFF
--- a/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v4/create-an-odata-v4-endpoint/samples/sample4.xml
+++ b/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v4/create-an-odata-v4-endpoint/samples/sample4.xml
@@ -5,7 +5,7 @@
 
   <!-- Add this: -->
   <connectionStrings>
-    <add name="ProductsContext" connectionString="Data Source=(localdb)\v11.0; 
+    <add name="ProductsContext" connectionString="Data Source=(localdb)\mssqllocaldb; 
         Initial Catalog=ProductsContext; Integrated Security=True; MultipleActiveResultSets=True; 
         AttachDbFilename=|DataDirectory|ProductsContext.mdf"
       providerName="System.Data.SqlClient" />


### PR DESCRIPTION
connectionString currently leads to a SQL error 50: "Local Database Runtime error occurred. Cannot create an automatic instance" when trying to access the local database. Proposed fix taken from accepted StackOverflow answer here:
https://stackoverflow.com/a/26267373/8133586

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
