### PR TITLE
Corrected broken URLs to point to updated content.

### DIFF
--- a/aspnet/mvc/pluralsight.md
+++ b/aspnet/mvc/pluralsight.md
@@ -22,14 +22,13 @@ MVC Video Training from Pluralsight
 - [SignalR](https://pluralsight.com/training/Player?author=scott-allen&name=aspdotnet-mvc5-fundamentals-m7-signalr&mode=live&clip=0&course=aspdotnet-mvc5-fundamentals)
 - [Web Developer Tools and Visual Studio 2013](https://pluralsight.com/training/Player?author=scott-allen&name=aspdotnet-mvc5-fundamentals-m8-visualstudio&mode=live&clip=0&course=aspdotnet-mvc5-fundamentals)
 
-
-"This MVC 5 course recorded by K. Scott Allen for Pluralsight provides a fantastic way to quickly get up to speed on the latest release of ASP.NET MVC. Scott's presentation style is easy to follow and technically compelling, and the course format, video player, and overall cadence are really great. Plus – it's free, so there's no excuse not to learn MVC 5 today!"
-
-Scott Guthrie, Executive Vice President, Microsoft Cloud and Enterprise group, Microsoft
-
+> This MVC 5 course recorded by K. Scott Allen for Pluralsight provides a fantastic way to quickly get up to speed on the latest release of ASP.NET MVC. Scott's presentation style is easy to follow and technically compelling, and the course format, video player, and overall cadence are really great. Plus – it's free, so there's no excuse not to learn MVC 5 today!
+>
+> &mdash; Scott Guthrie, Executive Vice President, Microsoft Cloud and Enterprise group, Microsoft
 
 ![pluralsight-logo-playbutton](pluralsight/_static/image1.png)
 
-Unlock access to 3,000+ dev, IT and creative courses that you can watch anytime, anywhere
+Unlock access to 3,000+ dev, IT, and creative courses that you can watch anytime, anywhere.
 
-**Starting at $ 29/mo.**[Start Free Trial](https://www.pluralsight.com/courses/aspdotnet-mvc5-fundamentals) [Subscribe Now](https://www.pluralsight.com/pricing)
+* [ASP.NET MVC 5 Fundamentals](https://www.pluralsight.com/courses/aspdotnet-mvc5-fundamentals)
+* [Pluralsight Pricing and plans](https://www.pluralsight.com/pricing)

--- a/aspnet/mvc/pluralsight.md
+++ b/aspnet/mvc/pluralsight.md
@@ -24,7 +24,7 @@ MVC Video Training from Pluralsight
 
 > This MVC 5 course recorded by K. Scott Allen for Pluralsight provides a fantastic way to quickly get up to speed on the latest release of ASP.NET MVC. Scott's presentation style is easy to follow and technically compelling, and the course format, video player, and overall cadence are really great. Plus – it's free, so there's no excuse not to learn MVC 5 today!
 >
-> &mdash; Scott Guthrie, Executive Vice President, Microsoft Cloud and Enterprise group, Microsoft
+> &mdash;Scott Guthrie, Executive Vice President, Microsoft Cloud and Enterprise group, Microsoft
 
 ![pluralsight-logo-playbutton](pluralsight/_static/image1.png)
 

--- a/aspnet/mvc/pluralsight.md
+++ b/aspnet/mvc/pluralsight.md
@@ -32,4 +32,4 @@ Scott Guthrie, Executive Vice President, Microsoft Cloud and Enterprise group, M
 
 Unlock access to 3,000+ dev, IT and creative courses that you can watch anytime, anywhere
 
-**Starting at $ 29/mo.**[Start Free Trial](https://pluralsight.com/microsoft/OLT/subscribe/Subscribe1.aspx?freetrial=true&planHint=Monthly&utm_source=microsoft&utm_medium=sponsored-page&utm_content=aspdotnet-mvc5-fundamentals&utm_campaign=microsoft-sponsored-course) [Subscribe Now](https://pluralsight.com/microsoft/olt/subscriptions.aspx?utm_source=microsoft&utm_medium=sponsored-page&utm_content=aspdotnet-mvc5-fundamentals&utm_campaign=microsoft-sponsored-course)
+**Starting at $ 29/mo.**[Start Free Trial](https://www.pluralsight.com/courses/aspdotnet-mvc5-fundamentals) [Subscribe Now](https://www.pluralsight.com/pricing)


### PR DESCRIPTION
The "Start Free Trial" and "Subscribe Now" links pointed to a 404 page at Pluralsight. I have updated the URLs with destinations that make sense to the average user. The free trial URL remains focused on Scott Allen's ASP.NET MVC 5 course for promotional purposes.

**If Microsoft has updated affiliated links, that might be a better option for the future.**


