### PR TITLE
Surface IIS config in Windows Auth topic

### DIFF
--- a/aspnetcore/security/authentication/windowsauth.md
+++ b/aspnetcore/security/authentication/windowsauth.md
@@ -1,44 +1,44 @@
 ---
-title: Configure Windows authentication in ASP.NET Core
+title: Configure Windows Authentication in ASP.NET Core
 author: ardalis
-description: This article describes how to configure Windows authentication in ASP.NET Core, using IIS Express, IIS, HTTP.sys, and WebListener.
+description: This article describes how to configure Windows Authentication in ASP.NET Core, using IIS Express, IIS, HTTP.sys, and WebListener.
 ms.author: riande
-ms.date: 08/15/2018
+ms.date: 08/18/2018
 uid: security/authentication/windowsauth
 ---
-# Configure Windows authentication in ASP.NET Core
+# Configure Windows Authentication in ASP.NET Core
 
 By [Steve Smith](https://ardalis.com) and [Scott Addie](https://twitter.com/Scott_Addie)
 
-Windows authentication can be configured for ASP.NET Core apps hosted with IIS, [HTTP.sys](xref:fundamentals/servers/httpsys), or [WebListener](xref:fundamentals/servers/weblistener).
+Windows Authentication can be configured for ASP.NET Core apps hosted with IIS, [HTTP.sys](xref:fundamentals/servers/httpsys), or [WebListener](xref:fundamentals/servers/weblistener).
 
-## What is Windows authentication?
+## Windows Authentication
 
-Windows authentication relies on the operating system to authenticate users of ASP.NET Core apps. You can use Windows authentication when your server runs on a corporate network using Active Directory domain identities or other Windows accounts to identify users. Windows authentication is best suited to intranet environments in which users, client applications, and web servers belong to the same Windows domain.
+Windows Authentication relies on the operating system to authenticate users of ASP.NET Core apps. You can use Windows Authentication when your server runs on a corporate network using Active Directory domain identities or other Windows accounts to identify users. Windows Authentication is best suited to intranet environments in which users, client applications, and web servers belong to the same Windows domain.
 
-[Learn more about Windows authentication and installing it for IIS](/iis/configuration/system.webServer/security/authentication/windowsAuthentication/).
+[Learn more about Windows Authentication and installing it for IIS](/iis/configuration/system.webServer/security/authentication/windowsAuthentication/).
 
-## Enable Windows authentication in an ASP.NET Core app
+## Enable Windows Authentication in an ASP.NET Core app
 
-The Visual Studio Web Application template can be configured to support Windows authentication.
+The Visual Studio Web Application template can be configured to support Windows Authentication.
 
-### Use the Windows authentication app template
+### Use the Windows Authentication app template
 
 In Visual Studio:
 
-1. Create a new ASP.NET Core Web Application. 
+1. Create a new ASP.NET Core Web Application.
 1. Select Web Application from the list of templates.
-1. Select the **Change Authentication** button and select **Windows Authentication**. 
+1. Select the **Change Authentication** button and select **Windows Authentication**.
 
 Run the app. The username appears in the top right of the app.
 
 ![Windows Authentication Browser Screenshot](windowsauth/_static/browser-screenshot.png)
 
-For development work using IIS Express, the template provides all the configuration necessary to use Windows authentication. The following section shows how to manually configure an ASP.NET Core app for Windows authentication.
+For development work using IIS Express, the template provides all the configuration necessary to use Windows Authentication. The following section shows how to manually configure an ASP.NET Core app for Windows Authentication.
 
 ### Visual Studio settings for Windows and anonymous authentication
 
-The Visual Studio project **Properties** page's **Debug** tab provides check boxes for Windows authentication and anonymous authentication.
+The Visual Studio project **Properties** page's **Debug** tab provides check boxes for Windows Authentication and anonymous authentication.
 
 ![Windows Authentication Browser Screenshot](windowsauth/_static/vs-auth-property-menu.png)
 
@@ -46,9 +46,17 @@ Alternatively, these two properties can be configured in the *launchSettings.jso
 
 [!code-json[](windowsauth/sample/launchSettings.json?highlight=3-4)]
 
-## Enable Windows authentication with IIS
+## Enable Windows Authentication with IIS
 
-IIS uses the [ASP.NET Core Module](xref:fundamentals/servers/aspnet-core-module) to host ASP.NET Core apps. The module allows Windows authentication to flow to IIS by default. Windows authentication is configured in IIS, not the app. The following sections show how to use IIS Manager to configure an ASP.NET Core app to use Windows authentication.
+IIS uses the [ASP.NET Core Module](xref:fundamentals/servers/aspnet-core-module) to host ASP.NET Core apps. Windows Authentication is configured in IIS, not the app. The following sections show how to use IIS Manager to configure an ASP.NET Core app to use Windows Authentication.
+
+### IIS configuration
+
+Enable the IIS Role Service for Windows Authentication. For more information, see [Enable Windows Authentication in IIS Role Services (see Step 2)](xref:host-and-deploy/iis/index#iis-configuration).
+
+IIS Integration Middleware is configured to automatically authenticate requests by default. For more information, see [Host ASP.NET Core on Windows with IIS: IIS options (AutomaticAuthentication)](xref:host-and-deploy/iis/index#iis-options).
+
+The ASP.NET Core Module is configured to forward the Windows Authentication token to the app by default. For more information, see [ASP.NET Core Module configuration reference: Attributes of the aspNetCore element](xref:host-and-deploy/aspnet-core-module#attributes-of-the-aspnetcore-element).
 
 ### Create a new IIS site
 
@@ -56,7 +64,7 @@ Specify a name and folder and allow it to create a new application pool.
 
 ### Customize authentication
 
-Open the Authentication menu for the site.
+Open the Authentication features for the site.
 
 ![IIS Authentication Menu](windowsauth/_static/iis-authentication-menu.png)
 
@@ -72,13 +80,13 @@ Using Visual Studio or the .NET Core CLI, publish the app to the destination fol
 
 Learn more about [publishing to IIS](xref:host-and-deploy/iis/index).
 
-Launch the app to verify Windows authentication is working.
+Launch the app to verify Windows Authentication is working.
 
 ::: moniker range=">= aspnetcore-2.0"
 
-## Enable Windows authentication with HTTP.sys
+## Enable Windows Authentication with HTTP.sys
 
-Although Kestrel doesn't support Windows authentication, you can use [HTTP.sys](xref:fundamentals/servers/httpsys) to support self-hosted scenarios on Windows. The following example configures the app's web host to use HTTP.sys with Windows authentication:
+Although Kestrel doesn't support Windows Authentication, you can use [HTTP.sys](xref:fundamentals/servers/httpsys) to support self-hosted scenarios on Windows. The following example configures the app's web host to use HTTP.sys with Windows Authentication:
 
 [!code-csharp[](windowsauth/sample/Program2x.cs?highlight=9-14)]
 
@@ -89,9 +97,9 @@ Although Kestrel doesn't support Windows authentication, you can use [HTTP.sys](
 
 ::: moniker range="< aspnetcore-2.0"
 
-## Enable Windows authentication with WebListener
+## Enable Windows Authentication with WebListener
 
-Although Kestrel doesn't support Windows authentication, you can use [WebListener](xref:fundamentals/servers/weblistener) to support self-hosted scenarios on Windows. The following example configures the app's web host to use WebListener with Windows authentication:
+Although Kestrel doesn't support Windows Authentication, you can use [WebListener](xref:fundamentals/servers/weblistener) to support self-hosted scenarios on Windows. The following example configures the app's web host to use WebListener with Windows Authentication:
 
 [!code-csharp[](windowsauth/sample/Program1x.cs?highlight=6-11)]
 
@@ -100,26 +108,26 @@ Although Kestrel doesn't support Windows authentication, you can use [WebListene
 
 ::: moniker-end
 
-## Work with Windows authentication
+## Work with Windows Authentication
 
 The configuration state of anonymous access determines the way in which the `[Authorize]` and `[AllowAnonymous]` attributes are used in the app. The following two sections explain how to handle the disallowed and allowed configuration states of anonymous access.
 
 ### Disallow anonymous access
 
-When Windows authentication is enabled and anonymous access is disabled, the `[Authorize]` and `[AllowAnonymous]` attributes have no effect. If the IIS site (or HTTP.sys or WebListener server) is configured to disallow anonymous access, the request never reaches your app. For this reason, the `[AllowAnonymous]` attribute isn't applicable.
+When Windows Authentication is enabled and anonymous access is disabled, the `[Authorize]` and `[AllowAnonymous]` attributes have no effect. If the IIS site (or HTTP.sys or WebListener server) is configured to disallow anonymous access, the request never reaches your app. For this reason, the `[AllowAnonymous]` attribute isn't applicable.
 
 ### Allow anonymous access
 
-When both Windows authentication and anonymous access are enabled, use the `[Authorize]` and `[AllowAnonymous]` attributes. The `[Authorize]` attribute allows you to secure pieces of the app which truly do require Windows authentication. The `[AllowAnonymous]` attribute overrides `[Authorize]` attribute usage within apps which allow anonymous access. See [Simple Authorization](xref:security/authorization/simple) for attribute usage details.
+When both Windows Authentication and anonymous access are enabled, use the `[Authorize]` and `[AllowAnonymous]` attributes. The `[Authorize]` attribute allows you to secure pieces of the app which truly do require Windows Authentication. The `[AllowAnonymous]` attribute overrides `[Authorize]` attribute usage within apps which allow anonymous access. See [Simple Authorization](xref:security/authorization/simple) for attribute usage details.
 
-In ASP.NET Core 2.x, the `[Authorize]` attribute requires additional configuration in *Startup.cs* to challenge anonymous requests for Windows authentication. The recommended configuration varies slightly based on the web server being used.
+In ASP.NET Core 2.x, the `[Authorize]` attribute requires additional configuration in *Startup.cs* to challenge anonymous requests for Windows Authentication. The recommended configuration varies slightly based on the web server being used.
 
 > [!NOTE]
 > By default, users who lack authorization to access a page are presented with an empty HTTP 403 response. The [StatusCodePages middleware](xref:fundamentals/error-handling#configuring-status-code-pages) can be configured to provide users with a better "Access Denied" experience.
 
 #### IIS
 
-If using IIS, add the following to the `ConfigureServices` method: 
+If using IIS, add the following to the `ConfigureServices` method:
 
 ```csharp
 // IISDefaults requires the following import:


### PR DESCRIPTION
Fixes #7789 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/security/authentication/windowsauth?view=aspnetcore-1.0&branch=pr-en-us-8159)

* The main thing is to surface that the Windows Authentication role service must be configured in IIS. This also mentions in passing that the IIS option for the middleware is defaulted to work and that the ANCM is defaulted to pass on the token. It's accomplished with a couple of cross-links in a new *IIS configuration* section.
* The other thing is that "Windows Authentication" is a proper noun, so I update that throughout the topic.