### PR TITLE
C26452: Converting links to markdown code

### DIFF
--- a/aspnet/ajax/cdn/jquery-cycle/cdnjquerycycle288.md
+++ b/aspnet/ajax/cdn/jquery-cycle/cdnjquerycycle288.md
@@ -13,9 +13,9 @@ jQuery Cycle 2.88
 ====================
 The following jQuery Cycle files are hosted on this CDN:
 
-- https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.all.js &mdash; The full version of the jQuery Cycle plugin. Includes all the more than two dozen special effects and all of the options.
-- https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.all.min.js &mdash; The minified version of the file above. Use this version for production applications to improve your website performance.
-- https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.js &mdash; This version of the jQuery Cycle plugin is smaller and contains only the "fade" transition effect.
-- https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.min.js &mdash; The minified version of the file above. Use this version for production applications to improve your website performance.
-- https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.lite.js &mdash; An even smaller version of the jQuery Cycle plugin that contains only the "fade" transition without all of the options.
-- https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.lite.min.js &mdash; The minified version of the file above. Use this version for production applications to improve your website performance.
+- [https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.all.js](https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.all.js) &mdash; The full version of the jQuery Cycle plugin. Includes all the more than two dozen special effects and all of the options.
+- [https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.all.min.js](https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.all.min.js) &mdash; The minified version of the file above. Use this version for production applications to improve your website performance.
+- [https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.js](https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.js) &mdash; This version of the jQuery Cycle plugin is smaller and contains only the "fade" transition effect.
+- [https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.min.js](https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.min.js) &mdash; The minified version of the file above. Use this version for production applications to improve your website performance.
+- [https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.lite.js](https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.lite.js) &mdash; An even smaller version of the jQuery Cycle plugin that contains only the "fade" transition without all of the options.
+- [https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.lite.min.js](https://ajax.aspnetcdn.com/ajax/jquery.cycle/2.88/jquery.cycle.lite.min.js) &mdash; The minified version of the file above. Use this version for production applications to improve your website performance.


### PR DESCRIPTION
Hello, @Rick-Anderson , 
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
"Links are not inside the MD link structure"

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.

Many thanks in advance.