### PR TITLE
Removed EF Core 2.1 note

### DIFF
--- a/aspnetcore/data/ef-rp/complex-data-model.md
+++ b/aspnetcore/data/ef-rp/complex-data-model.md
@@ -538,8 +538,6 @@ The preceding code provides seed data for the new entities. Most of this code cr
 * `Enrollments`
 * `CourseAssignment`
 
-Note: [EF Core 2.1](https://github.com/aspnet/EntityFrameworkCore/wiki/Roadmap) will support [data seeding](https://github.com/aspnet/EntityFrameworkCore/issues/629).
-
 ## Add a migration
 
 Build the project.


### PR DESCRIPTION
EF Core 2.1 is out and already supports data seeding, so this note is no longer relevant.
