### PR TITLE
Assign CustomWebApplicationFactory value before using it

### DIFF
--- a/aspnetcore/test/integration-tests/samples/2.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/IntegrationTests/IndexPageTests.cs
+++ b/aspnetcore/test/integration-tests/samples/2.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/IntegrationTests/IndexPageTests.cs
@@ -24,11 +24,12 @@ namespace RazorPagesProject.Tests
         public IndexPageTests(
             CustomWebApplicationFactory<RazorPagesProject.Startup> factory)
         {
+            _factory = factory;
             _client = factory.CreateClient(new WebApplicationFactoryClientOptions
                 {
                     AllowAutoRedirect = false
                 });
-            _factory = factory;
+           
         }
         #endregion
 

--- a/aspnetcore/test/integration-tests/samples/2.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/IntegrationTests/IndexPageTests.cs
+++ b/aspnetcore/test/integration-tests/samples/2.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/IntegrationTests/IndexPageTests.cs
@@ -29,7 +29,6 @@ namespace RazorPagesProject.Tests
                 {
                     AllowAutoRedirect = false
                 });
-           
         }
         #endregion
 


### PR DESCRIPTION
Changed code from 

            _client = factory.CreateClient(new WebApplicationFactoryClientOptions
                {
                    AllowAutoRedirect = false
                });
_factory = factory;
To

_factory = factory;
            _client = factory.CreateClient(new WebApplicationFactoryClientOptions
                {
                    AllowAutoRedirect = false
                });

When creating a new PR, please do the following and delete this template text:

* Reference the issue number if there is one:

  Fixes #Issue_Number

  > The "Fixes #nnn" syntax in the PR description causes
  > GitHub to automatically close the issue when this PR is merged.
