### PR TITLE
Windows Service with HTTPS

### DIFF
--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -248,6 +248,9 @@ var host = WebHost.CreateDefaultBuilder(args)
             });
         });
     })
+    .UseContentRoot(pathToContentRoot)
+    .UseStartup<Startup>()
+    .Build();
 ```
 
 ## Additional resources

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -222,34 +222,7 @@ Services that interact with requests from the Internet or a corporate network an
 
 ## Configure HTTPS
 
-Specify a [Kestrel server HTTPS endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration). The following example specifies an HTTPS port with an [X.509 certificate (X509Certificate2)](/dotnet/api/system.security.cryptography.x509certificates.x509certificate2) provided by [CertificateLoader.LoadFromStoreCert](/dotnet/api/microsoft.aspnetcore.server.kestrel.https.internal.certificateloader.loadfromstorecert). The endpoint configuration:
-
-* Sets the port to 5001.
-* Uses the [local development certificate (localhost)](xref:aspnetcore-2.1#on-by-default).
-* Loads the certificate from the [StoreLocation.LocalMachine](/dotnet/api/system.security.cryptography.x509certificates.storelocation) certificate store. A Windows Service runs under the [LocalSystem](/windows/desktop/services/localsystem-account) account, which requires loading the certificate from the `LocalMachine` store.
-
-```csharp
-var host = WebHost.CreateDefaultBuilder(args)
-    .UseKestrel((context, options) =>
-    {
-        options.ListenAnyIP(5001, listenOptions =>
-        {
-            listenOptions.UseHttps(httpsOptions =>
-            {
-                var cert = CertificateLoader.LoadFromStoreCert(
-                    "localhost", "My", StoreLocation.LocalMachine, 
-                    allowInvalid: true);
-                httpsOptions.ServerCertificateSelector = (connectionContext, name) =>
-                {
-                    return cert;
-                };
-            });
-        });
-    })
-    .UseContentRoot(pathToContentRoot)
-    .UseStartup<Startup>()
-    .Build();
-```
+Specify a [Kestrel server HTTPS endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration).
 
 ## Additional resources
 

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -222,9 +222,7 @@ Services that interact with requests from the Internet or a corporate network an
 
 ## Configure HTTPS
 
-Specify an HTTPS endpoint with an [X509Certificate2](/dotnet/api/system.security.cryptography.x509certificates.x509certificate2) in a [Kestrel server endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration).
-
-The following example specifies an HTTPS port with a certificate provided by [CertificateLoader.LoadFromStoreCert](/dotnet/api/microsoft.aspnetcore.server.kestrel.https.internal.certificateloader.loadfromstorecert). The endpoint configuration:
+Specify a [Kestrel server HTTPS endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration). The following example specifies an HTTPS port with an [X509Certificate2](/dotnet/api/system.security.cryptography.x509certificates.x509certificate2) provided by [CertificateLoader.LoadFromStoreCert](/dotnet/api/microsoft.aspnetcore.server.kestrel.https.internal.certificateloader.loadfromstorecert). The endpoint configuration:
 
 * Sets the port to 5001.
 * Uses the [local development certificate (localhost)](xref:aspnetcore-2.1#on-by-default).

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -222,13 +222,13 @@ Services that interact with requests from the Internet or a corporate network an
 
 ## Configure HTTPS
 
-A Windows Service runs under the [LocalSystem](/windows/desktop/services/localsystem-account) account. Specify an HTTPS port and [X509Certificate2](/dotnet/api/system.security.cryptography.x509certificates.x509certificate2) in a [Kestrel server endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration). 
+Specify an HTTPS port and [X509Certificate2](/dotnet/api/system.security.cryptography.x509certificates.x509certificate2) in a [Kestrel server endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration).
 
 The following example creates an HTTPS endpoint with a certificate provided by [CertificateLoader.LoadFromStoreCert](/dotnet/api/microsoft.aspnetcore.server.kestrel.https.internal.certificateloader.loadfromstorecert). The endpoint configuration:
 
 * Sets the port to 5001.
 * Uses the [local development certificate (localhost)](xref:aspnetcore-2.1#on-by-default).
-* Loads the certificate from the [StoreLocation.LocalMachine](/dotnet/api/system.security.cryptography.x509certificates.storelocation) certificate store, which is accessible by the LocalSystem account.
+* Loads the certificate from the [StoreLocation.LocalMachine](/dotnet/api/system.security.cryptography.x509certificates.storelocation) certificate store. A Windows Service runs under the [LocalSystem](/windows/desktop/services/localsystem-account) account, which requires loading the certificate from the `LocalMachine` store.
 
 ```csharp
 var host = WebHost.CreateDefaultBuilder(args)

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -222,9 +222,9 @@ Services that interact with requests from the Internet or a corporate network an
 
 ## Configure HTTPS
 
