### PR TITLE
Enforcing SSL topic: HTTPS_PORT env var details

### DIFF
--- a/aspnetcore/fundamentals/host/web-host.md
+++ b/aspnetcore/fundamentals/host/web-host.md
@@ -322,11 +322,11 @@ WebHost.CreateDefaultBuilder(args)
 
 ### HTTPS Port
 
-Set the HTTPS port. Used in [enforcing HTTPS](xref:security/enforcing-ssl).
+Set the HTTPS redirect port. Used in [enforcing HTTPS](xref:security/enforcing-ssl).
 
 **Key**: https_port
 **Type**: *string*
-**Default**: 443
+**Default**: A default value isn't set.
 **Set using**: `UseSetting`
 **Environment variable**: `ASPNETCORE_HTTPS_PORT`
 

--- a/aspnetcore/fundamentals/host/web-host.md
+++ b/aspnetcore/fundamentals/host/web-host.md
@@ -318,6 +318,25 @@ WebHost.CreateDefaultBuilder(args)
 
 ::: moniker-end
 
+::: moniker range=">= aspnetcore-2.1"
+
+### HTTPS Port
+
+Set the HTTPS port. Used in [enforcing HTTPS](xref:security/enforcing-ssl).
+
+**Key**: https_port
+**Type**: *string*
+**Default**: 443
+**Set using**: `UseSetting`
+**Environment variable**: `ASPNETCORE_HTTPS_PORT`
+
+```csharp
+WebHost.CreateDefaultBuilder(args)
+    .UseSetting("https_port", "8080")
+```
+
+::: moniker-end
+
 ::: moniker range=">= aspnetcore-2.0"
 
 ### Prefer Hosting URLs

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -55,7 +55,9 @@ The following mechanisms set the port automatically:
 
 The port can be configured by setting the:
 
-* `ASPNETCORE_HTTPS_PORT` environment variable.
+* `ASPNETCORE_HTTPS_PORT` environment variable when the app relies on either of the following host configuration approaches. Otherwise, the port is configured by setting the `HTTPS_PORT` environment variable.
+  - The app runs on the [Web Host](xref:fundamentals/host/web-host).
+  - The app uses the environment variable configuration provider ([AddEnvironmentVariables(IConfigurationBuilder, String)](/dotnet/api/microsoft.extensions.configuration.environmentvariablesextensions.addenvironmentvariables#Microsoft_Extensions_Configuration_EnvironmentVariablesExtensions_AddEnvironmentVariables_Microsoft_Extensions_Configuration_IConfigurationBuilder_System_String_)) with a prefix of `ASPNETCORE_`.
 * `http_port` host configuration key (for example, via *hostsettings.json* or a command line argument).
 * [HttpsRedirectionOptions.HttpsPort](/dotnet/api/microsoft.aspnetcore.httpspolicy.httpsredirectionoptions.httpsport). See the preceding example that shows how to set the port to 5001.
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -53,13 +53,18 @@ The following mechanisms set the port automatically:
 > [!NOTE]
 > When an app is run behind a reverse proxy (for example, IIS, IIS Express), `IServerAddressesFeature` isn't available. The port must be manually configured. When the port isn't set, requests aren't redirected.
 
-The port can be configured by setting the:
+The port can be configured by setting the [https_port Web Host configuration setting](#):
 
-* `ASPNETCORE_HTTPS_PORT` environment variable when the app relies on either of the following host configuration approaches. Otherwise, the port is configured by setting the `HTTPS_PORT` environment variable.
-  - The app runs on the [Web Host](xref:fundamentals/host/web-host).
-  - The app uses the environment variable configuration provider ([AddEnvironmentVariables(IConfigurationBuilder, String)](/dotnet/api/microsoft.extensions.configuration.environmentvariablesextensions.addenvironmentvariables#Microsoft_Extensions_Configuration_EnvironmentVariablesExtensions_AddEnvironmentVariables_Microsoft_Extensions_Configuration_IConfigurationBuilder_System_String_)) with a prefix of `ASPNETCORE_`.
-* `http_port` host configuration key (for example, via *hostsettings.json* or a command line argument).
-* [HttpsRedirectionOptions.HttpsPort](/dotnet/api/microsoft.aspnetcore.httpspolicy.httpsredirectionoptions.httpsport). See the preceding example that shows how to set the port to 5001.
+**Key**: https_port
+**Type**: *string*
+**Default**: 443
+**Set using**: `UseSetting`
+**Environment variable**: `<PREFIX_>HTTPS_PORT` (The prefix is `ASPNETCORE_` when using the Web Host.)
+
+```csharp
+WebHost.CreateDefaultBuilder(args)
+    .UseSetting("https_port", "8080")
+```
 
 > [!NOTE]
 > The port can be configured indirectly by setting the URL with the `ASPNETCORE_URLS` environment variable. The environment variable configures the server, and then the middleware indirectly discovers the HTTPS port via `IServerAddressesFeature`.

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -57,7 +57,7 @@ The port can be configured by setting the [https_port Web Host configuration set
 
 **Key**: https_port
 **Type**: *string*
-**Default**: 443
+**Default**: A default value isn't set.
 **Set using**: `UseSetting`
 **Environment variable**: `<PREFIX_>HTTPS_PORT` (The prefix is `ASPNETCORE_` when using the Web Host.)
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -53,7 +53,7 @@ The following mechanisms set the port automatically:
 > [!NOTE]
 > When an app is run behind a reverse proxy (for example, IIS, IIS Express), `IServerAddressesFeature` isn't available. The port must be manually configured. When the port isn't set, requests aren't redirected.
 
-The port can be configured by setting the [https_port Web Host configuration setting](#):
+The port can be configured by setting the [https_port Web Host configuration setting](xref:fundamentals/host/web-host#https-port):
 
 **Key**: https_port
 **Type**: *string*


### PR DESCRIPTION
Fixes #7659 

More to come on remarks about env vars across the repo when I get to the *Configuration coverage* issue (#7102).

I think we're going to have to go in this direction wherever we mention env vars explicitly because we probably won't be able to rely on prior knowledge when they're mentioned outside of config/hosting. I'll analyze the situation further later this week or early next week. For now, this will fix this *one spot*.