### PR TITLE
Fix sample snippet by adding async

### DIFF
--- a/aspnetcore/signalr/hubcontext.md
+++ b/aspnetcore/signalr/hubcontext.md
@@ -38,7 +38,7 @@ Now, with access to an instance of `IHubContext`, you can call hub methods as if
 Access the `IHubContext` within the middleware pipeline like so:
 
 ```csharp
-app.Use(next => (context) =>
+app.Use(next => async (context) =>
 {
     var hubContext = context.RequestServices
                             .GetRequiredService<IHubContext<MyHub>>();


### PR DESCRIPTION
Noticed that this sample snippet doesn't have the `async` keyword or return a task in the middleware func, so it won't compile as-is. Added `async` since it's the easiest way to do this.