### PR TITLE
Support .NET API xref links in ASP.NET Core docs

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -35,7 +35,10 @@
       }
     ],
     "overwrite": [],
-    "externalReference": [],    
+    "externalReference": [],
+    "xrefService": [
+      "https://xref.docs.microsoft.com/query?uid={uid}"
+    ],
     "globalMetadata": {
       "_navPath": "/foo",
       "_navRel": "/foo",

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -37,7 +37,7 @@ The `ControllerBase` class provides access to several properties and methods. In
 
 ## Annotate class with ApiControllerAttribute
 
-ASP.NET Core 2.1 introduces the <xref:Microsoft.AspNetCore.Mvc.ApiControllerAttribute?text=[ApiController]> attribute to denote a web API controller class. For example:
+ASP.NET Core 2.1 introduces the [[ApiController]](xref:Microsoft.AspNetCore.Mvc.ApiControllerAttribute) attribute to denote a web API controller class. For example:
 
 [!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Controllers/ProductsController.cs?name=snippet_ControllerSignature&highlight=2)]
 
@@ -69,11 +69,11 @@ A binding source attribute defines the location at which an action parameter's v
 
 |Attribute|Binding source |
 |---------|---------|
-|**<xref:Microsoft.AspNetCore.Mvc.FromBodyAttribute?text=[FromBody]>**     | Request body |
-|**<xref:Microsoft.AspNetCore.Mvc.FromFormAttribute?text=[FromForm]>**     | Form data in the request body |
-|**<xref:Microsoft.AspNetCore.Mvc.FromHeaderAttribute?text=[FromHeader]>** | Request header |
-|**<xref:Microsoft.AspNetCore.Mvc.FromQueryAttribute?text=[FromQuery]>**   | Request query string parameter |
-|**<xref:Microsoft.AspNetCore.Mvc.FromRouteAttribute?text=[FromRoute]>**   | Route data from the current request |
+|**[[FromBody]](xref:Microsoft.AspNetCore.Mvc.FromBodyAttribute)**     | Request body |
+|**[[FromForm]](xref:Microsoft.AspNetCore.Mvc.FromFormAttribute)**     | Form data in the request body |
+|**[[FromHeader]](xref:Microsoft.AspNetCore.Mvc.FromHeaderAttribute)** | Request header |
+|**[[FromQuery]](xref:Microsoft.AspNetCore.Mvc.FromQueryAttribute)**   | Request query string parameter |
+|**[[FromRoute]](xref:Microsoft.AspNetCore.Mvc.FromRouteAttribute)**   | Route data from the current request |
 |**[[FromServices]](xref:mvc/controllers/dependency-injection#action-injection-with-fromservices)** | The request service injected as an action parameter |
 
 > [!WARNING]
@@ -99,7 +99,7 @@ The default inference rules are disabled when the <xref:Microsoft.AspNetCore.Mvc
 
 ### Multipart/form-data request inference
 
-When an action parameter is annotated with the <xref:Microsoft.AspNetCore.Mvc.FromFormAttribute?text=[FromForm]> attribute, the `multipart/form-data` request content type is inferred.
+When an action parameter is annotated with the [[FromForm]](xref:Microsoft.AspNetCore.Mvc.FromFormAttribute) attribute, the `multipart/form-data` request content type is inferred.
 
 The default behavior is disabled when the <xref:Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.SuppressConsumesConstraintForFormFileParameters> property is set to `true`. Add the following code in *Startup.ConfigureServices* after `services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);`:
 

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -45,7 +45,7 @@ A compatibility version of 2.1 or later, set via <xref:Microsoft.Extensions.Depe
 
 [!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Startup.cs?name=snippet_SetCompatibilityVersion&highlight=2)]
 
-The `[ApiController]` attribute is commonly coupled with `ControllerBase` to enable REST-specific behavior for controllers. `ControllerBase` provides access to methods such as <xref:Microsoft.AspNetCore.Mvc.ControllerBase.NotFound> and <xref:Microsoft.AspNetCore.Mvc.ControllerBase.File*>.
+The `[ApiController]` attribute is commonly coupled with `ControllerBase` to enable REST-specific behavior for controllers. `ControllerBase` provides access to methods such as <xref:Microsoft.AspNetCore.Mvc.ControllerBase.NotFound*> and <xref:Microsoft.AspNetCore.Mvc.ControllerBase.File*>.
 
 Another approach is to create a custom base controller class annotated with the `[ApiController]` attribute:
 

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -69,11 +69,11 @@ A binding source attribute defines the location at which an action parameter's v
 
 |Attribute|Binding source |
 |---------|---------|
-|**<xref:Microsoft.AspNetCore.Mvc.FromBodyAttribute?text=[[FromBody]]>**     | Request body |
-|**<xref:Microsoft.AspNetCore.Mvc.FromFormAttribute?text=[[FromForm]]>**     | Form data in the request body |
-|**<xref:Microsoft.AspNetCore.Mvc.FromHeaderAttribute?text=[[FromHeader]]>** | Request header |
-|**<xref:Microsoft.AspNetCore.Mvc.FromQueryAttribute?text=[[FromQuery]]>**   | Request query string parameter |
-|**<xref:Microsoft.AspNetCore.Mvc.FromRouteAttribute?text=[[FromRoute]]>**   | Route data from the current request |
+|**<xref:Microsoft.AspNetCore.Mvc.FromBodyAttribute?text=[FromBody]>**     | Request body |
+|**<xref:Microsoft.AspNetCore.Mvc.FromFormAttribute?text=[FromForm]>**     | Form data in the request body |
+|**<xref:Microsoft.AspNetCore.Mvc.FromHeaderAttribute?text=[FromHeader]>** | Request header |
+|**<xref:Microsoft.AspNetCore.Mvc.FromQueryAttribute?text=[FromQuery]>**   | Request query string parameter |
+|**<xref:Microsoft.AspNetCore.Mvc.FromRouteAttribute?text=[FromRoute]>**   | Route data from the current request |
 |**[[FromServices]](xref:mvc/controllers/dependency-injection#action-injection-with-fromservices)** | The request service injected as an action parameter |
 
 > [!WARNING]

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -4,7 +4,7 @@ author: scottaddie
 description: Learn about the features available for building a web API in ASP.NET Core and when it's appropriate to use each feature.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 08/14/2018
+ms.date: 08/15/2018
 uid: web-api/index
 ---
 # Build web APIs with ASP.NET Core
@@ -17,7 +17,7 @@ This document explains how to build a web API in ASP.NET Core and when it's most
 
 ## Derive class from ControllerBase
 
-Inherit from the [ControllerBase](/dotnet/api/microsoft.aspnetcore.mvc.controllerbase) class in a controller that's intended to serve as a web API. For example:
+Inherit from the <xref:Microsoft.AspNetCore.Mvc.ControllerBase> class in a controller that's intended to serve as a web API. For example:
 
 ::: moniker range=">= aspnetcore-2.1"
 
@@ -31,21 +31,21 @@ Inherit from the [ControllerBase](/dotnet/api/microsoft.aspnetcore.mvc.controlle
 
 ::: moniker-end
 
-The `ControllerBase` class provides access to several properties and methods. In the preceding code, examples include [BadRequest](/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.badrequest) and [CreatedAtAction](/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.createdataction). These methods are called within action methods to return HTTP 400 and 201 status codes, respectively. The [ModelState](/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.modelstate) property, also provided by `ControllerBase`, is accessed to handle request model validation.
+The `ControllerBase` class provides access to several properties and methods. In the preceding code, examples include <xref:Microsoft.AspNetCore.Mvc.ControllerBase.BadRequest(Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary)> and <xref:Microsoft.AspNetCore.Mvc.ControllerBase.CreatedAtAction(System.String,System.Object,System.Object)>. These methods are called within action methods to return HTTP 400 and 201 status codes, respectively. The <xref:Microsoft.AspNetCore.Mvc.ControllerBase.ModelState> property, also provided by `ControllerBase`, is accessed to handle request model validation.
 
 ::: moniker range=">= aspnetcore-2.1"
 
 ## Annotate class with ApiControllerAttribute
 
-ASP.NET Core 2.1 introduces the [[ApiController]](/dotnet/api/microsoft.aspnetcore.mvc.apicontrollerattribute) attribute to denote a web API controller class. For example:
+ASP.NET Core 2.1 introduces the <xref:Microsoft.AspNetCore.Mvc.ApiControllerAttribute?text=[ApiController]> attribute to denote a web API controller class. For example:
 
 [!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Controllers/ProductsController.cs?name=snippet_ControllerSignature&highlight=2)]
 
-A compatibility version of 2.1 or later, set via [SetCompatibilityVersion](/dotnet/api/microsoft.extensions.dependencyinjection.mvccoremvcbuilderextensions.setcompatibilityversion), is required to use this attribute. For example, the highlighted code in *Startup.ConfigureServices* sets the 2.1 compatibility flag:
+A compatibility version of 2.1 or later, set via <xref:Microsoft.Extensions.DependencyInjection.MvcCoreMvcBuilderExtensions.SetCompatibilityVersion*>, is required to use this attribute. For example, the highlighted code in *Startup.ConfigureServices* sets the 2.1 compatibility flag:
 
 [!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Startup.cs?name=snippet_SetCompatibilityVersion&highlight=2)]
 
-The `[ApiController]` attribute is commonly coupled with `ControllerBase` to enable REST-specific behavior for controllers. `ControllerBase` provides access to methods such as [NotFound](/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.notfound) and [File](/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.file).
+The `[ApiController]` attribute is commonly coupled with `ControllerBase` to enable REST-specific behavior for controllers. `ControllerBase` provides access to methods such as <xref:Microsoft.AspNetCore.Mvc.ControllerBase.NotFound> and <xref:Microsoft.AspNetCore.Mvc.ControllerBase.File*>.
 
 Another approach is to create a custom base controller class annotated with the `[ApiController]` attribute:
 
@@ -59,7 +59,7 @@ Validation errors automatically trigger an HTTP 400 response. The following code
 
 [!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api.Pre21/Controllers/PetsController.cs?name=snippet_ModelStateIsValidCheck)]
 
-The default behavior is disabled when the [SuppressModelStateInvalidFilter](/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.suppressmodelstateinvalidfilter) property is set to `true`. Add the following code in *Startup.ConfigureServices* after `services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);`:
+The default behavior is disabled when the <xref:Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.SuppressModelStateInvalidFilter> property is set to `true`. Add the following code in *Startup.ConfigureServices* after `services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);`:
 
 [!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Startup.cs?name=snippet_ConfigureApiBehaviorOptions&highlight=5)]
 
@@ -69,11 +69,11 @@ A binding source attribute defines the location at which an action parameter's v
 
 |Attribute|Binding source |
 |---------|---------|
-|**[[FromBody]](/dotnet/api/microsoft.aspnetcore.mvc.frombodyattribute)**     | Request body |
-|**[[FromForm]](/dotnet/api/microsoft.aspnetcore.mvc.fromformattribute)**     | Form data in the request body |
-|**[[FromHeader]](/dotnet/api/microsoft.aspnetcore.mvc.fromheaderattribute)** | Request header |
-|**[[FromQuery]](/dotnet/api/microsoft.aspnetcore.mvc.fromqueryattribute)**   | Request query string parameter |
-|**[[FromRoute]](/dotnet/api/microsoft.aspnetcore.mvc.fromrouteattribute)**   | Route data from the current request |
+|**<xref:Microsoft.AspNetCore.Mvc.FromBodyAttribute?text=[[FromBody]]>**     | Request body |
+|**<xref:Microsoft.AspNetCore.Mvc.FromFormAttribute?text=[[FromForm]]>**     | Form data in the request body |
+|**<xref:Microsoft.AspNetCore.Mvc.FromHeaderAttribute?text=[[FromHeader]]>** | Request header |
+|**<xref:Microsoft.AspNetCore.Mvc.FromQueryAttribute?text=[[FromQuery]]>**   | Request query string parameter |
+|**<xref:Microsoft.AspNetCore.Mvc.FromRouteAttribute?text=[[FromRoute]]>**   | Route data from the current request |
 |**[[FromServices]](xref:mvc/controllers/dependency-injection#action-injection-with-fromservices)** | The request service injected as an action parameter |
 
 > [!WARNING]
@@ -85,23 +85,23 @@ Without the `[ApiController]` attribute, binding source attributes are explicitl
 
 Inference rules are applied for the default data sources of action parameters. These rules configure the binding sources you're otherwise likely to manually apply to the action parameters. The binding source attributes behave as follows:
 
-* **[FromBody]** is inferred for complex type parameters. An exception to this rule is any complex, built-in type with a special meaning, such as [IFormCollection](/dotnet/api/microsoft.aspnetcore.http.iformcollection) and [CancellationToken](/dotnet/api/system.threading.cancellationtoken). The binding source inference code ignores those special types. `[FromBody]` isn't inferred for simple types such as `string` or `int`. Therefore, the `[FromBody]` attribute should be used for simple types when that functionality is desired. When an action has more than one parameter explicitly specified (via `[FromBody]`) or inferred as bound from the request body, an exception is thrown. For example, the following action signatures cause an exception:
+* **[FromBody]** is inferred for complex type parameters. An exception to this rule is any complex, built-in type with a special meaning, such as <xref:Microsoft.AspNetCore.Http.IFormCollection> and <xref:System.Threading.CancellationToken>. The binding source inference code ignores those special types. `[FromBody]` isn't inferred for simple types such as `string` or `int`. Therefore, the `[FromBody]` attribute should be used for simple types when that functionality is desired. When an action has more than one parameter explicitly specified (via `[FromBody]`) or inferred as bound from the request body, an exception is thrown. For example, the following action signatures cause an exception:
 
 [!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Controllers/TestController.cs?name=snippet_ActionsCausingExceptions)]
 
