### PR TITLE
Fixed invalid variable name in generic host snippet

### DIFF
--- a/aspnetcore/fundamentals/host/generic-host/samples-snapshot/2.x/GenericHostSample/Program.cs
+++ b/aspnetcore/fundamentals/host/generic-host/samples-snapshot/2.x/GenericHostSample/Program.cs
@@ -41,12 +41,12 @@ namespace GenericHostSample
             var host = new HostBuilder()
                 .ConfigureAppConfiguration((hostContext, configApp) =>
                 {
-                    configHost.SetBasePath(Directory.GetCurrentDirectory());
+                    configApp.SetBasePath(Directory.GetCurrentDirectory());
                     configApp.AddJsonFile("appsettings.json", optional: true);
                     configApp.AddJsonFile(
                         $"appsettings.{hostContext.HostingEnvironment.EnvironmentName}.json", 
                         optional: true);
-                    configHost.AddEnvironmentVariables(prefix: "PREFIX_");
+                    configApp.AddEnvironmentVariables(prefix: "PREFIX_");
                     configApp.AddCommandLine(args);
                 })
             #endregion


### PR DESCRIPTION
Snippet `ConfigureAppConfiguration` in the generic host fundamental page was referencing an invalid variable name in the context of the scope. Updated to use the correct variable name. 


