### PR TITLE
C30172: Escaping '@' character to avoid broken content in localization

### DIFF
--- a/aspnet/mvc/overview/older-versions/working-with-the-dropdownlist-box-and-jquery/using-the-dropdownlist-helper-with-aspnet-mvc.md
+++ b/aspnet/mvc/overview/older-versions/working-with-the-dropdownlist-box-and-jquery/using-the-dropdownlist-helper-with-aspnet-mvc.md
@@ -184,7 +184,7 @@ Open the *Views\Home\MultiSelectCountry.cshtml* file and add an `htmlAttributes`
 
 [!code-cshtml[Main](using-the-dropdownlist-helper-with-aspnet-mvc/samples/sample12.cshtml)]
 
-In the code above, we are adding the HTML attribute and attribute value `class = "chzn-select"`. The @ character preceding class has nothing to do with the Razor view engine. `class` is a [C# keyword](https://msdn.microsoft.com/library/x53a06bb.aspx). C# keywords cannot be used as identifiers unless they include @ as a prefix. In the example above, `@class` is a valid identifier but **class** is not because **class** is a keyword.
+In the code above, we are adding the HTML attribute and attribute value `class = "chzn-select"`. The \@ character preceding class has nothing to do with the Razor view engine. `class` is a [C# keyword](https://msdn.microsoft.com/library/x53a06bb.aspx). C# keywords cannot be used as identifiers unless they include \@ as a prefix. In the example above, `@class` is a valid identifier but **class** is not because **class** is a keyword.
 
 Add references to the *Chosen/chosen.jquery.js* and *Chosen/chosen.css* files. The *Chosen/chosen.jquery.js* and implements the functionally of the Chosen plugin. The *Chosen/chosen.css* file provides the styling. Add these references to the bottom of the *Views\Home\MultiSelectCountry.cshtml* file. The following code shows how to reference the Chosen plugin.
 


### PR DESCRIPTION
Hello, @Rick-Anderson ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
"The unescaped '@' sign is breaking the code"
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR then share your PR number so we can confirm and close this PR.
Many thanks in advance.