### PR TITLE
Clarify package for Status Code Pages Middleware

### DIFF
--- a/aspnetcore/fundamentals/error-handling.md
+++ b/aspnetcore/fundamentals/error-handling.md
@@ -15,23 +15,23 @@ This article covers common approaches to handling errors in ASP.NET Core apps.
 
 [View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/fundamentals/error-handling/samples/2.x/ErrorHandlingSample) ([how to download](xref:tutorials/index#how-to-download-a-sample))
 
-## The developer exception page
+## The Developer Exception Page
 
 ::: moniker range=">= aspnetcore-2.1"
 
-To configure an app to display a page that shows detailed information about exceptions, use the *developer exception page*. The page made available by the [Microsoft.AspNetCore.Diagnostics](https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics/) package, which is available in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app). Add a line to the `Startup.Configure` method:
+To configure an app to display a page that shows detailed information about exceptions, use the *Developer Exception Page*. The page made available by the [Microsoft.AspNetCore.Diagnostics](https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics/) package, which is available in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app). Add a line to the `Startup.Configure` method:
 
 ::: moniker-end
 
 ::: moniker range="= aspnetcore-2.0"
 
-To configure an app to display a page that shows detailed information about exceptions, use the *developer exception page*. The page is made available by the [Microsoft.AspNetCore.Diagnostics](https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics/) package, which is available in the [Microsoft.AspNetCore.All metapackage](xref:fundamentals/metapackage). Add a line to the `Startup.Configure` method:
+To configure an app to display a page that shows detailed information about exceptions, use the *Developer Exception Page*. The page is made available by the [Microsoft.AspNetCore.Diagnostics](https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics/) package, which is available in the [Microsoft.AspNetCore.All metapackage](xref:fundamentals/metapackage). Add a line to the `Startup.Configure` method:
 
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-2.0"
 
-To configure an app to display a page that shows detailed information about exceptions, use the *developer exception page*. The page is made available by adding a package reference for the [Microsoft.AspNetCore.Diagnostics](https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics/) package in the project file. Add a line to the `Startup.Configure` method:
+To configure an app to display a page that shows detailed information about exceptions, use the *Developer Exception Page*. The page is made available by adding a package reference for the [Microsoft.AspNetCore.Diagnostics](https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics/) package in the project file. Add a line to the `Startup.Configure` method:
 
 ::: moniker-end
 
@@ -39,10 +39,10 @@ To configure an app to display a page that shows detailed information about exce
 
 Place the call to [UseDeveloperExceptionPage](/dotnet/api/microsoft.aspnetcore.builder.developerexceptionpageextensions.usedeveloperexceptionpage) in front of any middleware where you want to catch exceptions, such as `app.UseMvc`.
 
->[!WARNING]
-> Enable the developer exception page **only when the app is running in the Development environment**. You don't want to share detailed exception information publicly when the app runs in production. [Learn more about configuring environments](xref:fundamentals/environments).
+> [!WARNING]
+> Enable the Developer Exception Page **only when the app is running in the Development environment**. You don't want to share detailed exception information publicly when the app runs in production. [Learn more about configuring environments](xref:fundamentals/environments).
 
-To see the developer exception page, run the sample app with the environment set to `Development`, and add `?throw=true` to the base URL of the app. The page includes several tabs with information about the exception and the request. The first tab includes a stack trace:
+To see the Developer Exception Page, run the sample app with the environment set to `Development` and add `?throw=true` to the base URL of the app. The page includes several tabs with information about the exception and the request. The first tab includes a stack trace:
 
 ![Stack trace](error-handling/_static/developer-exception-page.png)
 
@@ -77,7 +77,27 @@ public IActionResult Error()
 
 ## Configuring status code pages
 
-By default, an app doesn't provide a rich status code page for HTTP status codes, such as *404 Not Found*. To provide status code pages, configure the Status Code Pages Middleware by adding a line to the `Startup.Configure` method:
+By default, an app doesn't provide a rich status code page for HTTP status codes, such as *404 Not Found*. To provide status code pages, use Status Code Pages Middleware.
+
+::: moniker range=">= aspnetcore-2.1"
+
+The middleware is made available by the [Microsoft.AspNetCore.Diagnostics](https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics/) package, which is available in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app).
+
+::: moniker-end
+
+::: moniker range="= aspnetcore-2.0"
+
+The middleware is made available by the [Microsoft.AspNetCore.Diagnostics](https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics/) package, which is available in the [Microsoft.AspNetCore.All metapackage](xref:fundamentals/metapackage).
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.0"
+
+The middleware is made available by adding a package reference for the [Microsoft.AspNetCore.Diagnostics](https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics/) package in the project file.
+
+::: moniker-end
+
+Add a line to the `Startup.Configure` method:
 
 ```csharp
 app.UseStatusCodePages();

--- a/aspnetcore/fundamentals/error-handling.md
+++ b/aspnetcore/fundamentals/error-handling.md
@@ -54,7 +54,7 @@ If the request has cookies, they appear on the **Cookies** tab. Headers are seen
 
 ![Headers](error-handling/_static/developer-exception-page-headers.png)
 
-## Configuring a custom exception handling page
+## Configure a custom exception handling page
 
 Configure an exception handler page to use when the app isn't running in the `Development` environment:
 
@@ -75,7 +75,7 @@ public IActionResult Error()
 }
 ```
 
