### PR TITLE
Fix links pointing to dev branch to point to master branch

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -41,7 +41,7 @@
       "_navRel": "/foo",
       "breadcrumb_path": "/aspnet/breadcrumb/toc.json",
       "feedback_github_repo": "aspnet/docs",
-      "feedback_product_url": "https://github.com/aspnet/Home/blob/dev/CONTRIBUTING.md",
+      "feedback_product_url": "https://github.com/aspnet/Home/blob/master/CONTRIBUTING.md",
       "feedback_system": "GitHub",
       "ms.prod": "aspnet-core",
       "searchScope": [

--- a/aspnetcore/security/authentication/social/index.md
+++ b/aspnetcore/security/authentication/social/index.md
@@ -18,7 +18,7 @@ This tutorial demonstrates how to build an ASP.NET Core 2.x app that enables use
 
 Enabling users to sign in with their existing credentials is convenient for the users and shifts many of the complexities of managing the sign-in process onto a third party. For examples of how social logins can drive traffic and customer conversions, see case studies by [Facebook](https://www.facebook.com/unsupportedbrowser) and [Twitter](https://dev.twitter.com/resources/case-studies).
 
-Note: Packages presented here abstract a great deal of complexity of the OAuth authentication flow, but understanding the details may become necessary when troubleshooting. Many resources are available; for example, see [Introduction to OAuth 2](https://www.digitalocean.com/community/tutorials/an-introduction-to-oauth-2) or [Understanding OAuth 2](http://www.bubblecode.net/2016/01/22/understanding-oauth2/). Some issues can be resolved by looking at the [ASP.NET Core source code for the provider packages](https://github.com/aspnet/Security/tree/dev/src).
+Note: Packages presented here abstract a great deal of complexity of the OAuth authentication flow, but understanding the details may become necessary when troubleshooting. Many resources are available; for example, see [Introduction to OAuth 2](https://www.digitalocean.com/community/tutorials/an-introduction-to-oauth-2) or [Understanding OAuth 2](http://www.bubblecode.net/2016/01/22/understanding-oauth2/). Some issues can be resolved by looking at the [ASP.NET Core source code for the provider packages](https://github.com/aspnet/Security/tree/master/src).
 
 ## Create a New ASP.NET Core Project
 

--- a/aspnetcore/tutorials/dotnet-watch.md
+++ b/aspnetcore/tutorials/dotnet-watch.md
@@ -173,4 +173,4 @@ VSTest executes when any file changes in either test project.
 
 ## `dotnet-watch` in GitHub
 
-`dotnet-watch` is part of the GitHub [DotNetTools repository](https://github.com/aspnet/DotNetTools/tree/dev/src/dotnet-watch).
+`dotnet-watch` is part of the GitHub [DotNetTools repository](https://github.com/aspnet/DotNetTools/tree/master/src/dotnet-watch).


### PR DESCRIPTION
Found some more links pointing to non-existing dev branches. Also found a link in docfx.json which was non-existent.