### PR TITLE
Update EF extensions file name+location

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -1469,17 +1469,17 @@ Create the custom configuration provider by inheriting from <xref:Microsoft.Exte
 
 An `AddEFConfiguration` extension method permits adding the configuration source to a `ConfigurationBuilder`.
 
-*EFConfigurationProvider/EFConfigurationExtensions.cs*:
+*Extensions/EntityFrameworkExtensions.cs*:
 
 ::: moniker range=">= aspnetcore-2.0"
 
-[!code-csharp[](index/samples/2.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationExtensions.cs?name=snippet1)]
+[!code-csharp[](index/samples/2.x/ConfigurationSample/Extensions/EntityFrameworkExtensions.cs?name=snippet1)]
 
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-2.0"
 
-[!code-csharp[](index/samples/1.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationExtensions.cs?name=snippet1)]
+[!code-csharp[](index/samples/1.x/ConfigurationSample/Extensions/EntityFrameworkExtensions.cs?name=snippet1)]
 
 ::: moniker-end
 

--- a/aspnetcore/fundamentals/configuration/index/samples/1.x/ConfigurationSample/Extensions/EntityFrameworkExtensions.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/1.x/ConfigurationSample/Extensions/EntityFrameworkExtensions.cs
@@ -1,8 +1,9 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using ConfigurationSample.EFConfigurationProvider;
 
-namespace ConfigurationSample.EFConfigurationProvider
+namespace ConfigurationSample.Extensions
 {
     #region snippet1
     public static class EntityFrameworkExtensions

--- a/aspnetcore/fundamentals/configuration/index/samples/1.x/ConfigurationSample/Startup.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/1.x/ConfigurationSample/Startup.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using ConfigurationSample.EFConfigurationProvider;
+using ConfigurationSample.Extensions;
 
 namespace ConfigurationSample
 {

--- a/aspnetcore/fundamentals/configuration/index/samples/2.x/ConfigurationSample/Extensions/EntityFrameworkExtensions.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/2.x/ConfigurationSample/Extensions/EntityFrameworkExtensions.cs
@@ -1,8 +1,9 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using ConfigurationSample.EFConfigurationProvider;
 
-namespace ConfigurationSample.EFConfigurationProvider
+namespace ConfigurationSample.Extensions
 {
     #region snippet1
     public static class EntityFrameworkExtensions

--- a/aspnetcore/fundamentals/configuration/index/samples/2.x/ConfigurationSample/Program.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/2.x/ConfigurationSample/Program.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
-using ConfigurationSample.EFConfigurationProvider;
+using ConfigurationSample.Extensions;
 using System.Collections.Generic;
 
 namespace ConfigurationSample


### PR DESCRIPTION
Fixes #8413 

* Let's go with an *Extensions* folder and make the file name match the class name of `EntityFrameworkExtensions`.
* I confirmed that both samps build with these updates.