### PR TITLE
Change 2.1 ActionResult heading to generic type form

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-2.1.md
+++ b/aspnetcore/release-notes/aspnetcore-2.1.md
@@ -108,7 +108,7 @@ public class BasicTests
 
 For more information, see the [Integration tests](xref:test/integration-tests) topic.
 
-## [ApiController], ActionResult
+## [ApiController], ActionResult\<T>
 
 ASP.NET Core 2.1 adds new programming conventions that make it easier to build clean and descriptive web APIs. `ActionResult<T>` is a new type added to allow an app to return either a response type or any other action result (similar to IActionResult), while still indicating the response type. The `[ApiController]` attribute has also been added as the way to opt in to Web API-specific conventions and behaviors.
 


### PR DESCRIPTION
Changes `ActionResult` to `ActionResult<T>`.