### PR TITLE
Specify VS 2017 version required for .NET Core 2.1

### DIFF
--- a/aspnetcore/tutorials/signalr-typescript-webpack.md
+++ b/aspnetcore/tutorials/signalr-typescript-webpack.md
@@ -33,7 +33,7 @@ Install the following software:
 
 * [.NET Core SDK 2.1 or later](https://www.microsoft.com/net/download/all)
 * [Node.js](https://nodejs.org/) with [npm](https://www.npmjs.com/)
-* [Visual Studio 2017](https://www.visualstudio.com/downloads/) version 15.7 or later with the **ASP.NET and web development** workload
+* [Visual Studio 2017](https://www.visualstudio.com/downloads/) version 15.7.3 or later with the **ASP.NET and web development** workload
 
 # [.NET Core CLI](#tab/netcore-cli)
 

--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -32,7 +32,7 @@ Install the following software:
 # [Visual Studio](#tab/visual-studio)
 
 * [.NET Core SDK 2.1 or later](https://www.microsoft.com/net/download/all)
-* [Visual Studio 2017](https://www.visualstudio.com/downloads/) version 15.7 or later with the **ASP.NET and web development** workload
+* [Visual Studio 2017](https://www.visualstudio.com/downloads/) version 15.7.3 or later with the **ASP.NET and web development** workload
 * [npm](https://www.npmjs.com/get-npm)
 
 # [Visual Studio Code](#tab/visual-studio-code)


### PR DESCRIPTION
The SignalR tutorials only display when 2.1 or later is selected in the version picker. VS 2017 15.7.3 or later is required for 2.1+. This PR fixes that prereq version number, which should take care of the related issues we've been seeing.