-## Configuring status code pages
+## Configure status code pages
 
 By default, an app doesn't provide a rich status code page for HTTP status codes, such as *404 Not Found*. To provide status code pages, use Status Code Pages Middleware.
 
@@ -102,6 +102,8 @@ Add a line to the `Startup.Configure` method:
 ```csharp
 app.UseStatusCodePages();
 ```
+
+<xref:Microsoft.AspNetCore.Builder.StatusCodePagesExtensions.UseStatusCodePages*> should be called before request handling middlewares in the pipeline (for example, Static Files Middleware and MVC Middleware).
 
 By default, Status Code Pages Middleware adds text-only handlers for common status codes, such as 404:
 

--- a/aspnetcore/fundamentals/error-handling.md
+++ b/aspnetcore/fundamentals/error-handling.md
@@ -19,7 +19,7 @@ This article covers common approaches to handling errors in ASP.NET Core apps.
 
 ::: moniker range=">= aspnetcore-2.1"
 
-To configure an app to display a page that shows detailed information about exceptions, use the *Developer Exception Page*. The page made available by the [Microsoft.AspNetCore.Diagnostics](https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics/) package, which is available in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app). Add a line to the `Startup.Configure` method:
+To configure an app to display a page that shows detailed information about exceptions, use the *Developer Exception Page*. The page is made available by the [Microsoft.AspNetCore.Diagnostics](https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics/) package, which is available in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app). Add a line to the `Startup.Configure` method:
 
 ::: moniker-end
 

--- a/aspnetcore/fundamentals/error-handling/samples/2.x/ErrorHandlingSample/Startup.cs
+++ b/aspnetcore/fundamentals/error-handling/samples/2.x/ErrorHandlingSample/Startup.cs
@@ -34,6 +34,9 @@ namespace ErrorHandlingSample
 
 #if StatusCodePages
             #region snippet_StatusCodePages
+            // Expose the members of the 'Microsoft.AspNetCore.Http' namespace 
+            // at the top of the file:
+            // using Microsoft.AspNetCore.Http;
             app.UseStatusCodePages(async context =>
             {
                 context.HttpContext.Response.ContentType = "text/plain";

--- a/aspnetcore/host-and-deploy/iis/modules.md
+++ b/aspnetcore/host-and-deploy/iis/modules.md
@@ -24,7 +24,7 @@ The table indicates native IIS modules that are functional on reverse proxy requ
 | **Client Certification Mapping Authentication**<br>`CertificateMappingAuthenticationModule` | Yes | |
 | **CGI**<br>`CgiModule` | No | |
 | **Configuration Validation**<br>`ConfigurationValidationModule` | Yes | |
-| **HTTP Errors**<br>`CustomErrorModule` | No | [Status Code Pages Middleware](xref:fundamentals/error-handling#configuring-status-code-pages) |
+| **HTTP Errors**<br>`CustomErrorModule` | No | [Status Code Pages Middleware](xref:fundamentals/error-handling#configure-status-code-pages) |
 | **Custom Logging**<br>`CustomLoggingModule` | Yes | |
 | **Default Document**<br>`DefaultDocumentModule` | No | [Default Files Middleware](xref:fundamentals/static-files#serve-a-default-document) |
 | **Digest Authentication**<br>`DigestAuthenticationModule` | Yes | |

--- a/aspnetcore/security/authentication/windowsauth.md
+++ b/aspnetcore/security/authentication/windowsauth.md
@@ -123,7 +123,7 @@ When both Windows Authentication and anonymous access are enabled, use the `[Aut
 In ASP.NET Core 2.x, the `[Authorize]` attribute requires additional configuration in *Startup.cs* to challenge anonymous requests for Windows Authentication. The recommended configuration varies slightly based on the web server being used.
 
 > [!NOTE]
-> By default, users who lack authorization to access a page are presented with an empty HTTP 403 response. The [StatusCodePages middleware](xref:fundamentals/error-handling#configuring-status-code-pages) can be configured to provide users with a better "Access Denied" experience.
+> By default, users who lack authorization to access a page are presented with an empty HTTP 403 response. The [StatusCodePages middleware](xref:fundamentals/error-handling#configure-status-code-pages) can be configured to provide users with a better "Access Denied" experience.
 
 #### IIS
 


### PR DESCRIPTION
Addresses #8118 

This is a quick patch based on @NicolasDorier's feedback on the issue. The issue requires more extensive changes, but we can knock this clarification out quickly.

This exposes:

* The Diagnostics package requirement for Status Code Pages Middleware. A reader may skip the Developer Exception Page content and jump right to this section and then not be aware that they need the package reference.
* The need for the members of the `Microsoft.AspNetCore.Http` namespace in the example code, which is required to enable the [Microsoft.AspNetCore.Diagnostics.StatusCodeContext.HttpContext](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.diagnostics.statuscodecontext.httpcontext) property.

@scottaddie A nit update here, too ... It seems to me that "Developer Exception Page" is the proper name of a specific framework technology. Therefore, I make it a proper noun here. If you disagree, let me know, and I'll revert those changes here.