### PR TITLE
Middleware ext method namespace clarification

### DIFF
--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -125,7 +125,9 @@ public void Configure(IApplicationBuilder app)
 
 ::: moniker-end
 
-In the code above, <xref:Microsoft.AspNetCore.Builder.ExceptionHandlerExtensions.UseExceptionHandler*> is the first middleware component added to the pipeline. Therefore, the Exception Handler Middleware catches any exceptions that occur in later calls.
+In the preceding example code, each middleware extension method is exposed directly on <xref:Microsoft.AspNetCore.Builder.IApplicationBuilder> through the <xref:Microsoft.AspNetCore.Builder?displayProperty=fullName> namespace.
+
+<xref:Microsoft.AspNetCore.Builder.ExceptionHandlerExtensions.UseExceptionHandler*> is the first middleware component added to the pipeline. Therefore, the Exception Handler Middleware catches any exceptions that occur in later calls.
 
 Static Files Middleware is called early in the pipeline so that it can handle requests and short-circuit without going through the remaining components. The Static Files Middleware provides **no** authorization checks. Any files served by it, including those under *wwwroot*, are publicly available. For an approach to secure static files, see <xref:fundamentals/static-files>.
 

--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -125,7 +125,7 @@ public void Configure(IApplicationBuilder app)
 
 ::: moniker-end
 
-In the preceding example code, each middleware extension method is exposed directly on <xref:Microsoft.AspNetCore.Builder.IApplicationBuilder> through the <xref:Microsoft.AspNetCore.Builder?displayProperty=fullName> namespace.
+In the preceding example code, each middleware extension method is exposed on <xref:Microsoft.AspNetCore.Builder.IApplicationBuilder> through the <xref:Microsoft.AspNetCore.Builder?displayProperty=fullName> namespace.
 
 <xref:Microsoft.AspNetCore.Builder.ExceptionHandlerExtensions.UseExceptionHandler*> is the first middleware component added to the pipeline. Therefore, the Exception Handler Middleware catches any exceptions that occur in later calls.
 


### PR DESCRIPTION
Fixes #8274 

A quick fix that surfaces two concepts:

* The extension methods are exposed directly on the `IApplicationBuilder`.
* The namespace that exposes them is `Microsoft.AspNetCore.Builder`.

These concepts appear much later in the topic (*Write middleware*), but we probably need to surface them earlier, where extension methods for pipeline processing middleware are first mentioned.

Thanks to @NicolasDorier for discussion in #8118 leading to this enhancement.