### PR TITLE
Move SetCompatibilityVersion into an MVC subtopic

### DIFF
--- a/aspnetcore/fundamentals/startup.md
+++ b/aspnetcore/fundamentals/startup.md
@@ -58,45 +58,6 @@ For features that require substantial setup, there are `Add[Service]` extension 
 
 [!code-csharp[](../common/samples/WebApplication1/Startup.cs?highlight=4,7,11&start=40&end=55)]
 
-::: moniker range=">= aspnetcore-2.1"
-
-<a name="setcompatibilityversion"></a>
-
-### SetCompatibilityVersion for ASP.NET Core MVC
-
-The `SetCompatibilityVersion` method allows an app to opt-in or opt-out of potentially breaking behavior changes introduced in ASP.NET Core MVC 2.1 or later. These potentially breaking behavior changes are generally in how the MVC subsystem behaves and how **your code** is called by the runtime. By opting in, you get the latest behavior, and the long-term behavior of ASP.NET Core.
-
-The following code sets the compatibility mode to ASP.NET Core 2.1:
-
-[!code-csharp[Main](startup/sampleCompatibility/Startup.cs?name=snippet1)]
-
-We recommend you test your app using the latest version (`CompatibilityVersion.Version_2_1`). We anticipate that most apps won't have breaking behavior changes using the latest version.
-
-Apps that call `SetCompatibilityVersion(CompatibilityVersion.Version_2_0)` are protected from potentially breaking behavior changes introduced in the ASP.NET Core 2.1 MVC and later 2.x versions. This protection:
-
-* Does not apply to all 2.1 and later changes, it's targeted to potentially breaking ASP.NET Core runtime behavior changes in the MVC subsystem.
-* Does not extend to the next major version.
-
-The default compatibility for ASP.NET Core 2.1 and later 2.x apps that do **not** call `SetCompatibilityVersion` is 2.0 compatibility. That is, not calling `SetCompatibilityVersion` is the same as calling `SetCompatibilityVersion(CompatibilityVersion.Version_2_0)`.
-
-The following code sets the compatibility mode to ASP.NET Core 2.1, except for the following behaviors:
-
-* [AllowCombiningAuthorizeFilters](https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs)
-* [InputFormatterExceptionPolicy](https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs)
-
-[!code-csharp[Main](startup/sampleCompatibility/Startup2.cs?name=snippet1)]
-
-For apps that encounter breaking behavior changes, using the appropriate compatibility switches:
-
-* Allows you to use the latest release and opt out of specific breaking behavior changes.
-* Gives you time to update your app so it works with the latest changes.
-
-The [MvcOptions](https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs) class source comments have a good explanation of what changed and why the changes are an improvement for most users.
-
-At some future date, there will be an [ASP.NET Core 3.0 version](https://github.com/aspnet/Home/wiki/Roadmap). Old behaviors supported by compatibility switches will be removed in the 3.0 version. We feel these are positive changes benefitting nearly all users. By introducing these changes now, most apps can benefit now, and the others will have time to update their apps.
-
-::: moniker-end
-
 ## The Configure method
 
 The [Configure](/dotnet/api/microsoft.aspnetcore.hosting.startupbase.configure) method is used to specify how the app responds to HTTP requests. The request pipeline is configured by adding [middleware](xref:fundamentals/middleware/index) components to an [IApplicationBuilder](/dotnet/api/microsoft.aspnetcore.builder.iapplicationbuilder) instance. `IApplicationBuilder` is available to the `Configure` method, but it isn't registered in the service container. Hosting creates an `IApplicationBuilder` and passes it directly to `Configure` ([reference source](https://github.com/aspnet/Hosting/blob/release/2.0.0/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs#L179-L192)).

--- a/aspnetcore/migration/20_21.md
+++ b/aspnetcore/migration/20_21.md
@@ -113,7 +113,7 @@ The preceding code changes are detailed in:
 * [GDPR support in ASP.NET Core](xref:security/gdpr) for `CookiePolicyOptions` and `UseCookiePolicy`.
 * [HTTP Strict Transport Security Protocol (HSTS)](xref:security/enforcing-ssl#http-strict-transport-security-protocol-hsts) for `UseHsts`.
 * [Require HTTPS](xref:security/enforcing-ssl#require-https) for `UseHttpsRedirection`.
-* [SetCompatibilityVersion](xref:fundamentals/startup#setcompatibilityversion) for `SetCompatibilityVersion(CompatibilityVersion.Version_2_1)`.
+* [SetCompatibilityVersion](xref:mvc/compatibility-version) for `SetCompatibilityVersion(CompatibilityVersion.Version_2_1)`.
 
 ## Changes to authentication code
 
@@ -158,7 +158,7 @@ This section outlines the steps to replace the ASP.NET Core 2.0 template generat
   * *Extensions*
 * Build the project.
 * [Scaffold Identity](xref:security/authentication/scaffold-identity) into your project:
-  * Select the projects exiting *_Layout.cshtml* file.
+  * Select the projects exiting *\_Layout.cshtml* file.
   * Select the **+** icon on the right side of the **Data context class**. Accept the default name.
   * Select **Add** to create a new Data context class. Creating a new data context is required for to scaffold. You remove the new data context in the next section.
 
@@ -166,12 +166,12 @@ This section outlines the steps to replace the ASP.NET Core 2.0 template generat
 
 * Delete the Identity scaffolder generated `IdentityDbContext` derived class in the *Areas/Identity/Data/* folder.
 * Delete *Areas/Identity/IdentityHostingStartup.cs*
-* Update the *_LoginPartial.cshtml* file:
-  * Move *Pages/_LoginPartial.cshtml* to *Pages/Shared/_LoginPartial.cshtml*
+* Update the *\_LoginPartial.cshtml* file:
+  * Move *Pages/\_LoginPartial.cshtml* to *Pages/Shared/\_LoginPartial.cshtml*
   * Add `asp-area="Identity"` to the form and anchor links.
   * Update the `<form />` element to `<form asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Page("/Index", new { area = "" })" method="post" id="logoutForm" class="navbar-right">`
 
-  The following code shows the updated *_LoginPartial.cshtml* file:
+  The following code shows the updated *\_LoginPartial.cshtml* file:
 
   [!code-cshtml[Main](20_21/sample/_LoginPartial.cshtml?highlight=8,11,22,23)]
 
@@ -183,15 +183,15 @@ Update `ConfigureServices` with the following code:
 
 ### The layout file
 
-* Move *Pages/_Layout.cshtml* to *Pages/Shared/_Layout.cshtml*
+* Move *Pages/\_Layout.cshtml* to *Pages/Shared/\_Layout.cshtml*
 * The *Layout.cshtml* file has the following changes:
 
   * `<partial name="_CookieConsentPartial" />` is added. For more information, see [GDPR support in ASP.NET Core](xref:security/gdpr).
   * jQuery changes from 2.2.0 to 3.3.1
 
-### _ValidationScriptsPartial.cshtml
+### \_ValidationScriptsPartial.cshtml
 
-* *Pages/_ValidationScriptsPartial.cshtml* moves to  *Pages/Shared/_ValidationScriptsPartial.cshtml*
+* *Pages/\_ValidationScriptsPartial.cshtml* moves to *Pages/Shared/\_ValidationScriptsPartial.cshtml*
 * *jquery.validate/1.14.0* changes to *jquery.validate/1.17.0*
 
 ### New files
@@ -212,7 +212,7 @@ The *Layout.cshtml* file has the following changes:
 * `<partial name="_CookieConsentPartial" />` is added.
 * jQuery changes from 2.2.0 to 3.3.1
 
-### _ValidationScriptsPartial.cshtml
+### \_ValidationScriptsPartial.cshtml
 
 *jquery.validate/1.14.0* changes to *jquery.validate/1.17.0*
 
@@ -228,5 +228,5 @@ See [GDPR support in ASP.NET Core](xref:security/gdpr) for information on the pr
 ## Additional changes
 
 * If hosting the app on Windows with IIS, install the latest [.NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle).
-* [SetCompatibilityVersion](xref:fundamentals/startup#setcompatibilityversion)
+* [SetCompatibilityVersion](xref:mvc/compatibility-version)
 * [Transport configuration](xref:fundamentals/servers/kestrel#transport-configuration)

--- a/aspnetcore/mvc/compatibility-version.md
+++ b/aspnetcore/mvc/compatibility-version.md
@@ -1,0 +1,44 @@
+---
+title: Compatibility version for ASP.NET Core MVC
+author: rick-anderson
+description: Discover how the Startup class in ASP.NET Core configures services and the app's request pipeline.
+monikerRange: '>= aspnetcore-2.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 04/20/2018
+uid: mvc/compatibility-version
+---
+# Compatibility version for ASP.NET Core MVC
+
+By [Rick Anderson](https://twitter.com/RickAndMSFT)
+
+The <xref:Microsoft.Extensions.DependencyInjection.MvcCoreMvcBuilderExtensions.SetCompatibilityVersion*> method allows an app to opt-in or opt-out of potentially breaking behavior changes introduced in ASP.NET Core MVC 2.1 or later. These potentially breaking behavior changes are generally in how the MVC subsystem behaves and how **your code** is called by the runtime. By opting in, you get the latest behavior, and the long-term behavior of ASP.NET Core.
+
+The following code sets the compatibility mode to ASP.NET Core 2.1:
+
+[!code-csharp[Main](compatibility-version/samples/2.x/CompatibilityVersionSample/Startup.cs?name=snippet1)]
+
+We recommend you test your app using the latest version (`CompatibilityVersion.Version_2_1`). We anticipate that most apps won't have breaking behavior changes using the latest version.
+
+Apps that call `SetCompatibilityVersion(CompatibilityVersion.Version_2_0)` are protected from potentially breaking behavior changes introduced in the ASP.NET Core 2.1 MVC and later 2.x versions. This protection:
+
+* Does not apply to all 2.1 and later changes, it's targeted to potentially breaking ASP.NET Core runtime behavior changes in the MVC subsystem.
+* Does not extend to the next major version.
+
+The default compatibility for ASP.NET Core 2.1 and later 2.x apps that do **not** call `SetCompatibilityVersion` is 2.0 compatibility. That is, not calling `SetCompatibilityVersion` is the same as calling `SetCompatibilityVersion(CompatibilityVersion.Version_2_0)`.
+
+The following code sets the compatibility mode to ASP.NET Core 2.1, except for the following behaviors:
+
+* [AllowCombiningAuthorizeFilters](https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs)
+* [InputFormatterExceptionPolicy](https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs)
+
+[!code-csharp[Main](compatibility-version/samples/2.x/CompatibilityVersionSample/Startup2.cs?name=snippet1)]
+
+For apps that encounter breaking behavior changes, using the appropriate compatibility switches:
+
+* Allows you to use the latest release and opt out of specific breaking behavior changes.
+* Gives you time to update your app so it works with the latest changes.
+
+The [MvcOptions](https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs) class source comments have a good explanation of what changed and why the changes are an improvement for most users.
+
+At some future date, there will be an [ASP.NET Core 3.0 version](https://github.com/aspnet/Home/wiki/Roadmap). Old behaviors supported by compatibility switches will be removed in the 3.0 version. We feel these are positive changes benefitting nearly all users. By introducing these changes now, most apps can benefit now, and the others will have time to update their apps.

--- a/aspnetcore/mvc/compatibility-version/samples/2.x/CompatibilityVersionSample/CompatibilityVersionSample.csproj
+++ b/aspnetcore/mvc/compatibility-version/samples/2.x/CompatibilityVersionSample/CompatibilityVersionSample.csproj
@@ -5,11 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App"  />
+    <PackageReference Include="Microsoft.AspNetCore.App"  Version="2.1.2" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/mvc/compatibility-version/samples/2.x/CompatibilityVersionSample/Program.cs
+++ b/aspnetcore/mvc/compatibility-version/samples/2.x/CompatibilityVersionSample/Program.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
-namespace WebApp1
+namespace CompatibilityVersionSample
 {
     public class Program
     {

--- a/aspnetcore/mvc/compatibility-version/samples/2.x/CompatibilityVersionSample/Startup.cs
+++ b/aspnetcore/mvc/compatibility-version/samples/2.x/CompatibilityVersionSample/Startup.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace WebApp1
+namespace CompatibilityVersionSample
 {
     public class Startup
     {
@@ -12,7 +12,7 @@ namespace WebApp1
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc()
-                    .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+                .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
         }
         #endregion
 

--- a/aspnetcore/mvc/compatibility-version/samples/2.x/CompatibilityVersionSample/Startup2.cs
+++ b/aspnetcore/mvc/compatibility-version/samples/2.x/CompatibilityVersionSample/Startup2.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace WebApp1
+namespace CompatibilityVersionSample
 {
     public class Startup2
     {
@@ -13,18 +13,18 @@ namespace WebApp1
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc()
-             // Include the 2.1 behaviors
-             .SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
-             // Except for the following.
-             .AddMvcOptions(options =>
-             {
-               // Don't combine authorize filters (keep 2.0 behavior).
-               options.AllowCombiningAuthorizeFilters = false;
-               // All exceptions thrown by an IInputFormatter will be treated
-               // as model state errors (keep 2.0 behavior).
-               options.InputFormatterExceptionPolicy =
-                              InputFormatterExceptionPolicy.AllExceptions;
-             });
+                // Include the 2.1 behaviors
+                .SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
+                // Except for the following.
+                .AddMvcOptions(options =>
+                {
+                    // Don't combine authorize filters (keep 2.0 behavior).
+                    options.AllowCombiningAuthorizeFilters = false;
+                    // All exceptions thrown by an IInputFormatter are treated
+                    // as model state errors (keep 2.0 behavior).
+                    options.InputFormatterExceptionPolicy =
+                        InputFormatterExceptionPolicy.AllExceptions;
+                });
         }
         #endregion
 

--- a/aspnetcore/mvc/overview.md
+++ b/aspnetcore/mvc/overview.md
@@ -245,3 +245,9 @@ Tag Helpers provide an HTML-friendly development experience and a rich IntelliSe
 ### View Components
 
 [View Components](views/view-components.md) allow you to package rendering logic and reuse it throughout the application. They're similar to [partial views](views/partial.md), but with associated logic.
+
+## Compatibility version
+
+The <xref:Microsoft.Extensions.DependencyInjection.MvcCoreMvcBuilderExtensions.SetCompatibilityVersion*> method allows an app to opt-in or opt-out of potentially breaking behavior changes introduced in ASP.NET Core MVC 2.1 or later.
+
+For more information, see <xref:mvc/compatibility-version>.

--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -257,7 +257,7 @@ public void OnHead()
 }
 ```
 
-If no HEAD handler (`OnHead`) is defined, Razor Pages falls back to calling the GET page handler (`OnGet`) in ASP.NET Core 2.1 or later. Opt in to this behavior with the [SetCompatibilityVersion method](xref:fundamentals/startup#setcompatibilityversion-for-aspnet-core-mvc) in `Startup.Configure` for ASP.NET Core 2.1 to 2.x:
+If no HEAD handler (`OnHead`) is defined, Razor Pages falls back to calling the GET page handler (`OnGet`) in ASP.NET Core 2.1 or later. Opt in to this behavior with the [SetCompatibilityVersion method](xref:mvc/compatibility-version) in `Startup.Configure` for ASP.NET Core 2.1 to 2.x:
 
 ```csharp
 services.AddMvc()
@@ -268,7 +268,6 @@ services.AddMvc()
 
 Rather than opting into all 2.1 behaviors with `SetCompatibilityVersion`, you can explicitly opt-in to specific behaviors. The following code opts into the mapping HEAD requests to the GET handler.
 
-
 ```csharp
 services.AddMvc()
     .AddRazorPagesOptions(options =>
@@ -276,6 +275,7 @@ services.AddMvc()
         options.AllowMappingHeadRequestsToGetHandler = true;
     });
 ```
+
 ::: moniker-end
 
 <a name="xsrf"></a>

--- a/aspnetcore/release-notes/aspnetcore-2.1.md
+++ b/aspnetcore/release-notes/aspnetcore-2.1.md
@@ -153,6 +153,12 @@ In 2.1, Razor Pages search for Razor assets (such as layouts and partials) in th
 
 Razor Pages now support [areas](xref:mvc/controllers/areas). To see an example of areas, create a new Razor Pages web app with individual user accounts. A Razor Pages web app with individual user accounts includes */Areas/Identity/Pages*.
 
+## MVC compatibility version
+
+The <xref:Microsoft.Extensions.DependencyInjection.MvcCoreMvcBuilderExtensions.SetCompatibilityVersion*> method allows an app to opt-in or opt-out of potentially breaking behavior changes introduced in ASP.NET Core MVC 2.1 or later.
+
+For more information, see <xref:mvc/compatibility-version>.
+
 ## Migrate from 2.0 to 2.1
 
 See [Migrate from ASP.NET Core 2.0 to 2.1](xref:migration/20_21).

--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -201,6 +201,7 @@
 ### [Areas](xref:mvc/controllers/areas)
 ### [Application parts](xref:mvc/extensibility/app-parts)
 ### [Custom model binding](xref:mvc/advanced/custom-model-binding)
+## [Compatibility version](xref:mvc/compatibility-version)
 
 # [Web API](xref:web-api/index)
 ## [Controller action return types](xref:web-api/action-return-types)

--- a/aspnetcore/tutorials/razor-pages/sql.md
+++ b/aspnetcore/tutorials/razor-pages/sql.md
@@ -24,7 +24,7 @@ The `MovieContext` object handles the task of connecting to the database and map
 For more information on the methods used in `ConfigureServices`, see:
 
 * [EU General Data Protection Regulation (GDPR) support in ASP.NET Core](xref:security/gdpr) for `CookiePolicyOptions`.
-* [SetCompatibilityVersion](xref:fundamentals/startup#setcompatibilityversion-for-aspnet-core-mvc)
+* [SetCompatibilityVersion](xref:mvc/compatibility-version)
 
 ::: moniker-end
 

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -45,6 +45,8 @@ A compatibility version of 2.1 or later, set via <xref:Microsoft.Extensions.Depe
 
 [!code-csharp[](../web-api/define-controller/samples/WebApiSample.Api/Startup.cs?name=snippet_SetCompatibilityVersion&highlight=2)]
 
+For more information, see <xref:mvc/compatibility-version>.
+
 The `[ApiController]` attribute is commonly coupled with `ControllerBase` to enable REST-specific behavior for controllers. `ControllerBase` provides access to methods such as <xref:Microsoft.AspNetCore.Mvc.ControllerBase.NotFound*> and <xref:Microsoft.AspNetCore.Mvc.ControllerBase.File*>.
 
 Another approach is to create a custom base controller class annotated with the `[ApiController]` attribute:


### PR DESCRIPTION
Fixes #8170 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/compatibility-version?view=aspnetcore-2.1&branch=pr-en-us-8196)

* Other than an API link, there are no changes to the original text. Just moving the content and sample app here.
* The new topic preserves the original date of the content from #5948.

Please check [20-21.md (Internal Review Topic)](https://review.docs.microsoft.com/en-us/aspnet/core/migration/20_21?view=aspnetcore-1.0&branch=pr-en-us-8196), as I escaped several underscores in an attempt to make GH rendering good.