-Specify an HTTPS port and [X509Certificate2](/dotnet/api/system.security.cryptography.x509certificates.x509certificate2) in a [Kestrel server endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration).
+Specify an HTTPS endpoint with an [X509Certificate2](/dotnet/api/system.security.cryptography.x509certificates.x509certificate2) in a [Kestrel server endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration).
 
-The following example creates an HTTPS endpoint with a certificate provided by [CertificateLoader.LoadFromStoreCert](/dotnet/api/microsoft.aspnetcore.server.kestrel.https.internal.certificateloader.loadfromstorecert). The endpoint configuration:
+The following example specifies an HTTPS port with a certificate provided by [CertificateLoader.LoadFromStoreCert](/dotnet/api/microsoft.aspnetcore.server.kestrel.https.internal.certificateloader.loadfromstorecert). The endpoint configuration:
 
 * Sets the port to 5001.
 * Uses the [local development certificate (localhost)](xref:aspnetcore-2.1#on-by-default).

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -220,6 +220,36 @@ If the custom `WebHostService` code requires a service from dependency injection
 
 Services that interact with requests from the Internet or a corporate network and are behind a proxy or load balancer might require additional configuration. For more information, see <xref:host-and-deploy/proxy-load-balancer>.
 
+## Configure HTTPS
+
+A Windows Service runs under the [LocalSystem](/windows/desktop/services/localsystem-account) account. Specify an HTTPS port and [X509Certificate2](/dotnet/api/system.security.cryptography.x509certificates.x509certificate2) in a [Kestrel server endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration). 
+
+The following example creates an HTTPS endpoint with a certificate provided by [CertificateLoader.LoadFromStoreCert](/dotnet/api/microsoft.aspnetcore.server.kestrel.https.internal.certificateloader.loadfromstorecert). The endpoint configuration:
+
+* Sets the port to 5001.
+* Uses the [local development certificate (localhost)](xref:aspnetcore-2.1#on-by-default).
+* Loads the certificate from the [StoreLocation.LocalMachine](/dotnet/api/system.security.cryptography.x509certificates.storelocation) certificate store, which is accessible by the LocalSystem account.
+
+```csharp
+var host = WebHost.CreateDefaultBuilder(args)
+    .UseKestrel((context, options) =>
+    {
+        options.ListenAnyIP(5001, listenOptions =>
+        {
+            listenOptions.UseHttps(httpsOptions =>
+            {
+                var cert = CertificateLoader.LoadFromStoreCert(
+                    "localhost", "My", StoreLocation.LocalMachine, 
+                    allowInvalid: true);
+                httpsOptions.ServerCertificateSelector = (connectionContext, name) =>
+                {
+                    return cert;
+                };
+            });
+        });
+    })
+```
+
 ## Additional resources
 
 * [Kestrel endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration) (includes HTTPS configuration and SNI support)

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -222,7 +222,7 @@ Services that interact with requests from the Internet or a corporate network an
 
 ## Configure HTTPS
 
-Specify a [Kestrel server HTTPS endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration). The following example specifies an HTTPS port with an [X509Certificate2](/dotnet/api/system.security.cryptography.x509certificates.x509certificate2) provided by [CertificateLoader.LoadFromStoreCert](/dotnet/api/microsoft.aspnetcore.server.kestrel.https.internal.certificateloader.loadfromstorecert). The endpoint configuration:
+Specify a [Kestrel server HTTPS endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration). The following example specifies an HTTPS port with an [X.509 certificate (X509Certificate2)](/dotnet/api/system.security.cryptography.x509certificates.x509certificate2) provided by [CertificateLoader.LoadFromStoreCert](/dotnet/api/microsoft.aspnetcore.server.kestrel.https.internal.certificateloader.loadfromstorecert). The endpoint configuration:
 
 * Sets the port to 5001.
 * Uses the [local development certificate (localhost)](xref:aspnetcore-2.1#on-by-default).


### PR DESCRIPTION
Fixes #7842 

I didn't need to change anything other than setting `StoreLocation.LocalMachine`. I'm under the impression that a cert install by a user in the `My` store will be available to a WS running under the LocalSystem account *if only this one change is made to the `LoadFromStoreCert` call.* I need engineering confirmation on that point.

cc: @Hugh-walsh