### PR TITLE
Fix urls linking to non-existing dev branch

### DIFF
--- a/aspnetcore/fundamentals/startup.md
+++ b/aspnetcore/fundamentals/startup.md
@@ -78,8 +78,8 @@ The default compatibility for ASP.NET Core 2.1 and later 2.x applications that d
 
 The following code sets the compatibility mode to ASP.NET Core 2.1, except for the following behaviors:
 
-* [AllowCombiningAuthorizeFilters](https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs)
-* [InputFormatterExceptionPolicy](https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs)
+* [AllowCombiningAuthorizeFilters](https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs)
+* [InputFormatterExceptionPolicy](https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs)
 
 [!code-csharp[Main](startup/sampleCompatibility/Startup2.cs?name=snippet1)]
 
@@ -88,7 +88,7 @@ For apps that encounter breaking behavior changes, using the appropriate compati
 * Allows you to use the latest release and opt out of specific breaking behavior changes.
 * Gives you time to update your app so it works with the latest changes.
 
-The [MvcOptions](https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs) class source comments have a good explanation of what changed and why the changes are an improvement for most users.
+The [MvcOptions](https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs) class source comments have a good explanation of what changed and why the changes are an improvement for most users.
 
 At some future date, there will be an [ASP.NET Core 3.0 version](https://github.com/aspnet/Home/wiki/Roadmap). Old behaviors supported by compatibility switches will be removed in the 3.0 version. We feel these are positive changes benefitting nearly all users. By introducing these changes now, most apps can benefit now, and the others will have time to update their applications.
 


### PR DESCRIPTION
I noticed that some links point to https://github.com/aspnet/Mvc/blob/dev/src/ but since that one doesn't exist (anymore?). I fixed them to point to master.