### PR TITLE
Change extensibility example

### DIFF
--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -203,15 +203,17 @@ await host.StartAsync();
 An app establishes the `UseHostedService` extension method to register the hosted service passed in `T`:
 
 ```csharp
+// Add the following namespaces for this example:
+// using System;
+// using Microsoft.Extensions.DependencyInjection;
+// using Microsoft.Extensions.Hosting;
 public static class Extensions
 {
     public static IHostBuilder UseHostedService<T>(this IHostBuilder hostBuilder)
         where T : class, IHostedService, IDisposable
     {
         return hostBuilder.ConfigureServices(services =>
-        {
             services.AddHostedService<T>();
-        });
     }
 }
 ```

--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -203,10 +203,10 @@ await host.StartAsync();
 An app establishes the `UseHostedService` extension method to register the hosted service passed in `T`:
 
 ```csharp
-// Add the following namespaces for this example:
-// using System;
-// using Microsoft.Extensions.DependencyInjection;
-// using Microsoft.Extensions.Hosting;
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
 public static class Extensions
 {
     public static IHostBuilder UseHostedService<T>(this IHostBuilder hostBuilder)

--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -213,7 +213,7 @@ public static class Extensions
         where T : class, IHostedService, IDisposable
     {
         return hostBuilder.ConfigureServices(services =>
-            services.AddHostedService<T>();
+            services.AddHostedService<T>());
     }
 }
 ```

--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -190,16 +190,30 @@ Use the factory and configure the custom service container for the app:
 
 ## Extensibility
 
-Host extensibility is performed with extension methods on `IHostBuilder`. The following example shows how an extension method extends an `IHostBuilder` implementation with [RabbitMQ](https://www.rabbitmq.com/). The extension method (elsewhere in the app) registers a RabbitMQ `IHostedService`:
+Host extensibility is performed with extension methods on `IHostBuilder`. The following example shows how an extension method extends an `IHostBuilder` implementation with the [TimedHostedService](xref:fundamentals/host/hosted-services#timed-background-tasks) example demonstrated in <xref:fundamentals/host/hosted-services>.
 
 ```csharp
-// UseRabbitMq is an extension method that sets up RabbitMQ to handle incoming
-// messages.
 var host = new HostBuilder()
-    .UseRabbitMq<MyMessageHandler>()
+    .UseHostedService<TimedHostedService>()
     .Build();
 
 await host.StartAsync();
+```
+
+An app establishes the `UseHostedService` extension method to register the hosted service passed in `T`:
+
+```csharp
+public static class Extensions
+{
+    public static IHostBuilder UseHostedService<T>(this IHostBuilder hostBuilder)
+        where T : class, IHostedService, IDisposable
+    {
+        return hostBuilder.ConfigureServices(services =>
+        {
+            services.AddHostedService<T>();
+        });
+    }
+}
 ```
 
 ## Manage the host


### PR DESCRIPTION
Fixes #8393 

* Swaps RabbitMQ for the `TimedHostedService` example, which is an example over in the background tasks/hosted services topic.
* It's a bit silly, but I think this was all that David was trying to show ... it's easy to extend on the host builder.