### PR TITLE
Add note about using Secret Manager in development only

### DIFF
--- a/aspnetcore/security/authentication/social/index.md
+++ b/aspnetcore/security/authentication/social/index.md
@@ -51,11 +51,12 @@ Note: Projects created using **Web Application** or **Web API** project template
 
 ## Use SecretManager to store tokens assigned by login providers
 
-Social login providers assign **Application Id** and **Application Secret** tokens during the registration process (exact naming varies by provider).
+Social login providers assign **Application Id** and **Application Secret** tokens during the registration process. The exact token names vary by provider. These tokens represent the credentials your app uses to access their API. The tokens constitute the "secrets" that can be linked to your app configuration with the help of [Secret Manager](xref:security/app-secrets#secret-manager). Secret Manager is a more secure alternative to storing the tokens in a configuration file, such as *appsettings.json*.
 
-These values are effectively the *user name* and *password* your application uses to access their API, and constitute the "secrets" that can be linked to your application configuration with the help of **Secret Manager** instead of storing them in configuration files directly or hard-coding them.
+> [!IMPORTANT]
+> Secret Manager is for development purposes only. You can store and protect Azure test and production secrets with the [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
 
-Follow the steps in [Safe storage of app secrets in development in ASP.NET Core](xref:security/app-secrets) topic so that you can store tokens assigned by each login provider below.
+Follow the steps in [Safe storage of app secrets in development in ASP.NET Core](xref:security/app-secrets) topic to store tokens assigned by each login provider below.
 
 ## Setup login providers required by your application
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/Docs/issues/7409

[Internal Review Page](https://review.docs.microsoft.com/en-us/aspnet/core/security/authentication/social/?view=aspnetcore-2.1&branch=pr-en-us-7421#use-secretmanager-to-store-tokens-assigned-by-login-providers)