### PR TITLE
Re-transplant SignalR docs to the correct TOC tree

### DIFF
--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -222,6 +222,12 @@
 ### [.NET client](xref:signalr/dotnet-client)
 ### [WebPack and TypeScript](xref:tutorials/signalr-typescript-webpack)
 ### [JavaScript API](/javascript/api/?view=signalr-js-latest)
+## [Configuration](xref:signalr/configuration)
+## [Authentication and authorization](xref:signalr/authn-and-authz)
+## [Security considerations](xref:signalr/security)
+## [MessagePack Hub Protocol](xref:signalr/messagepackhubprotocol)
+## [Streaming](xref:signalr/streaming)
+## [Differences between SignalR versions](xref:signalr/version-differences)
 
 # [Test, debug, and troubleshoot](xref:test/index)
 ## [Unit testing](/dotnet/articles/core/testing/unit-testing-with-dotnet-test)
@@ -267,13 +273,6 @@
 ### [Angular project template](xref:spa/angular)
 ### [React project template](xref:spa/react)
 ### [React with Redux project template](xref:spa/react-with-redux)
-
-## [Configuration](xref:signalr/configuration)
-## [Authentication and authorization](xref:signalr/authn-and-authz)
-## [Security considerations](xref:signalr/security)
-## [MessagePack Hub Protocol](xref:signalr/messagepackhubprotocol)
-## [Streaming](xref:signalr/streaming)
-## [Differences between SignalR versions](xref:signalr/version-differences)
 
 # [Mobile](xref:mobile/index)
 ## [Create backend services for native mobile apps](xref:mobile/native-mobile-backend)


### PR DESCRIPTION
Somehow some of the SignalR docs got moved to the "Client-side development" hive. This should move them back, if I understand how the TOC file works properly :)

[Internal Review Site](https://review.docs.microsoft.com/en-us/aspnet/core/?view=aspnetcore-2.1&branch=anurse%2Ffix-signalr-toc&viewFallbackFrom=aspnetcore-1.0&tabs=visual-studio)

![image](https://user-images.githubusercontent.com/7574/44045530-9febf194-9edd-11e8-9d78-bb23fe1aa922.png)