### PR TITLE
Path missing "Shared" folder

### DIFF
--- a/aspnetcore/includes/RP/page1.md
+++ b/aspnetcore/includes/RP/page1.md
@@ -84,7 +84,7 @@ The `PageModel` base class has a `ViewData` dictionary property that can be used
 
 ::: moniker range="= aspnetcore-2.0"
 
-The "Title" property is used in the *Pages/_Layout.cshtml* file. The following markup shows the first few lines of the *Pages/_Layout.cshtml* file.
+The "Title" property is used in the *Pages/Shared/_Layout.cshtml* file. The following markup shows the first few lines of the *Pages/Shared/_Layout.cshtml* file.
 
 ::: moniker-end
 
@@ -107,15 +107,15 @@ The `Layout` property is set in the *Pages/_ViewStart.cshtml* file:
 
 [!code-cshtml[](../../tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/Pages/_ViewStart.cshtml)]
 
-The preceding markup sets the layout file to *Pages/_Layout.cshtml* for all Razor files under the *Pages* folder. See [Layout](xref:razor-pages/index#layout) for more information.
+The preceding markup sets the layout file to *Pages/Shared/_Layout.cshtml* for all Razor files under the *Pages* folder. See [Layout](xref:razor-pages/index#layout) for more information.
 
 ### Update the layout
 
-Change the `<title>` element in the *Pages/_Layout.cshtml* file to use a shorter string.
+Change the `<title>` element in the *Pages/Shared/_Layout.cshtml* file to use a shorter string.
 
 [!code-cshtml[](../../tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/Pages/_Layout.cshtml?range=1-6&highlight=6)]
 
-Find the following anchor element in the *Pages/_Layout.cshtml* file.
+Find the following anchor element in the *Pages/Shared/_Layout.cshtml* file.
 
 ```cshtml
 <a asp-page="/Index" class="navbar-brand">RazorPagesMovie</a>
@@ -128,7 +128,7 @@ Replace the preceding element with the following markup.
 
 The preceding anchor element is a [Tag Helper](xref:mvc/views/tag-helpers/intro). In this case, it's the [Anchor Tag Helper](xref:mvc/views/tag-helpers/builtin-th/anchor-tag-helper). The `asp-page="/Movies/Index"` Tag Helper attribute and value creates a link to the `/Movies/Index` Razor Page.
 
-Save your changes, and test the app by clicking on the **RpMovie** link. See the [_Layout.cshtml](https://github.com/aspnet/Docs/blob/master/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/Pages/_Layout.cshtml) file in GitHub.
+Save your changes, and test the app by clicking on the **RpMovie** link. See the [_Layout.cshtml](https://github.com/aspnet/Docs/blob/master/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/Pages/Shared/_Layout.cshtml) file in GitHub.
 
 ### The Create page model
 


### PR DESCRIPTION
The tutorial page has a typo in the path.
