### PR TITLE
Enhance service creation content

### DIFF
--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -61,7 +61,7 @@ The following minimum changes are required to set up an existing ASP.NET Core pr
    For the sample app and command that follows, the service is:
 
    * Named **MyService**.
-   * Published to *c:\\svc* folder.
+   * Published to the *c:\\svc* folder.
    * Has an app executable named *AspNetCoreService.exe*.
 
    Open a command shell with administrative privileges and run the following command:
@@ -76,7 +76,7 @@ The following minimum changes are required to set up an existing ASP.NET Core pr
    
    * Named **MyService**.
    * Created from a project that sets a target framework to `netcoreapp2.1`.
-   * Published to *c:\\my_services\\AspNetCoreService\\bin\\Release\\netcoreapp2.1\\publish* folder.
+   * Published to the *c:\\my_services\\AspNetCoreService\\bin\\Release\\netcoreapp2.1\\publish* folder.
    * Has an app executable named *AspNetCoreService.exe*.
 
    Open a command shell with administrative privileges and run the following command:

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -48,32 +48,22 @@ The following minimum changes are required to set up an existing ASP.NET Core pr
 
      ::: moniker-end
 
-1. Publish the app to a folder. Use [dotnet publish](/dotnet/articles/core/tools/dotnet-publish) or a [Visual Studio publish profile](xref:host-and-deploy/visual-studio-publish-profiles) that publishes to a folder.
+1. Publish the app. Use [dotnet publish](/dotnet/articles/core/tools/dotnet-publish) or a [Visual Studio publish profile](xref:host-and-deploy/visual-studio-publish-profiles).
 
    To publish the sample app from the command line, run the following command in a console window from the project folder:
 
    ```console
-   dotnet publish --configuration Release --output c:\svc
+   dotnet publish --configuration Release
    ```
 
