### PR TITLE
Update webapp-alias-notice.md

### DIFF
--- a/aspnetcore/includes/webapp-alias-notice.md
+++ b/aspnetcore/includes/webapp-alias-notice.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> In ASP.NET Core 2.1 or later, `webapp` is an alias of the `razor` argument. If the `dotnet new webapp <OPTIONS>` command loads the [dotnet new](/dotnet/core/tools/dotnet-new) command help instead of creating a new Razor Pages app, install the [.NET Core 2.1 SDK](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300).
+> If the `dotnet new webapp <OPTIONS>` command loads the [dotnet new](/dotnet/core/tools/dotnet-new) command help instead of creating a new Razor Pages app, install the newest version of the .NET Core SDK from [here](https://www.microsoft.com/net/download). In the newest version, `webapp` is an alias of `razor`.

--- a/aspnetcore/includes/webapp-alias-notice.md
+++ b/aspnetcore/includes/webapp-alias-notice.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> If the `dotnet new webapp <OPTIONS>` command loads the [dotnet new](/dotnet/core/tools/dotnet-new) command help instead of creating a new Razor Pages app, install the newest version of the .NET Core SDK from [here](https://www.microsoft.com/net/download). In the newest version, `webapp` is an alias of `razor`.
+> If the `dotnet new webapp <OPTIONS>` command loads the [dotnet new](/dotnet/core/tools/dotnet-new) command help instead of creating a new Razor Pages app, install [.NET Core SDK 2.1.300 or later](https://www.microsoft.com/net/download/archives). As of .NET Core SDK 2.1.300, the `webapp` *Short Name* is an alias for `razor`.


### PR DESCRIPTION
Historical context in https://github.com/aspnet/Docs/issues/6937 & https://github.com/aspnet/Docs/pull/6939.

The current text specifies "2.1", which wasn't specific enough (I had 2.1.200 installed and wondered why it wasn't working). This generalizes things, moves the most important part to the front and changes the download link to the .NET Core download home page instead of the version list.

If you want to keep the link pointed at the version list, I suggest https://www.microsoft.com/net/download/dotnet-core/2.1. The current link points directly to a specific version that is already out of date.