### PR TITLE
WIP: Identify the package that has UseHsts

### DIFF
--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -105,11 +105,11 @@ Per [OWASP](https://www.owasp.org/index.php/About_The_Open_Web_Application_Secur
 
 ASP.NET Core 2.1 or later implements HSTS with the `UseHsts` extension method. The following code calls `UseHsts` when the app isn't in [development mode](xref:fundamentals/environments):
 
-[!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet1&highlight=10)]
+[!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet1&highlight=10-11)]
 
 `UseHsts` isn't recommended in development because the HSTS header is highly cacheable by browsers. By default, `UseHsts` excludes the local loopback address.
 
-The following code:
+The following code configures HSTS:
 
 [!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet2&highlight=5-12)]
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -30,7 +30,7 @@ We recommend all ASP.NET Core web apps call HTTPS Redirection Middleware ([UseHt
 
 The following code calls `UseHttpsRedirection` in the `Startup` class:
 
-[!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet1&highlight=13)]
+[!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet1&highlight=14)]
 
 The preceding highlighted code:
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -30,7 +30,7 @@ We recommend all ASP.NET Core web apps call HTTPS Redirection Middleware ([UseHt
 
 The following code calls `UseHttpsRedirection` in the `Startup` class:
 
-[!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet1&highlight=14)]
+[!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet1&highlight=13)]
 
 The preceding highlighted code:
 
@@ -103,9 +103,11 @@ Requiring HTTPS globally (`options.Filters.Add(new RequireHttpsAttribute());`) i
 
 Per [OWASP](https://www.owasp.org/index.php/About_The_Open_Web_Application_Security_Project), [HTTP Strict Transport Security (HSTS)](https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet) is an opt-in security enhancement that is specified by a web application through the use of a special response header. Once a supported browser receives this header that browser will prevent any communications from being sent over HTTP to the specified domain and will instead send all communications over HTTPS. It also prevents HTTPS click through prompts on browsers.
 
-ASP.NET Core 2.1 or later implements HSTS with the `UseHsts` extension method. The following code calls `UseHsts` when the app isn't in [development mode](xref:fundamentals/environments):
+ASP.NET Core 2.1 or later implements HSTS with the `UseHsts` extension method. The method is defined in the `Microsoft.AspNetCore.HttpsPolicy` NuGet package, which is included in the [Microsoft.AspnetCore.App](xref:fundamentals/metapackage-app) metapackage.
 
-[!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet1&highlight=10-11)]
+The following code calls `UseHsts` when the app isn't in [development mode](xref:fundamentals/environments):
+
+[!code-csharp[](enforcing-ssl/sample/Startup.cs?name=snippet1&highlight=10)]
 
 `UseHsts` isn't recommended in development because the HSTS header is highly cacheable by browsers. By default, `UseHsts` excludes the local loopback address.
 

--- a/aspnetcore/security/enforcing-ssl/sample/Startup.cs
+++ b/aspnetcore/security/enforcing-ssl/sample/Startup.cs
@@ -48,6 +48,7 @@ namespace WebHTTPS
             else
             {
                 app.UseExceptionHandler("/Error");
+                // Requires NuGet package Microsoft.AspNetCore.HttpsPolicy
                 app.UseHsts();
             }
 

--- a/aspnetcore/security/enforcing-ssl/sample/Startup.cs
+++ b/aspnetcore/security/enforcing-ssl/sample/Startup.cs
@@ -48,7 +48,6 @@ namespace WebHTTPS
             else
             {
                 app.UseExceptionHandler("/Error");
-                // Requires NuGet package Microsoft.AspNetCore.HttpsPolicy
                 app.UseHsts();
             }
 


### PR DESCRIPTION
@Rick-Anderson This uses a code comment to identify the package needed, as we do elsewhere for identifying `using` statements. It could go in the doc text instead.  I didn't specify the using statement because it's the same one already in use for the other UseXXX methods.
