### PR TITLE
Update prereq include

### DIFF
--- a/aspnetcore/includes/net-core-prereqs-windows.md
+++ b/aspnetcore/includes/net-core-prereqs-windows.md
@@ -1,6 +1,8 @@
-[Visual Studio for Windows](https://www.microsoft.com/net/download/windows).  
-Select the **ASP.NET and web development** and **.NET Core cross-platform development** workloads.
+[Visual Studio 2017](https://www.microsoft.com/net/download/windows) with the following workloads:
+
+* **ASP.NET and web development**
+* **.NET Core cross-platform development**
 
 ::: moniker range=">= aspnetcore-2.1"
-[.Net Core 2.1 SDK](https://www.microsoft.com/net/download/windows)
+[.NET Core 2.1 SDK or later](https://www.microsoft.com/net/download/windows)
 ::: moniker-end

--- a/aspnetcore/includes/net-core-prereqs-windows.md
+++ b/aspnetcore/includes/net-core-prereqs-windows.md
@@ -1,6 +1,6 @@
 [Visual Studio for Windows](https://www.microsoft.com/net/download/windows).  
-Select the **ASP.NET and web development** workload.
+Select the **ASP.NET and web development** and **.NET Core cross-platform development** workloads.
 
 ::: moniker range=">= aspnetcore-2.1"
-[.Net Core 2.1 SDK](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300)
+[.Net Core 2.1 SDK](https://www.microsoft.com/net/download/windows)
 ::: moniker-end


### PR DESCRIPTION
Fixes #7453 

In addition to the link going stale, shouldn't this also instruct to take the **.NET Core cross-platform development** workload?