### PR TITLE
Update bundling and minification to make sense

### DIFF
--- a/aspnet/mvc/overview/performance/bundling-and-minification.md
+++ b/aspnet/mvc/overview/performance/bundling-and-minification.md
@@ -181,7 +181,7 @@ Explicitly adding each file to a bundle is generally the preferred over wildcard
 
 ## Bundle Caching
 
-Bundles set the HTTP Expires Header one year from when the bundle is created. If you navigate to a previously viewed page, Fiddler shows IE does not make a conditional request for the bundle, that is, there are no HTTP GET requests from IE for the bundles and no HTTP 304 responses from the server. You can force IE to make a conditional request for each bundle with the F5 key (resulting in a HTTP 304 response for each bundle). You can force a full refresh by using ^F5 (resulting in a HTTP 200 response for each bundle.)
+Bundles set the HTTP Expires Header one year from when the bundle is created. If you navigate to a previously viewed page, Fiddler shows IE does not make a additional request for the bundle, that is, there are no HTTP GET requests from IE for the bundles and no HTTP 304 responses from the server. You can force IE to make an additional request for each bundle with the F5 key (resulting in a HTTP 304 response for each bundle). You can force a full refresh by using ^F5 (resulting in a HTTP 200 response for each bundle.)
 
 The following image shows the **Caching** tab of the Fiddler response pane:
 


### PR DESCRIPTION
If the bundle is not cached IE does make an **additional** request rather than a **conditional** request.
Please let me know whether I am wrong or not.

Thanks
