### PR TITLE
Reorganize Windows Service samp app config

### DIFF
--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -66,7 +66,7 @@ The following minimum changes are required to set up an existing ASP.NET Core pr
 
      ::: moniker range=">= aspnetcore-2.0"
 
-     [!code-csharp[](windows-service/samples/2.x/AspNetCoreService/Program.cs?name=ServiceOnly&highlight=8-9,12)]
+     [!code-csharp[](windows-service/samples/2.x/AspNetCoreService/Program.cs?name=ServiceOnly&highlight=8-9,16)]
 
      ::: moniker-end
 
@@ -199,7 +199,7 @@ To handle [OnStarting](/dotnet/api/microsoft.aspnetcore.hosting.windowsservices.
 
    ::: moniker range=">= aspnetcore-2.0"
 
-   [!code-csharp[](windows-service/samples/2.x/AspNetCoreService/Program.cs?name=HandleStopStart&highlight=14)]
+   [!code-csharp[](windows-service/samples/2.x/AspNetCoreService/Program.cs?name=HandleStopStart&highlight=17)]
 
    > [!NOTE]
    > `isService` isn't passed from `Main` into `CreateWebHostBuilder` because the signature of `CreateWebHostBuilder` must be `CreateWebHostBuilder(string[])` in order for [integration testing](xref:test/integration-tests) to work properly.

--- a/aspnetcore/host-and-deploy/windows-service/samples/2.x/AspNetCoreService/Program.cs
+++ b/aspnetcore/host-and-deploy/windows-service/samples/2.x/AspNetCoreService/Program.cs
@@ -22,6 +22,10 @@ namespace AspNetCoreService
             var pathToContentRoot = Path.GetDirectoryName(pathToExe);
 
             return WebHost.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((context, config) =>
+                {
+                    // Configure the app here.
+                })
                 .UseContentRoot(pathToContentRoot)
                 .UseStartup<Startup>();
         }
@@ -55,6 +59,10 @@ namespace AspNetCoreService
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((context, config) =>
+                {
+                    // Configure the app here.
+                })
                 .UseStartup<Startup>();
         #endregion
 #endif
@@ -86,6 +94,10 @@ namespace AspNetCoreService
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((context, config) =>
+                {
+                    // Configure the app here.
+                })
                 .UseStartup<Startup>();
         #endregion
 #endif

--- a/aspnetcore/host-and-deploy/windows-service/samples/2.x/AspNetCoreService/Startup.cs
+++ b/aspnetcore/host-and-deploy/windows-service/samples/2.x/AspNetCoreService/Startup.cs
@@ -9,12 +9,12 @@ namespace AspNetCoreService
 {
     public class Startup
     {
+        private readonly IConfiguration _config;
+
         public Startup(IConfiguration config)
         {
-            Configuration = config;
+            _config = config;
         }
-
-        public IConfiguration Configuration { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)

--- a/aspnetcore/host-and-deploy/windows-service/samples_snapshot/1.x/AspNetCoreService/Startup.cs
+++ b/aspnetcore/host-and-deploy/windows-service/samples_snapshot/1.x/AspNetCoreService/Startup.cs
@@ -9,23 +9,23 @@ namespace AspNetCoreService
 {
     public class Startup
     {
-        public Startup(IConfiguration config)
+        public Startup(IHostingEnvironment env)
         {
-            Configuration = config;
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
+
+            Configuration = builder.Build();
         }
 
-        public IConfiguration Configuration { get; }
+        public IConfigurationRoot Configuration { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
-
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            services.AddMvc();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -38,12 +38,9 @@ namespace AspNetCoreService
             else
             {
                 app.UseExceptionHandler("/Error");
-                app.UseHsts();
             }
 
-            app.UseHttpsRedirection();
             app.UseStaticFiles();
-            app.UseCookiePolicy();
             app.UseMvc();
         }
     }


### PR DESCRIPTION
Fixes #8131 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/windows-service?view=aspnetcore-1.0&branch=pr-en-us-8136)

* Provide a hint for `ConfigureAppConfiguration`.
* Drop the `ConfigurationBuilder` in `Startup` (not needed with `CreateDefaultBuilder` and we don't want 2.1+ devs going that way).

I'm retaining (but not wiring up) the original `Startup` as a snapshot file in case I need to show the 1.x/2.0 approach in the future.

cc: @Eldorian