### PR TITLE
App startup topic updates

### DIFF
--- a/aspnetcore/fundamentals/startup.md
+++ b/aspnetcore/fundamentals/startup.md
@@ -80,7 +80,7 @@ For more information on how to use `IApplicationBuilder` and the order of middle
 
 [!code-csharp[](startup/snapshot_sample/Program.cs?highlight=18,22)]
 
-## Startup filters
+## Extending Startup with startup filters
 
 Use [IStartupFilter](/dotnet/api/microsoft.aspnetcore.hosting.istartupfilter) to configure middleware at the beginning or end of an app's [Configure](#the-configure-method) middleware pipeline. `IStartupFilter` is useful to ensure that a middleware runs before or after middleware added by libraries at the start or end of the app's request processing pipeline.
 
@@ -96,9 +96,9 @@ The `RequestSetOptionsMiddleware` is configured in the `RequestSetOptionsStartup
 
 [!code-csharp[](startup/sample/RequestSetOptionsStartupFilter.cs?name=snippet1&highlight=7)]
 
-The `IStartupFilter` is registered in the service container in `ConfigureServices`:
+The `IStartupFilter` is registered in the service container in [IWebHostBuilder.ConfigureServices](xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder.ConfigureServices*) to demonstrate how the startup filter augments `Startup` from outside of the `Startup` class:
 
-[!code-csharp[](startup/sample/Startup.cs?name=snippet1&highlight=3)]
+[!code-csharp[](startup/sample/Program.cs?name=snippet1&highlight=4-5)]
 
 When a query string parameter for `option` is provided, the middleware processes the value assignment before the MVC middleware renders the response:
 

--- a/aspnetcore/fundamentals/startup.md
+++ b/aspnetcore/fundamentals/startup.md
@@ -80,7 +80,7 @@ For more information on how to use `IApplicationBuilder` and the order of middle
 
 [!code-csharp[](startup/snapshot_sample/Program.cs?highlight=18,22)]
 
-## Extending Startup with startup filters
+## Extend Startup with startup filters
 
 Use [IStartupFilter](/dotnet/api/microsoft.aspnetcore.hosting.istartupfilter) to configure middleware at the beginning or end of an app's [Configure](#the-configure-method) middleware pipeline. `IStartupFilter` is useful to ensure that a middleware runs before or after middleware added by libraries at the start or end of the app's request processing pipeline.
 

--- a/aspnetcore/fundamentals/startup/sample/Program.cs
+++ b/aspnetcore/fundamentals/startup/sample/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace StartupFilterSample
 {
@@ -11,8 +12,15 @@ namespace StartupFilterSample
         }
 
         public static IWebHost BuildWebHost(string[] args) =>
+            #region snippet1
             WebHost.CreateDefaultBuilder(args)
+                .ConfigureServices(services =>
+                {
+                    services.AddTransient<IStartupFilter, 
+                        RequestSetOptionsStartupFilter>();
+                })
                 .UseStartup<Startup>()
                 .Build();
+            #endregion
     }
 }

--- a/aspnetcore/fundamentals/startup/sample/Startup.cs
+++ b/aspnetcore/fundamentals/startup/sample/Startup.cs
@@ -6,13 +6,10 @@ namespace StartupFilterSample
 {
     public class Startup
     {
-        #region snippet1
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddTransient<IStartupFilter, RequestSetOptionsStartupFilter>();
             services.AddMvc();
         }
-        #endregion
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {


### PR DESCRIPTION
Fixes #8407 

* The update of the 2.0 sample here is tracked by #5495.
* Placed the snippet region just around the `CreateDefaultBuilder` call so that the 2.0-era `BuildWebHost` call isn't seen in the topic.
