### PR TITLE
move away from Directory.GetCurrentDirectory()

### DIFF
--- a/aspnetcore/fundamentals/configuration/index/sample/ConfigJson/Program.cs
+++ b/aspnetcore/fundamentals/configuration/index/sample/ConfigJson/Program.cs
@@ -11,7 +11,7 @@ public class Program
     public static void Main(string[] args = null)
     {
         var builder = new ConfigurationBuilder()
-            .SetBasePath(Directory.GetCurrentDirectory())
+            .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
             .AddJsonFile("appsettings.json");
 
         Configuration = builder.Build();


### PR DESCRIPTION
As I discovered when I took this code to use in a console app yesterday...Directory.GetCurrentDirectory() failed to provide the path for the appsettings.json when the console app was launched in a method other than double clicking (for instance, pasting the full path in the Explorer path bar, or launching via CMD when the directory was set somewhere other than the EXE's directory).

Would it be better to use AppDomain.CurrentDomain.BaseDirectory which is more likely to accurately find the EXE's actual directory, and thus the appsettings.json, on any given launch method?

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
