### PR TITLE
Replace line numbers range with snippet name

### DIFF
--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.Api.Pre21/Controllers/PetsController.cs
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.Api.Pre21/Controllers/PetsController.cs
@@ -47,10 +47,12 @@ namespace WebApiSample.Api.Controllers
         [ProducesResponseType(400)]
         public async Task<IActionResult> CreateAsync([FromBody] Pet pet)
         {
+            #region snippet_ModelStateIsValidCheck
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
+            #endregion
 
             await _repository.AddPetAsync(pet);
 

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -57,7 +57,7 @@ The following sections describe convenience features added by the attribute.
 
 Validation errors automatically trigger an HTTP 400 response. The following code becomes unnecessary in your actions:
 
-[!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api.Pre21/Controllers/PetsController.cs?range=46-49)]
+[!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api.Pre21/Controllers/PetsController.cs?name=snippet_ModelStateIsValidCheck)]
 
 The default behavior is disabled when the [SuppressModelStateInvalidFilter](/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.suppressmodelstateinvalidfilter) property is set to `true`. Add the following code in *Startup.ConfigureServices* after `services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);`:
 


### PR DESCRIPTION
The line numbers being used were no longer the correct ones. Replace that delicate range with a newly created region name to prevent this from happening again.

Shout out to @DavidCBerry13 for spotting this mistake.