### PR TITLE
Correct broken link to source code sample

### DIFF
--- a/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
+++ b/aspnetcore/security/authorization/iauthorizationpolicyprovider.md
@@ -146,4 +146,4 @@ To use custom policies from an `IAuthorizationPolicyProvider`, you must:
 services.AddTransient<IAuthorizationPolicyProvider, MinimumAgePolicyProvider>();
 ```
 
-A complete custom `IAuthorizationPolicyProvider` sample is available in the [aspnet/AuthSamples GitHub repository](https://github.com/aspnet/AuthSamples/tree/dev/samples/CustomPolicyProvider).
+A complete custom `IAuthorizationPolicyProvider` sample is available in the [aspnet/AuthSamples GitHub repository](https://github.com/aspnet/AuthSamples/tree/master/samples/CustomPolicyProvider).


### PR DESCRIPTION
As per the "contributing" instructions, because this is a simple change, there is no issue raised for this change. 

There is a broken link in this file (to a source code repo in GitHub). I've corrected the link, pointing it to what is (I hope) the correct location. 