-1. Use the [sc.exe](https://technet.microsoft.com/library/bb490995) command-line tool to create the service (`sc create <SERVICE_NAME> binPath= "<PATH_TO_SERVICE_EXECUTABLE>"`). The `binPath` value is the path to the app's executable, which includes the executable file name. **The space between the equal sign and the quote character that starts the path is required.**
-
-   For the sample app and command that follows, the service is:
-
-   * Named **MyService**.
-   * Published to the *c:\\svc* folder.
-   * Represented by an app executable named *AspNetCoreService.exe*.
-
-   Open a command shell with administrative privileges and run the following command:
+1. Use the [sc.exe](https://technet.microsoft.com/library/bb490995) command-line tool to create the service. The `binPath` value is the path to the app's executable, which includes the executable file name. **The space between the equal sign and the quote character at the start of the path is required.**
 
    ```console
-   sc create MyService binPath= "c:\svc\aspnetcoreservice.exe"
+   sc create <SERVICE_NAME> binPath= "<PATH_TO_SERVICE_EXECUTABLE>"
    ```
-   
-   **Make sure the space is present between the `binPath=` argument and its value.**
-   
-   For a service published in the project folder (published without specifying the `--output` option), use the path to the *publish* folder to create the service. In the following example, the service is:
-   
+
+   For a service published in the project folder, use the path to the *publish* folder to create the service. In the following example, the service is:
+
    * Named **MyService**.
    * Created from a project that sets the target framework to `netcoreapp2.1`.
    * Published to the *c:\\my_services\\AspNetCoreService\\bin\\Release\\netcoreapp2.1\\publish* folder.
@@ -82,10 +72,16 @@ The following minimum changes are required to set up an existing ASP.NET Core pr
    Open a command shell with administrative privileges and run the following command:
 
    ```console
-   sc create MyService binPath= "c:\my_services\AspNetCoreService\bin\Release\netcoreapp2.1\publish"
+   sc create MyService binPath= "c:\my_services\aspnetcoreservice\bin\release\netcoreapp2.1\publish\aspnetcoreservice.exe"
    ```
-
-   **Make sure the space is present between the `binPath=` argument and its value.**
+   
+   > [!IMPORTANT]
+   > Make sure the space is present between the `binPath=` argument and its value.
+   
+   To publish and start the service from a different folder:
+   
+   1. Use the [--output &lt;OUTPUT_DIRECTORY&gt;](/dotnet/core/tools/dotnet-publish#options) option on the `dotnet publish` command.
+   1. Create the service with the `sc.exe` command using the output folder path. Include the name of the service's executable in the path provided to `binPath`.
 
 1. Start the service with the `sc start <SERVICE_NAME>` command.
 

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -65,14 +65,13 @@ The following minimum changes are required to set up an existing ASP.NET Core pr
    For a service published in the project folder, use the path to the *publish* folder to create the service. In the following example, the service is:
 
    * Named **MyService**.
-   * Created from a project that sets the target framework to `netcoreapp2.1`.
-   * Published to the *c:\\my_services\\AspNetCoreService\\bin\\Release\\netcoreapp2.1\\publish* folder.
+   * Published to the *c:\\my_services\\AspNetCoreService\\bin\\Release\\&lt;TARGET_FRAMEWORK&gt;\\publish* folder.
    * Represented by an app executable named *AspNetCoreService.exe*.
 
    Open a command shell with administrative privileges and run the following command:
 
    ```console
-   sc create MyService binPath= "c:\my_services\aspnetcoreservice\bin\release\netcoreapp2.1\publish\aspnetcoreservice.exe"
+   sc create MyService binPath= "c:\my_services\aspnetcoreservice\bin\release\<TARGET_FRAMEWORK>\publish\aspnetcoreservice.exe"
    ```
    
    > [!IMPORTANT]

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -62,7 +62,7 @@ The following minimum changes are required to set up an existing ASP.NET Core pr
 
    * Named **MyService**.
    * Published to the *c:\\svc* folder.
-   * Has an app executable named *AspNetCoreService.exe*.
+   * Represented by an app executable named *AspNetCoreService.exe*.
 
    Open a command shell with administrative privileges and run the following command:
 
@@ -77,7 +77,7 @@ The following minimum changes are required to set up an existing ASP.NET Core pr
    * Named **MyService**.
    * Created from a project that sets a target framework to `netcoreapp2.1`.
    * Published to the *c:\\my_services\\AspNetCoreService\\bin\\Release\\netcoreapp2.1\\publish* folder.
-   * Has an app executable named *AspNetCoreService.exe*.
+   * Represented by an app executable named *AspNetCoreService.exe*.
 
    Open a command shell with administrative privileges and run the following command:
 

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -75,7 +75,7 @@ The following minimum changes are required to set up an existing ASP.NET Core pr
    For a service published in the project folder (published without specifying the `--output` option), use the path to the *publish* folder to create the service. In the following example, the service is:
    
    * Named **MyService**.
-   * Created from a project that sets a target framework to `netcoreapp2.1`.
+   * Created from a project that sets the target framework to `netcoreapp2.1`.
    * Published to the *c:\\my_services\\AspNetCoreService\\bin\\Release\\netcoreapp2.1\\publish* folder.
    * Represented by an app executable named *AspNetCoreService.exe*.
 

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -69,6 +69,21 @@ The following minimum changes are required to set up an existing ASP.NET Core pr
    ```console
    sc create MyService binPath= "c:\svc\aspnetcoreservice.exe"
    ```
+   
+   **Make sure the space is present between the `binPath=` argument and its value.**
+   
+   For a service published in the project folder (published without specifying the `--output` option), use the path to the *publish* folder to create the service. In the following example, the service is:
+   
+   * Named **MyService**.
+   * Created from a project that sets a target framework to `netcoreapp2.1`.
+   * Published to *c:\\my_services\\AspNetCoreService\\bin\\Release\\netcoreapp2.1\\publish* folder.
+   * Has an app executable named *AspNetCoreService.exe*.
+
+   Open a command shell with administrative privileges and run the following command:
+
+   ```console
+   sc create MyService binPath= "c:\my_services\AspNetCoreService\bin\Release\netcoreapp2.1\publish"
+   ```
 
    **Make sure the space is present between the `binPath=` argument and its value.**
 


### PR DESCRIPTION
Fixes #7373 

@scottaddie In this case, I'm making an exception to our general rule about not specifying the TF explicitly because I want it to be utterly clear what the path will look like. For the example prereqs, I've added a bullet to say that the project is published for `netcoreapp2.1`. [EDIT] The TF will be updated at each sample update, so I'm not worried about it for the future of the topic.

Also, I want to reinforce the `binPath` argument space requirement, so I repeat the following line on purpose for this new example ...

> **Make sure the space is present between the `binPath=` argument and its value.**

It's an easily overlooked instruction that turns into a big 'ole :bomb: if it isn't seen by the reader.

Thanks to @mmaguirehub for reporting! :rocket: