### PR TITLE
synchronize link to updated sample code that use VS 2017

### DIFF
--- a/aspnet/web-api/overview/testing-and-debugging/mocking-entity-framework-when-unit-testing-aspnet-web-api-2.md
+++ b/aspnet/web-api/overview/testing-and-debugging/mocking-entity-framework-when-unit-testing-aspnet-web-api-2.md
@@ -13,7 +13,7 @@ Mocking Entity Framework when Unit Testing ASP.NET Web API 2
 ====================
 by [Tom FitzMacken](https://github.com/tfitzmac)
 
-[Download Completed Project](http://code.msdn.microsoft.com/Unit-Testing-with-ASPNET-e2867d4d)
+[Download Completed Project](https://code.msdn.microsoft.com/Unit-Testing-with-ASPNET-1374bc11)
 
 > This guidance and application demonstrate how to create unit tests for your Web API 2 application that uses the Entity Framework. It shows how to modify the scaffolded controller to enable passing a context object for testing, and how to create test objects that work with Entity Framework.
 > 

--- a/aspnet/web-api/overview/testing-and-debugging/unit-testing-with-aspnet-web-api.md
+++ b/aspnet/web-api/overview/testing-and-debugging/unit-testing-with-aspnet-web-api.md
@@ -13,7 +13,7 @@ Unit Testing ASP.NET Web API 2
 ====================
 by [Tom FitzMacken](https://github.com/tfitzmac)
 
-[Download Completed Project](http://code.msdn.microsoft.com/Unit-Testing-with-ASPNET-e2867d4d)
+[Download Completed Project](https://code.msdn.microsoft.com/Unit-Testing-with-ASPNET-1374bc11)
 
 > This guidance and application demonstrate how to create simple unit tests for your Web API 2 application. This tutorial shows how to include a unit test project in your solution, and write test methods that check the returned values from a controller method.
 > 


### PR DESCRIPTION
Synchronize the link to sample code at the top description to be the same link to sample code that use VS 2017.

* Refers to #4308 because looks like the link from the top description isn't the same as the "Download the complete code" link. The top description still points to the old VS 2013 sample code, therefore I update the link to be the same link as I have submitted before 🙂 

cc @scottaddie 