### PR TITLE
Clarify ANCM stdout/stderr redirection remark

### DIFF
--- a/aspnetcore/host-and-deploy/aspnet-core-module.md
+++ b/aspnetcore/host-and-deploy/aspnet-core-module.md
@@ -120,7 +120,7 @@ If the ASP.NET Core Module fails to launch the backend process or the backend pr
 
 ## Log creation and redirection
 
-The ASP.NET Core Module redirects stdout and stderr logs to disk if the `stdoutLogEnabled` and `stdoutLogFile` attributes of the `aspNetCore` element are set. Any folders in the `stdoutLogFile` path must exist in order for the module to create the log file. The app pool must have write access to the location where the logs are written (use `IIS AppPool\<app_pool_name>` to provide write permission).
+The ASP.NET Core Module redirects stdout and stderr console output to disk if the `stdoutLogEnabled` and `stdoutLogFile` attributes of the `aspNetCore` element are set. Any folders in the `stdoutLogFile` path must exist in order for the module to create the log file. The app pool must have write access to the location where the logs are written (use `IIS AppPool\<app_pool_name>` to provide write permission).
 
 Logs aren't rotated, unless process recycling/restart occurs. It's the responsibility of the hoster to limit the disk space the logs consume.
 


### PR DESCRIPTION
Fixes #8263 

@Tratcher Do we even want to stick with the word "redirection"? It suggests that the logging is removed from console output to a file. We could name the section "ASP.NET Core Module logging" and describe its behavior as "logs" instead of "redirects" ...

> The ASP.NET Core Module logs stdout and stderr console output to disk if the \`stdoutLogEnabled\` and \`stdoutLogFile\` attributes of the \`aspNetCore\` element are set.

... or we could just go with what's on the PR now and leave the word "redirection" in place.