### PR TITLE
Add recommendation and example for ignoring XML doc warnings per class

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -184,6 +184,32 @@ Suppress warnings by defining a semicolon-delimited list of warning codes to ign
 
 [!code-xml[](../tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.Swashbuckle/TodoApi.csproj?name=snippet_SuppressWarnings&highlight=3)]
 
+If you don't want to ignore all Missing XML Comment warnings for the project, you can use `#pragma` statements around specific classes you want to ignore. For example, you may want to ignore the `Program` and `Startup` classes as they will not be exposed via the API docs.
+
+```csharp
+namespace MyApi
+{
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .Build();
+    }
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+}
+```
+
+Note that if you do not `restore` the warning at the end of the class, it ignores the rest of the project's classes.
+
 ::: moniker-end
 
 ::: moniker range="<= aspnetcore-1.1"

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -4,7 +4,7 @@ author: zuckerthoben
 description: Learn how to add Swashbuckle to your ASP.NET Core web API project to integrate the Swagger UI.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 06/29/2018
+ms.date: 07/27/2018
 uid: tutorials/get-started-with-swashbuckle
 ---
 # Get started with Swashbuckle and ASP.NET Core
@@ -178,37 +178,11 @@ Enabling XML comments provides debug information for undocumented public types a
 warning CS1591: Missing XML comment for publicly visible type or member 'TodoController.GetAll()'
 ```
 
-Suppress warnings by defining a semicolon-delimited list of warning codes to ignore in the *.csproj* file. Appending the warning codes to `$(NoWarn);` applies the C# default values too.
+To suppress warnings project-wide, define a semicolon-delimited list of warning codes to ignore in the *.csproj* file. Appending the warning codes to `$(NoWarn);` applies the C# default values too.
 
 ::: moniker range=">= aspnetcore-2.0"
 
 [!code-xml[](../tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.Swashbuckle/TodoApi.csproj?name=snippet_SuppressWarnings&highlight=3)]
-
-If you don't want to ignore all Missing XML Comment warnings for the project, you can use `#pragma` statements around specific classes you want to ignore. For example, you may want to ignore the `Program` and `Startup` classes as they will not be exposed via the API docs.
-
-```csharp
-namespace MyApi
-{
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-
-    public class Program
-    {
-        public static void Main(string[] args)
-        {
-            BuildWebHost(args).Run();
-        }
-
-        public static IWebHost BuildWebHost(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .Build();
-    }
-
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-}
-```
-
-Note that if you do not `restore` the warning at the end of the class, it ignores the rest of the project's classes.
 
 ::: moniker-end
 
@@ -217,6 +191,26 @@ Note that if you do not `restore` the warning at the end of the class, it ignore
 [!code-xml[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/TodoApi.csproj?name=snippet_SuppressWarnings&highlight=3)]
 
 ::: moniker-end
+
+To suppress warnings only for specific members, enclose the code in [#pragma warning](/dotnet/csharp/language-reference/preprocessor-directives/preprocessor-pragma-warning) preprocessor directives. This approach is useful for code that shouldn't be exposed via the API docs. In the following example, warning code CS1591 is ignored for the entire `Program` class. Enforcement of the warning code is restored at the close of the class definition. Specify multiple warning codes with a comma-delimited list.
+
+```csharp
+namespace TodoApi
+{
+#pragma warning disable CS1591
+    public class Program
+    {
+        public static void Main(string[] args) =>
+            BuildWebHost(args).Run();
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .Build();
+    }
+#pragma warning restore CS1591
+}
+```
 
 Configure Swagger to use the generated XML file. For Linux or non-Windows operating systems, file names and paths can be case-sensitive. For example, a *TodoApi.XML* file is valid on Windows but not CentOS.
 

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -178,7 +178,7 @@ Enabling XML comments provides debug information for undocumented public types a
 warning CS1591: Missing XML comment for publicly visible type or member 'TodoController.GetAll()'
 ```
 
-To suppress warnings project-wide, define a semicolon-delimited list of warning codes to ignore in the *.csproj* file. Appending the warning codes to `$(NoWarn);` applies the C# default values too.
+To suppress warnings project-wide, define a semicolon-delimited list of warning codes to ignore in the project file. Appending the warning codes to `$(NoWarn);` applies the C# default values too.
 
 ::: moniker range=">= aspnetcore-2.0"
 


### PR DESCRIPTION
Fixes #7795 - Add recommendation for ignoring XML doc warnings for certain classes in Swagger documentation

[Internal Review Page](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-2.1&branch=pr-en-us-7849&tabs=visual-studio%2Cvisual-studio-xml#xml-comments)