### PR TITLE
Add a section about storing data protection keys using the EF Core provider

### DIFF
--- a/aspnetcore/security/data-protection/implementation/key-storage-providers.md
+++ b/aspnetcore/security/data-protection/implementation/key-storage-providers.md
@@ -73,6 +73,40 @@ public void ConfigureServices(IServiceCollection services)
 > [!IMPORTANT]
 > We recommend using [Windows DPAPI](xref:security/data-protection/implementation/key-encryption-at-rest) to encrypt the keys at rest.
 
+::: moniker range=">= aspnetcore-2.2"
+
+## Entity Framework Core
+
+The [Microsoft.AspNetCore.DataProtection.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.EntityFrameworkCore/) package allows storing data protection keys using Entity Framework Core and any of the database providers it supports. Keys can be shared across several instances of a web app using a database.
+
+To configure the EF Core provider, call the [`PersistKeysToDbContext<TContext>`](/dotnet/api/microsoft.aspnetcore.dataprotection.entityframeworkcoredataprotectionextensions.persistkeystodbcontext) method:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services
+        .AddDbContext<MyKeysContext>(o => o.UseSqlServer(myConnectionString))
+        .AddDataProtection()
+        .PersistKeysToDbContext<MyKeysContext>();
+}
+```
+
+The generic parameter, `TContext`, must inherit from [DbContext](/dotnet/api/microsoft.entityframeworkcore.dbcontext) and
+[IDataProtectionKeyContext](/dotnet/api/microsoft.aspnetcore.dataprotection.entityframeworkcore.idataprotectionkeycontext).
+
+```csharp
+class MyKeysContext : DbContext, IDataProtectionKeyContext
+{
+    // A recommended constructor overload when using EF Core with dependency injection
+    public MyKeysContext(DbContextOptions<DataProtectionKeyContext> options) : base(options) { }
+
+    // this maps to a table which will store keys
+    public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
+}
+```
+
+::: moniker-end
+
 ## Custom key repository
 
 If the in-box mechanisms aren't appropriate, the developer can specify their own key persistence mechanism by providing a custom [IXmlRepository](/dotnet/api/microsoft.aspnetcore.dataprotection.repositories.ixmlrepository).

--- a/aspnetcore/security/data-protection/implementation/key-storage-providers.md
+++ b/aspnetcore/security/data-protection/implementation/key-storage-providers.md
@@ -77,33 +77,18 @@ public void ConfigureServices(IServiceCollection services)
 
 ## Entity Framework Core
 
-The [Microsoft.AspNetCore.DataProtection.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.EntityFrameworkCore/) package allows storing data protection keys using Entity Framework Core and any of the database providers it supports. Keys can be shared across several instances of a web app using a database.
+The [Microsoft.AspNetCore.DataProtection.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.EntityFrameworkCore/) package provides a mechanism for storing data protection keys using Entity Framework Core. `Microsoft.AspNetCore.DataProtection.EntityFrameworkCore` must be added to the project file, it's not part of the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app).
+
+With this package, keys can be shared across multiple instances of a web app.
 
 To configure the EF Core provider, call the [`PersistKeysToDbContext<TContext>`](/dotnet/api/microsoft.aspnetcore.dataprotection.entityframeworkcoredataprotectionextensions.persistkeystodbcontext) method:
 
-```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    services
-        .AddDbContext<MyKeysContext>(o => o.UseSqlServer(myConnectionString))
-        .AddDataProtection()
-        .PersistKeysToDbContext<MyKeysContext>();
-}
-```
+[!code-csharp[Main](key-storage-providers/sample/Startup.cs?name=snippet&highlight=13-15)]
 
 The generic parameter, `TContext`, must inherit from [DbContext](/dotnet/api/microsoft.entityframeworkcore.dbcontext) and
-[IDataProtectionKeyContext](/dotnet/api/microsoft.aspnetcore.dataprotection.entityframeworkcore.idataprotectionkeycontext).
+[IDataProtectionKeyContext](/dotnet/api/microsoft.aspnetcore.dataprotection.entityframeworkcore.idataprotectionkeycontext):
 
-```csharp
-class MyKeysContext : DbContext, IDataProtectionKeyContext
-{
-    // A recommended constructor overload when using EF Core with dependency injection
-    public MyKeysContext(DbContextOptions<DataProtectionKeyContext> options) : base(options) { }
-
-    // this maps to a table which will store keys
-    public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
-}
-```
+[!code-csharp[Main](key-storage-providers/sample/MyKeysContext.cs)]
 
 ::: moniker-end
 

--- a/aspnetcore/security/data-protection/implementation/key-storage-providers.md
+++ b/aspnetcore/security/data-protection/implementation/key-storage-providers.md
@@ -77,7 +77,7 @@ public void ConfigureServices(IServiceCollection services)
 
 ## Entity Framework Core
 
-The [Microsoft.AspNetCore.DataProtection.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.EntityFrameworkCore/) package provides a mechanism for storing data protection keys using Entity Framework Core. `Microsoft.AspNetCore.DataProtection.EntityFrameworkCore` must be added to the project file, it's not part of the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app).
+The [Microsoft.AspNetCore.DataProtection.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.EntityFrameworkCore/) package provides a mechanism for storing data protection keys to a database using Entity Framework Core. The `Microsoft.AspNetCore.DataProtection.EntityFrameworkCore` NuGet package must be added to the project file, it's not part of the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app).
 
 With this package, keys can be shared across multiple instances of a web app.
 

--- a/aspnetcore/security/data-protection/implementation/key-storage-providers/sample/MyKeysContext.cs
+++ b/aspnetcore/security/data-protection/implementation/key-storage-providers/sample/MyKeysContext.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using WebApp1.Data;
+
+namespace WebApp1
+{
+    class MyKeysContext : DbContext, IDataProtectionKeyContext
+    {
+        // A recommended constructor overload when using EF Core 
+        // with dependency injection.
+        public MyKeysContext(DbContextOptions<ApplicationDbContext> options) 
+            : base(options) { }
+
+        // This maps to the table that stores keys.
+        public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
+    }
+}

--- a/aspnetcore/security/data-protection/implementation/key-storage-providers/sample/Startup.cs
+++ b/aspnetcore/security/data-protection/implementation/key-storage-providers/sample/Startup.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using WebApp1.Data;
+
+namespace WebApp1
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        #region snippet
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.CheckConsentNeeded = context => true;
+                options.MinimumSameSitePolicy = SameSiteMode.None;
+            });
+
+            services.AddDbContext<ApplicationDbContext>(options =>
+                options.UseSqlServer(
+                    Configuration.GetConnectionString("DefaultConnection")));
+
+            // using Microsoft.AspNetCore.DataProtection;
+            services.AddDataProtection()
+                .PersistKeysToDbContext<MyKeysContext>();
+
+            services.AddDefaultIdentity<IdentityUser>()
+                .AddDefaultUI(UIFramework.Bootstrap4)
+                .AddEntityFrameworkStores<ApplicationDbContext>();
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+        }
+        #endregion
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+                app.UseDatabaseErrorPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Error");
+                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+                app.UseHsts();
+            }
+
+            app.UseHttpsRedirection();
+            app.UseStaticFiles();
+            app.UseCookiePolicy();
+
+            app.UseAuthentication();
+
+            app.UseMvc();
+        }
+    }
+}


### PR DESCRIPTION
Adding documentation about a new feature coming in 2.2. https://github.com/aspnet/DataProtection/pull/323

cref https://github.com/aspnet/Home/issues/2505

@rick-anderson edit below:
[Internal review url](https://review.docs.microsoft.com/en-us/aspnet/core/security/data-protection/implementation/key-storage-providers?view=aspnetcore-2.2&branch=pr-en-us-8328#entity-framework-core)

~Do not merge until preview-2 ships.~