### PR TITLE
Update Select HTML.ActionLink to use asp tag helpers

### DIFF
--- a/aspnetcore/data/ef-rp/intro/samples/cu/Pages/Instructors/IndexRRD.cshtml
+++ b/aspnetcore/data/ef-rp/intro/samples/cu/Pages/Instructors/IndexRRD.cshtml
@@ -84,15 +84,15 @@
             }
             <tr class="@selectedRow">
                 <td>
-                    @Html.ActionLink("Select", "OnGetAsync", 
-                                  new { courseID = item.CourseID })
+                    <a asp-page="./Index" asp-route-courseID="@item.CourseID">Select</a>
                 </td>
                 <td>
                     @item.CourseID
                 </td>
                 <td>
                     @item.Title
-                </td>  <td>
+                </td>
+                <td>
                     @item.Department.Name
                 </td>
             </tr>


### PR DESCRIPTION
`<td>@Html.ActionLink("Select", "OnGetAsync", new { courseId = item.CourseID })</td>` throws an error saying:

> Cannot resolve action 'OnGetAsync'

I also fixed a spacing issue

<hr />

I see a now closed issue: #6230 that seems to also have trouble with this link, but does not mention this specific error.

The only similarity I have with that issue is that I also created the project with[ Individual User Accounts as the security](https://github.com/aspnet/Docs/issues/6230#issuecomment-390510927), though as Rick-Anderson [mentioned ](https://github.com/aspnet/Docs/issues/6230#issuecomment-390786825) it's likely not the problem.