### PR TITLE
Update information about hosted Bootstrap 4 versions

### DIFF
--- a/aspnet/ajax/cdn/overview.md
+++ b/aspnet/ajax/cdn/overview.md
@@ -789,6 +789,20 @@ The following releases of [https://github.com/scottjehl/Respond](https://github.
 
 The following releases of [getbootstrap.com](http://getbootstrap.com "getbootstrap.com") bootstrap are hosted on the CDN:
 
+#### Bootstrap version 4.1.1
+
+- https://ajax.aspnetcdn.com/ajax/bootstrap/4.1.1/bootstrap.js
+- https://ajax.aspnetcdn.com/ajax/bootstrap/4.1.1/bootstrap.min.js
+- https://ajax.aspnetcdn.com/ajax/bootstrap/4.1.1/css/bootstrap.css
+- https://ajax.aspnetcdn.com/ajax/bootstrap/4.1.1/css/bootstrap.css.map
+- https://ajax.aspnetcdn.com/ajax/bootstrap/4.1.1/css/bootstrap.min.css
+- https://ajax.aspnetcdn.com/ajax/bootstrap/4.1.1/css/bootstrap-grid.css
+- https://ajax.aspnetcdn.com/ajax/bootstrap/4.1.1/css/bootstrap-grid.min.css
+- https://ajax.aspnetcdn.com/ajax/bootstrap/4.1.1/css/bootstrap-grid.css.map
+- https://ajax.aspnetcdn.com/ajax/bootstrap/4.1.1/css/bootstrap-reboot.css
+- https://ajax.aspnetcdn.com/ajax/bootstrap/4.1.1/css/bootstrap-reboot.min.css
+- https://ajax.aspnetcdn.com/ajax/bootstrap/4.1.1/css/bootstrap-reboot.css.map
+
 #### Bootstrap version 4.0.0
 
 - https://ajax.aspnetcdn.com/ajax/bootstrap/4.0.0/bootstrap.js


### PR DESCRIPTION
This commit adds information about 4.1.1 being added to the CDN.

The original tip-off:
https://github.com/aspnet/Templating/pull/595#discussion_r201817830

Thanks!