### PR TITLE
Minor corrections to SignalR tutorial

### DIFF
--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -122,9 +122,9 @@ The SignalR server must be configured so that it knows to pass requests to Signa
 
 1. To configure a SignalR project, modify the project's `Startup.ConfigureServices` method.
 
-   `services.AddSignalR` adds SignalR as part of the [middleware](xref:fundamentals/middleware/index) pipeline.
+   `services.AddSignalR` makes the SignalR services available to the [dependency injection](xref:fundamentals/dependency-injection) system.
 
-2. Configure routes to your hubs using `UseSignalR`.
+1. Configure routes to your hubs with `UseSignalR` in the `Configure` method. `app.UseSignalR` adds SignalR to the [middleware](xref:fundamentals/middleware/index) pipeline.
 
    [!code-csharp[Startup](signalr/sample/Startup.cs?highlight=37,57-60)]
 

--- a/aspnetcore/tutorials/signalr/sample/Hubs/ChatHub.cs
+++ b/aspnetcore/tutorials/signalr/sample/Hubs/ChatHub.cs
@@ -7,7 +7,7 @@ namespace SignalRChat.Hubs
     {
         public async Task SendMessage(string user, string message)
         {
-            await Clients.All.SendAsync("ReceiveMessage", user,message);
+            await Clients.All.SendAsync("ReceiveMessage", user, message);
         }
     }
 }

--- a/aspnetcore/tutorials/signalr/sample/Startup.cs
+++ b/aspnetcore/tutorials/signalr/sample/Startup.cs
@@ -56,7 +56,7 @@ namespace SignalRChat
             app.UseCors("CorsPolicy");
             app.UseSignalR(routes =>
             {
-                routes.MapHub<ChatHub>("/chathub");
+                routes.MapHub<ChatHub>("/chatHub");
             });
             app.UseMvc();
         }


### PR DESCRIPTION
* Fixed whitespace and capitalization
* Clarified that `UseSignalR` adds to the middleware pipeline (`AddSignalR` just adds services to DI)