### PR TITLE
Add link to IHttpClientFactory sample app

### DIFF
--- a/aspnetcore/fundamentals/http-requests.md
+++ b/aspnetcore/fundamentals/http-requests.md
@@ -19,6 +19,8 @@ An [IHttpClientFactory](/dotnet/api/system.net.http.ihttpclientfactory) can be r
 * Manages the pooling and lifetime of underlying `HttpClientMessageHandler` instances to avoid common DNS problems that occur when manually managing `HttpClient` lifetimes.
 * Adds a configurable logging experience (via `ILogger`) for all requests sent through clients created by the factory.
 
+[View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/fundamentals/http-requests/samples) ([how to download](xref:tutorials/index#how-to-download-a-sample))
+
 ## Prerequisites
 
 Projects targeting .NET Framework require installation of the [Microsoft.Extensions.Http](https://www.nuget.org/packages/Microsoft.Extensions.Http/) NuGet package. Projects that target .NET Core and reference the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app) already include the `Microsoft.Extensions.Http` package.


### PR DESCRIPTION
The sample app link was missing.