### PR TITLE
Corrections in SignalR version support table

### DIFF
--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -17,7 +17,7 @@ ASP.NET Core SignalR isn't compatible with clients or servers for ASP.NET Signal
 |                      | ASP.NET SignalR | ASP.NET Core SignalR |
 | -------------------- | --------------- | -------------------- |
 | Server NuGet Package | [Microsoft.AspNet.SignalR](https://www.nuget.org/packages/Microsoft.AspNet.SignalR/) | [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App/) (.NET Core)<br>[Microsoft.AspNetCore.SignalR](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) (.NET Framework) |
-| Client NuGet Packages | [Microsoft.AspNet.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.Client/) [Microsoft.AspNet.SignalR.JS](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.JS/) | [Microsoft.AspNetCore.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client/) |
+| Client NuGet Package | [Microsoft.AspNet.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.Client/) [Microsoft.AspNet.SignalR.JS](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.JS/) | [Microsoft.AspNetCore.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client/) |
 | Client npm Package | [signalr](https://www.npmjs.com/package/signalr) | [@aspnet/signalr](https://www.npmjs.com/package/@aspnet/signalr) |
 | Server App Type | ASP.NET (System.Web) or OWIN Self-Host | ASP.NET Core |
 | Supported Server Platforms | .NET Framework 4.5 | .NET Framework 4.6.1 or later<br>.NET Core 2.1 or later |

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -17,7 +17,7 @@ ASP.NET Core SignalR isn't compatible with clients or servers for ASP.NET Signal
 |                      | ASP.NET SignalR | ASP.NET Core SignalR |
 | -------------------- | --------------- | -------------------- |
 | Server NuGet Package | [Microsoft.AspNet.SignalR](https://www.nuget.org/packages/Microsoft.AspNet.SignalR/) | [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App/) (.NET Core)<br>[Microsoft.AspNetCore.SignalR](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) (.NET Framework) |
-| Client NuGet Package | [Microsoft.AspNet.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.Client/) [Microsoft.AspNet.SignalR.JS](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.JS/) | [Microsoft.AspNetCore.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client/) |
+| Client NuGet Packages | [Microsoft.AspNet.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.Client/)<br>[Microsoft.AspNet.SignalR.JS](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.JS/) | [Microsoft.AspNetCore.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client/) |
 | Client npm Package | [signalr](https://www.npmjs.com/package/signalr) | [@aspnet/signalr](https://www.npmjs.com/package/@aspnet/signalr) |
 | Server App Type | ASP.NET (System.Web) or OWIN Self-Host | ASP.NET Core |
 | Supported Server Platforms | .NET Framework 4.5 | .NET Framework 4.6.1 or later<br>.NET Core 2.1 or later |

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -20,7 +20,7 @@ ASP.NET Core SignalR isn't compatible with clients or servers for ASP.NET Signal
 | Client NuGet Packages | [Microsoft.AspNet.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.Client/)<br>[Microsoft.AspNet.SignalR.JS](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.JS/) | [Microsoft.AspNetCore.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client/) |
 | Client npm Package | [signalr](https://www.npmjs.com/package/signalr) | [@aspnet/signalr](https://www.npmjs.com/package/@aspnet/signalr) |
 | Server App Type | ASP.NET (System.Web) or OWIN Self-Host | ASP.NET Core |
-| Supported Server Platforms | .NET Framework 4.5 | .NET Framework 4.6.1 or later<br>.NET Core 2.1 or later |
+| Supported Server Platforms | .NET Framework 4.5 or later | .NET Framework 4.6.1 or later<br>.NET Core 2.1 or later |
 
 ## Feature differences
 

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -16,7 +16,7 @@ ASP.NET Core SignalR isn't compatible with clients or servers for ASP.NET Signal
 
 |                      | ASP.NET SignalR | ASP.NET Core SignalR |
 | -------------------- | --------------- | -------------------- |
-| Server NuGet Package | [Microsoft.AspNet.SignalR](https://www.nuget.org/packages/Microsoft.AspNet.SignalR/) | [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App/) |
+| Server NuGet Package | [Microsoft.AspNet.SignalR](https://www.nuget.org/packages/Microsoft.AspNet.SignalR/) | [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App/) (.NET Core)<br>[Microsoft.AspNetCore.SignalR](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) (.NET Framework) |
 | Client NuGet Packages | [Microsoft.AspNet.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.Client/) [Microsoft.AspNet.SignalR.JS](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.JS/) | [Microsoft.AspNetCore.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client/) |
 | Client npm Package | [signalr](https://www.npmjs.com/package/signalr) | [@aspnet/signalr](https://www.npmjs.com/package/@aspnet/signalr) |
 | Server App Type | ASP.NET (System.Web) or OWIN Self-Host | ASP.NET Core |

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -4,7 +4,7 @@ author: tdykstra
 description: Differences between SignalR and ASP.NET Core SignalR 
 monikerRange: '>= aspnetcore-2.1'
 ms.author: tdykstra
-ms.date: 06/30/2018
+ms.date: 08/20/2018
 uid: signalr/version-differences
 ---
 
@@ -18,9 +18,9 @@ ASP.NET Core SignalR isn't compatible with clients or servers for ASP.NET Signal
 | -------------------- | --------------- | -------------------- |
 | Server NuGet Package | [Microsoft.AspNet.SignalR](https://www.nuget.org/packages/Microsoft.AspNet.SignalR/) | [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App/) |
 | Client NuGet Packages | [Microsoft.AspNet.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.Client/) [Microsoft.AspNet.SignalR.JS](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.JS/) | [Microsoft.AspNetCore.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client/) |
-| Client NPM Package | [signalr](https://www.npmjs.com/package/signalr) | [@aspnet/signalr](https://www.npmjs.com/package/@aspnet/signalr) |
+| Client npm Package | [signalr](https://www.npmjs.com/package/signalr) | [@aspnet/signalr](https://www.npmjs.com/package/@aspnet/signalr) |
 | Server App Type | ASP.NET (System.Web) or OWIN Self-Host | ASP.NET Core |
-| Supported Server Platforms | .NET Framework 4.5 | .NET Framework 4.6.1<br>.NET Core 2.1 |
+| Supported Server Platforms | .NET Framework 4.5 | .NET Framework 4.6.1 or later<br>.NET Core 2.1 or later |
 
 ## Feature differences
 


### PR DESCRIPTION
Fixes #8182 
Surfaces the .NET Framework package from https://github.com/aspnet/Docs/pull/8145

[Internal Review Page](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/version-differences?branch=pr-en-us-8183&view=aspnetcore-2.1#how-to-identify-the-signalr-version)