### PR TITLE
Mention `wwwroot` when copying over signalr.js

### DIFF
--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -65,7 +65,7 @@ Visual Studio includes the `Microsoft.AspNetCore.SignalR` package containing its
     npm install @aspnet/signalr
     ```
 
-4. Create a new folder named "signalr" inside the  *lib* folder in your project. Copy the *signalr.js* file from *node_modules\\@aspnet\signalr\dist\browser* to this folder.
+4. Create a new folder named "signalr" inside the  *wwwroot/lib* folder in your project. Copy the *signalr.js* file from *node_modules\\@aspnet\signalr\dist\browser* to this folder.
 
 # [Visual Studio Code](#tab/visual-studio-code/)
 


### PR DESCRIPTION
I think this should be added for those who do not know that `lib` is in `wwwroot`.

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
