### PR TITLE
the default model class is `ErrorViewModel`, not `ErrorModel`

### DIFF
--- a/aspnetcore/fundamentals/error-handling.md
+++ b/aspnetcore/fundamentals/error-handling.md
@@ -60,7 +60,7 @@ Configure an exception handler page to use when the app isn't running in the `De
 
 [!code-csharp[](error-handling/samples/2.x/ErrorHandlingSample/Startup.cs?name=snippet_DevExceptionPage&highlight=11)]
 
-In a Razor Pages app, the [dotnet new](/dotnet/core/tools/dotnet-new) Razor Pages template provides an Error page and `ErrorModel` page model class in the *Pages* folder.
+In a Razor Pages app, the [dotnet new](/dotnet/core/tools/dotnet-new) Razor Pages template provides an Error page and `ErrorViewModel` page model class in the *Pages* folder.
 
 In an MVC app, don't decorate the error handler action method with HTTP method attributes, such as `HttpGet`. Explicit verbs prevent some requests from reaching the method. Allow anonymous access to the method so that unauthenticated users are able to receive the error view.
 

--- a/aspnetcore/fundamentals/error-handling.md
+++ b/aspnetcore/fundamentals/error-handling.md
@@ -60,7 +60,7 @@ Configure an exception handler page to use when the app isn't running in the `De
 
 [!code-csharp[](error-handling/samples/2.x/ErrorHandlingSample/Startup.cs?name=snippet_DevExceptionPage&highlight=11)]
 
-In a Razor Pages app, the [dotnet new](/dotnet/core/tools/dotnet-new) Razor Pages template provides an Error page and `ErrorViewModel` page model class in the *Pages* folder.
+In a Razor Pages app, the [dotnet new](/dotnet/core/tools/dotnet-new) Razor Pages template provides an Error page and an error `PageModel` class in the *Pages* folder.
 
 In an MVC app, don't decorate the error handler action method with HTTP method attributes, such as `HttpGet`. Explicit verbs prevent some requests from reaching the method. Allow anonymous access to the method so that unauthenticated users are able to receive the error view.
 


### PR DESCRIPTION
You can see the correct name is already used the the code sample two sentences down