### PR TITLE
Updated link to follow-up tutorial

### DIFF
--- a/aspnetcore/tutorials/razor-pages/validation.md
+++ b/aspnetcore/tutorials/razor-pages/validation.md
@@ -151,7 +151,7 @@ The following code shows combining attributes on one line:
 
 See [Publish an ASP.NET Core web app to Azure App Service using Visual Studio](xref:tutorials/publish-to-azure-webapp-using-vs) for instructions on how to publish this app to Azure.
 
-Thanks for completing this introduction to Razor Pages. We appreciate feedback. [Get started with MVC and EF Core](xref:data/ef-mvc/intro) is an excellent follow up to this tutorial.
+Thanks for completing this introduction to Razor Pages. We appreciate feedback. [Get started with Razor Pages and EF Core](xref:data/ef-rp/intro) is an excellent follow up to this tutorial.
 
 ## Additional resources
 


### PR DESCRIPTION
The current follow-up tutorial link takes users to an MVC tutorial based on ASP.NET Core 2.0. This tutorial is based on Razor Pages and ASP.NET Core 2.1. I think it makes more sense for the recommended follow-up tutorial to continue building on the knowledge learned here about Razor Pages, so I updated the link to take users to [Razor Pages with Entity Framework Core in ASP.NET Core - Tutorial 1 of 8](https://docs.microsoft.com/en-us/aspnet/core/data/ef-rp/intro) instead.