-* **[FromForm]** is inferred for action parameters of type [IFormFile](/dotnet/api/microsoft.aspnetcore.http.iformfile) and [IFormFileCollection](/dotnet/api/microsoft.aspnetcore.http.iformfilecollection). It's not inferred for any simple or user-defined types.
+* **[FromForm]** is inferred for action parameters of type <xref:Microsoft.AspNetCore.Http.IFormFile> and <xref:Microsoft.AspNetCore.Http.IFormFileCollection>. It's not inferred for any simple or user-defined types.
 * **[FromRoute]** is inferred for any action parameter name matching a parameter in the route template. When more than one route matches an action parameter, any route value is considered `[FromRoute]`.
 * **[FromQuery]** is inferred for any other action parameters.
 
-The default inference rules are disabled when the [SuppressInferBindingSourcesForParameters](/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.suppressinferbindingsourcesforparameters) property is set to `true`. Add the following code in *Startup.ConfigureServices* after `services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);`:
+The default inference rules are disabled when the <xref:Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.SuppressInferBindingSourcesForParameters> property is set to `true`. Add the following code in *Startup.ConfigureServices* after `services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);`:
 
 [!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Startup.cs?name=snippet_ConfigureApiBehaviorOptions&highlight=4)]
 
 ### Multipart/form-data request inference
 
-When an action parameter is annotated with the [[FromForm]](/dotnet/api/microsoft.aspnetcore.mvc.fromformattribute) attribute, the `multipart/form-data` request content type is inferred.
+When an action parameter is annotated with the <xref:Microsoft.AspNetCore.Mvc.FromFormAttribute?text=[FromForm]> attribute, the `multipart/form-data` request content type is inferred.
 
-The default behavior is disabled when the [SuppressConsumesConstraintForFormFileParameters](/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.suppressconsumesconstraintforformfileparameters) property is set to `true`. Add the following code in *Startup.ConfigureServices* after `services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);`:
+The default behavior is disabled when the <xref:Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.SuppressConsumesConstraintForFormFileParameters> property is set to `true`. Add the following code in *Startup.ConfigureServices* after `services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);`:
 
 [!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Startup.cs?name=snippet_ConfigureApiBehaviorOptions&highlight=3)]
 
@@ -111,7 +111,7 @@ Attribute routing becomes a requirement. For example:
 
 [!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Controllers/ProductsController.cs?name=snippet_ControllerSignature&highlight=1)]
 
-Actions are inaccessible via [conventional routes](xref:mvc/controllers/routing#conventional-routing) defined in [UseMvc](/dotnet/api/microsoft.aspnetcore.builder.mvcapplicationbuilderextensions.usemvc#Microsoft_AspNetCore_Builder_MvcApplicationBuilderExtensions_UseMvc_Microsoft_AspNetCore_Builder_IApplicationBuilder_System_Action_Microsoft_AspNetCore_Routing_IRouteBuilder__) or by [UseMvcWithDefaultRoute](/dotnet/api/microsoft.aspnetcore.builder.mvcapplicationbuilderextensions.usemvcwithdefaultroute#Microsoft_AspNetCore_Builder_MvcApplicationBuilderExtensions_UseMvcWithDefaultRoute_Microsoft_AspNetCore_Builder_IApplicationBuilder_) in *Startup.Configure*.
+Actions are inaccessible via [conventional routes](xref:mvc/controllers/routing#conventional-routing) defined in <xref:Microsoft.AspNetCore.Builder.MvcApplicationBuilderExtensions.UseMvc*> or by <xref:Microsoft.AspNetCore.Builder.MvcApplicationBuilderExtensions.UseMvcWithDefaultRoute*> in *Startup.Configure*.
 
 ::: moniker-end
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/Docs/issues/7064

Modified 1 doc to demonstrate the new syntax. See http://dotnet.github.io/docfx/tutorial/links_and_cross_references.html#cross-reference-services for more context around the *docfx.json* file change.

[Internal Review Page](https://review.docs.microsoft.com/en-us/aspnet/core/web-api/?branch=pr-en-us-8112&view=aspnetcore-2.1#additional-resources)

/cc: @mairaw I took a different approach than how it's done in the dotnet/docs repo. Copying you in case you're interested in this solution.