### PR TITLE
Fixed invalid return types to use await

### DIFF
--- a/aspnetcore/signalr/hubs/sample/Hubs/ChatHub.cs
+++ b/aspnetcore/signalr/hubs/sample/Hubs/ChatHub.cs
@@ -14,13 +14,13 @@ namespace SignalRChat.Hubs
 
         public Task SendMessageToCaller(string message)
         {
-            return Clients.Caller.SendAsync("ReceiveMessage", message);
+            await Clients.Caller.SendAsync("ReceiveMessage", message);
         }
 
         public Task SendMessageToGroups(string message)
         {
             List<string> groups = new List<string>() { "SignalR Users" };
-            return Clients.Groups(groups).SendAsync("ReceiveMessage", message);
+            await Clients.Groups(groups).SendAsync("ReceiveMessage", message);
         }
 
         public override async Task OnConnectedAsync()


### PR DESCRIPTION
Fixed the methods to use the `await` keyword as opposed to `return` in methods specifying a return type of just `Task`

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
