### PR TITLE
Add note about LibMan install relative path support

### DIFF
--- a/aspnetcore/client-side/libman/libman-cli.md
+++ b/aspnetcore/client-side/libman/libman-cli.md
@@ -165,7 +165,7 @@ The following options are available for the `libman install` command:
 
 * `--files <FILE>`
 
-  Specify the name of the file to install from the library. If not specified, all files from the library are installed. Provide one `--files` option per file to be installed.
+  Specify the name of the file to install from the library. If not specified, all files from the library are installed. Provide one `--files` option per file to be installed. Relative paths are supported too. For example: `--files dist/browser/signalr.js`.
 
 * `-p|--provider <PROVIDER>`
 


### PR DESCRIPTION
Adds an example of using a relative path with `libman install --files`.