### PR TITLE
Changed Bootswatch URL to point to Bootswatch 3.

### DIFF
--- a/aspnet/web-forms/overview/getting-started/getting-started-with-aspnet-45-web-forms/ui_and_navigation.md
+++ b/aspnet/web-forms/overview/getting-started/getting-started-with-aspnet-45-web-forms/ui_and_navigation.md
@@ -158,7 +158,7 @@ In this tutorial, you will change look and feel of the Wingtip Toys application 
 3. Rename the *bootstrap.min.css* to *bootstrap-original.min.css*.
 4. In **Solution Explorer**, right-click the *Content* folder and select **Open Folder in File Explorer**.  
    The File Explorer will be displayed. You will save a downloaded bootstrap CSS files to this location.
-5. In your browser, go to [http://Bootswatch.com](https://bootswatch.com/3/).
+5. In your browser, go to [https://bootswatch.com/3/](https://bootswatch.com/3/).
 6. Scroll the browser window until you see the Cerulean theme. 
 
     ![UI and Navigation - Cerulean Theme](ui_and_navigation/_static/image5.png)

--- a/aspnet/web-forms/overview/getting-started/getting-started-with-aspnet-45-web-forms/ui_and_navigation.md
+++ b/aspnet/web-forms/overview/getting-started/getting-started-with-aspnet-45-web-forms/ui_and_navigation.md
@@ -158,7 +158,7 @@ In this tutorial, you will change look and feel of the Wingtip Toys application 
 3. Rename the *bootstrap.min.css* to *bootstrap-original.min.css*.
 4. In **Solution Explorer**, right-click the *Content* folder and select **Open Folder in File Explorer**.  
    The File Explorer will be displayed. You will save a downloaded bootstrap CSS files to this location.
-5. In your browser, go to [http://Bootswatch.com](http://bootswatch.com/).
+5. In your browser, go to [http://Bootswatch.com](https://bootswatch.com/3/).
 6. Scroll the browser window until you see the Cerulean theme. 
 
     ![UI and Navigation - Cerulean Theme](ui_and_navigation/_static/image5.png)


### PR DESCRIPTION
It is well known that if you use a Bootstrap 4 template on an ASP.NET template it will break the layout. This is a convenience change to prevent confusion as it will send people to the correct versioned URL as it was back when this article was written.

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
