### PR TITLE
C30171: Escaping '@' character to avoid broken content in localization

### DIFF
--- a/aspnetcore/mvc/views/working-with-forms.md
+++ b/aspnetcore/mvc/views/working-with-forms.md
@@ -163,7 +163,7 @@ The data annotations applied to the `Email` and `Password` properties generate m
 
 ### Expression names
 
-The `asp-for` attribute value is a `ModelExpression` and the right hand side of a lambda expression. Therefore, `asp-for="Property1"` becomes `m => m.Property1` in the generated code which is why you don't need to prefix with `Model`. You can use the "@" character to start an inline expression and move before the `m.`:
+The `asp-for` attribute value is a `ModelExpression` and the right hand side of a lambda expression. Therefore, `asp-for="Property1"` becomes `m => m.Property1` in the generated code which is why you don't need to prefix with `Model`. You can use the "\@" character to start an inline expression and move before the `m.`:
 
 ```HTML
 @{


### PR DESCRIPTION
Hello, @rick-anderson ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
"The unescaped '@' sign is breaking the code"
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.