### PR TITLE
SignalR: Add table to help identify version

### DIFF
--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -12,7 +12,7 @@ uid: signalr/version-differences
 
 ASP.NET Core SignalR is not compatible with clients or servers for ASP.NET SignalR. This article details the features which have been removed or changed in the ASP.NET Core SignalR.
 
-## How to identify which version of SignalR you are using:
+## How to identify which version of SignalR you are using
 
 |                      | ASP.NET SignalR | ASP.NET Core SignalR |
 | -------------------- | --------------- | -------------------- |

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -53,7 +53,7 @@ app.UseSignalR(routes =>
 
 ### Sticky sessions now required
 
-Because of how scale-out worked in ASP.NET SignalR, clients could reconnect and send messages to any server in the farm. Due to changes to the scale-out model, as well as not supporting reconnects, this is no longer supported. Once the client connects to the server it must interact with the same server for the duration of the connection.
+Because of how scale-out worked in ASP.NET SignalR, clients could reconnect and send messages to any server in the farm. Due to changes to the scale-out model, as well as not supporting reconnects, this is no longer supported. Once the client connects to the server, it must interact with the same server for the duration of the connection.
 
 ### Single hub per connection
 

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -8,9 +8,19 @@ ms.date: 06/30/2018
 uid: signalr/version-differences
 ---
 
-# Differences between SignalR and ASP.NET Core SignalR
+# Differences between ASP.NET SignalR and ASP.NET Core SignalR
 
-ASP.NET Core SignalR is not compatible with clients or servers for ASP.NET 4.x SignalR. This article details the features which have been removed or changed in the ASP.NET Core SignalR.
+ASP.NET Core SignalR is not compatible with clients or servers for ASP.NET SignalR. This article details the features which have been removed or changed in the ASP.NET Core SignalR.
+
+## How to identify which version of SignalR you are using:
+
+|                      | ASP.NET SignalR | ASP.NET Core SignalR |
+| -------------------- | --------------- | -------------------- |
+| Server NuGet Package | [Microsoft.AspNet.SignalR](https://www.nuget.org/packages/Microsoft.AspNet.SignalR/) | [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App/) |
+| Client NuGet Packages | [Microsoft.AspNet.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.Client/) [Microsoft.AspNet.SignalR.JS](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.JS/) | [Microsoft.AspNetCore.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client/) |
+| Client NPM Package | [signalr](https://www.npmjs.com/package/signalr) | [@aspnet/signalr](https://www.npmjs.com/package/@aspnet/signalr) |
+| Server App Type | ASP.NET (System.Web) or OWIN Self-Host | ASP.NET Core |
+| Supported Server Platforms | .NET Framework 4.5 | .NET Framework 4.6.1<br/>.NET Core 2.1 |
 
 ## Feature differences
 
@@ -24,12 +34,12 @@ ASP.NET Core SignalR supports JSON, as well as a new binary protocol based on [M
 
 ## Differences on the server
 
-The SignalR server-side libraries are included in the `Microsoft.AspNetCore.App` package that is part of the **ASP.NET Core Web Application** template for both Razor and MVC projects.
+The ASP.NET Core SignalR server-side libraries are included in the `Microsoft.AspNetCore.App` package that is part of the **ASP.NET Core Web Application** template for both Razor and MVC projects.
 
-SignalR is an ASP.NET Core middleware, so it must be configured by calling `AddSignalR` in `Startup.ConfigureServices`.
+ASP.NET Core SignalR is an ASP.NET Core middleware, so it must be configured by calling `AddSignalR` in `Startup.ConfigureServices`.
 
 ```csharp
-services.AddSignalR();
+services.AddSignalR()
 ```
 
 To configure routing, map routes to hubs inside the `UseSignalR` method call in the `Startup.Configure` method.
@@ -43,7 +53,7 @@ app.UseSignalR(routes =>
 
 ### Sticky sessions now required
 
-Because of how scale-out worked in the previous versions of SignalR, clients could reconnect and send messages to any server in the farm. Due to changes to the scale-out model, as well as not supporting reconnects, this is no longer supported. Now, once the client connects to the server it needs to interact with the same server for the duration of the connection.
+Because of how scale-out worked in ASP.NET SignalR, clients could reconnect and send messages to any server in the farm. Due to changes to the scale-out model, as well as not supporting reconnects, this is no longer supported. Now, once the client connects to the server it needs to interact with the same server for the duration of the connection.
 
 ### Single hub per connection
 
@@ -51,7 +61,7 @@ In ASP.NET Core SignalR, the connection model has been simplified. Connections a
 
 ### Streaming
 
-SignalR now supports [streaming data](xref:signalr/streaming) from the hub to the client.
+ASP.NET Core SignalR now supports [streaming data](xref:signalr/streaming) from the hub to the client.
 
 ### State
 
@@ -61,7 +71,7 @@ The ability to pass arbitrary state between clients and the hub (often called Hu
 
 ### TypeScript
 
-The ASP.NET Core version of SignalR is written in [TypeScript](https://www.typescriptlang.org/). You can write in JavaScript or TypeScript when using the [JavaScript client](xref:signalr/javascript-client).
+The ASP.NET Core SignalR is written in [TypeScript](https://www.typescriptlang.org/). You can write in JavaScript or TypeScript when using the [JavaScript client](xref:signalr/javascript-client).
 
 ### The JavaScript client is hosted at [npm](https://www.npmjs.com/)
 

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -20,7 +20,7 @@ ASP.NET Core SignalR isn't compatible with clients or servers for ASP.NET Signal
 | Client NuGet Packages | [Microsoft.AspNet.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.Client/) [Microsoft.AspNet.SignalR.JS](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.JS/) | [Microsoft.AspNetCore.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client/) |
 | Client NPM Package | [signalr](https://www.npmjs.com/package/signalr) | [@aspnet/signalr](https://www.npmjs.com/package/@aspnet/signalr) |
 | Server App Type | ASP.NET (System.Web) or OWIN Self-Host | ASP.NET Core |
-| Supported Server Platforms | .NET Framework 4.5 | .NET Framework 4.6.1<br/>.NET Core 2.1 |
+| Supported Server Platforms | .NET Framework 4.5 | .NET Framework 4.6.1<br>.NET Core 2.1 |
 
 ## Feature differences
 

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -36,13 +36,13 @@ ASP.NET Core SignalR supports JSON, as well as a new binary protocol based on [M
 
 The ASP.NET Core SignalR server-side libraries are included in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app) package that's part of the **ASP.NET Core Web Application** template for both Razor and MVC projects.
 
-ASP.NET Core SignalR is an ASP.NET Core middleware, so it must be configured by calling [AddSignalR](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.signalrdependencyinjectionextensions.addsignalr?view=aspnetcore-2.1) in `Startup.ConfigureServices`.
+ASP.NET Core SignalR is an ASP.NET Core middleware, so it must be configured by calling [AddSignalR](/dotnet/api/microsoft.extensions.dependencyinjection.signalrdependencyinjectionextensions.addsignalr) in `Startup.ConfigureServices`.
 
 ```csharp
 services.AddSignalR()
 ```
 
-To configure routing, map routes to hubs inside the [UseSignalR](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.signalrappbuilderextensions.usesignalr?view=aspnetcore-2.1) method call in the `Startup.Configure` method.
+To configure routing, map routes to hubs inside the [UseSignalR](/dotnet/api/microsoft.aspnetcore.builder.signalrappbuilderextensions.usesignalr) method call in the `Startup.Configure` method.
 
 ```csharp
 app.UseSignalR(routes =>
@@ -88,7 +88,7 @@ The dependency on jQuery has been removed, however projects can still use jQuery
 
 ### JavaScript client method syntax
 
-The JavaScript syntax has changed from the previous version of SignalR. Rather than using the `$connection` object, create a connection using the [HubConnectionBuilder](https://docs.microsoft.com/en-us/javascript/api/%40aspnet/signalr/hubconnectionbuilder?view=signalr-js-latest) API.
+The JavaScript syntax has changed from the previous version of SignalR. Rather than using the `$connection` object, create a connection using the [HubConnectionBuilder](/javascript/api/%40aspnet/signalr/hubconnectionbuilder) API.
 
 ```javascript
 const connection = new signalR.HubConnectionBuilder()
@@ -96,7 +96,7 @@ const connection = new signalR.HubConnectionBuilder()
     .build();
 ```
 
-Use the [on](https://docs.microsoft.com/en-us/javascript/api/@aspnet/signalr/HubConnection?view=signalr-js-latest#on) method to specify client methods that the hub can call.
+Use the [on](/javascript/api/@aspnet/signalr/HubConnection#on) method to specify client methods that the hub can call.
 
 ```javascript
 connection.on("ReceiveMessage", (user, message) => {
@@ -114,13 +114,13 @@ connection.start().catch(err => console.error(err.toString()));
 
 ### Hub proxies
 
-Hub proxies are no longer automatically generated. Instead, the method name is passed into the [invoke](https://docs.microsoft.com/en-us/javascript/api/%40aspnet/signalr/hubconnection?view=signalr-js-latest#invoke) API as a string.
+Hub proxies are no longer automatically generated. Instead, the method name is passed into the [invoke](/javascript/api/%40aspnet/signalr/hubconnection#invoke) API as a string.
 
 ### .NET and other clients
 
 The `Microsoft.AspNetCore.SignalR.Client` NuGet package contains the .NET client libraries for ASP.NET Core SignalR.
 
-Use the [HubConnectionBuilder](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.signalr.client.hubconnectionbuilder?view=aspnetcore-2.1) to create and build an instance of a connection to a hub.
+Use the [HubConnectionBuilder](/dotnet/api/microsoft.aspnetcore.signalr.client.hubconnectionbuilder) to create and build an instance of a connection to a hub.
 
 ```csharp
 connection = new HubConnectionBuilder()

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -106,7 +106,7 @@ connection.on("ReceiveMessage", (user, message) => {
 });
 ```
 
-After creating the client method, start the hub connection. Chain a [catch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch) method to log or handle errors.
+After creating the client method, start the hub connection. Chain a [catch](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch) method to log or handle errors.
 
 ```javascript
 connection.start().catch(err => console.error(err.toString()));

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -10,9 +10,9 @@ uid: signalr/version-differences
 
 # Differences between ASP.NET SignalR and ASP.NET Core SignalR
 
-ASP.NET Core SignalR is not compatible with clients or servers for ASP.NET SignalR. This article details the features which have been removed or changed in the ASP.NET Core SignalR.
+ASP.NET Core SignalR isn't compatible with clients or servers for ASP.NET SignalR. This article details features which have been removed or changed in ASP.NET Core SignalR.
 
-## How to identify which version of SignalR you are using
+## How to identify the SignalR version
 
 |                      | ASP.NET SignalR | ASP.NET Core SignalR |
 | -------------------- | --------------- | -------------------- |
@@ -34,15 +34,15 @@ ASP.NET Core SignalR supports JSON, as well as a new binary protocol based on [M
 
 ## Differences on the server
 
-The ASP.NET Core SignalR server-side libraries are included in the `Microsoft.AspNetCore.App` package that is part of the **ASP.NET Core Web Application** template for both Razor and MVC projects.
+The ASP.NET Core SignalR server-side libraries are included in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app) package that's part of the **ASP.NET Core Web Application** template for both Razor and MVC projects.
 
-ASP.NET Core SignalR is an ASP.NET Core middleware, so it must be configured by calling `AddSignalR` in `Startup.ConfigureServices`.
+ASP.NET Core SignalR is an ASP.NET Core middleware, so it must be configured by calling [AddSignalR](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.signalrdependencyinjectionextensions.addsignalr?view=aspnetcore-2.1) in `Startup.ConfigureServices`.
 
 ```csharp
 services.AddSignalR()
 ```
 
-To configure routing, map routes to hubs inside the `UseSignalR` method call in the `Startup.Configure` method.
+To configure routing, map routes to hubs inside the [UseSignalR](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.signalrappbuilderextensions.usesignalr?view=aspnetcore-2.1) method call in the `Startup.Configure` method.
 
 ```csharp
 app.UseSignalR(routes =>
@@ -53,7 +53,7 @@ app.UseSignalR(routes =>
 
 ### Sticky sessions now required
 
-Because of how scale-out worked in ASP.NET SignalR, clients could reconnect and send messages to any server in the farm. Due to changes to the scale-out model, as well as not supporting reconnects, this is no longer supported. Now, once the client connects to the server it needs to interact with the same server for the duration of the connection.
+Because of how scale-out worked in ASP.NET SignalR, clients could reconnect and send messages to any server in the farm. Due to changes to the scale-out model, as well as not supporting reconnects, this is no longer supported. Once the client connects to the server it must interact with the same server for the duration of the connection.
 
 ### Single hub per connection
 
@@ -71,11 +71,11 @@ The ability to pass arbitrary state between clients and the hub (often called Hu
 
 ### TypeScript
 
-The ASP.NET Core SignalR is written in [TypeScript](https://www.typescriptlang.org/). You can write in JavaScript or TypeScript when using the [JavaScript client](xref:signalr/javascript-client).
+The ASP.NET Core SignalR client is written in [TypeScript](https://www.typescriptlang.org/). You can write in JavaScript or TypeScript when using the [JavaScript client](xref:signalr/javascript-client).
 
 ### The JavaScript client is hosted at [npm](https://www.npmjs.com/)
 
-In previous versions, the JavaScript client was obtained through a NuGet package in Visual Studio. For the Core versions, the [@aspnet/signalr npm package](https://www.npmjs.com/package/@aspnet/signalr) contains the JavaScript libraries. This package isn't included in the **ASP.NET Core Web Application** template. Use npm to obtain and install the `@aspnet/signalr` npm package.
+In previous versions, the JavaScript client was obtained through a NuGet package in Visual Studio. For the Core versions, the [@aspnet/signalr](https://www.npmjs.com/package/@aspnet/signalr) npm package contains the JavaScript libraries. This package isn't included in the **ASP.NET Core Web Application** template. Use npm to obtain and install the `@aspnet/signalr` npm package.
 
 ```console
 npm init -y
@@ -88,7 +88,7 @@ The dependency on jQuery has been removed, however projects can still use jQuery
 
 ### JavaScript client method syntax
 
-The JavaScript syntax has changed from the previous version of SignalR. Rather than using the `$connection` object, create a connection using the `HubConnectionBuilder` API.
+The JavaScript syntax has changed from the previous version of SignalR. Rather than using the `$connection` object, create a connection using the [HubConnectionBuilder](https://docs.microsoft.com/en-us/javascript/api/%40aspnet/signalr/hubconnectionbuilder?view=signalr-js-latest) API.
 
 ```javascript
 const connection = new signalR.HubConnectionBuilder()
@@ -96,7 +96,7 @@ const connection = new signalR.HubConnectionBuilder()
     .build();
 ```
 
-Use `connection.on` to specify client methods that the hub can call.
+Use the [on](https://docs.microsoft.com/en-us/javascript/api/@aspnet/signalr/HubConnection?view=signalr-js-latest#on) method to specify client methods that the hub can call.
 
 ```javascript
 connection.on("ReceiveMessage", (user, message) => {
@@ -106,7 +106,7 @@ connection.on("ReceiveMessage", (user, message) => {
 });
 ```
 
-After creating the client method, start the hub connection. Chain a `catch` method to log or handle errors.
+After creating the client method, start the hub connection. Chain a [catch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch) method to log or handle errors.
 
 ```javascript
 connection.start().catch(err => console.error(err.toString()));
@@ -114,13 +114,13 @@ connection.start().catch(err => console.error(err.toString()));
 
 ### Hub proxies
 
-Hub proxies are no longer automatically generated. Instead, the method name is passed into the `invoke` API as a string.
+Hub proxies are no longer automatically generated. Instead, the method name is passed into the [invoke](https://docs.microsoft.com/en-us/javascript/api/%40aspnet/signalr/hubconnection?view=signalr-js-latest#invoke) API as a string.
 
 ### .NET and other clients
 
 The `Microsoft.AspNetCore.SignalR.Client` NuGet package contains the .NET client libraries for ASP.NET Core SignalR.
 
-Use the `HubConnectionBuilder` to create and build an instance of a connection to a hub.
+Use the [HubConnectionBuilder](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.signalr.client.hubconnectionbuilder?view=aspnetcore-2.1) to create and build an instance of a connection to a hub.
 
 ```csharp
 connection = new HubConnectionBuilder()


### PR DESCRIPTION
Adds a section to the ASP.NET Core SignalR Differences document to help identify the version you are using. This can be a helpful resource when customers aren't sure which version is which.

We're also adding a link to this doc (through an `aka.ms` forwarder) to some new version detection logic we're adding to the client (see https://github.com/aspnet/SignalR/pull/2820). I'm not 100% confident in putting a link in an exception message but I think it really needs more explanation than an exception message can provide. We're using a forwarder though so we can re-target it if things move around.

Also cleared up some references to make sure they use the more canonical "ASP.NET Core SignalR" and "ASP.NET SignalR" phrases

[Internal Review Link](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/version-differences?view=aspnetcore-2.1&branch=pr-en-us-8148)