### PR TITLE
Add Context section to signalr/hubs.md

### DIFF
--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -43,10 +43,10 @@ Each instance of the `Hub` class has a property named `Context` that contains th
 
 | Property | Description |
 | ------ | ----------- |
-| `ConnectionId` | Gets the unique ID for the connection, assigned by SignalR. There is one connection ID for each connection, and the same connection ID is used by all hubs if there are multiple hubs in an application.|
+| `ConnectionId` | Gets the unique ID for the connection, assigned by SignalR. There is one connection ID for each connection.|
 | `UserIdentifier` | Gets the user identifier. By default, SignalR uses the `ClaimTypes.NameIdentifier` from the `ClaimsPrincipal` associated with the connection as the user identifier. |
 | `User` | Gets the `ClaimsPrincipal`. |
-| `Items` | Gets a key/value collection that can be used to share data within the scope of this connection. |
+| `Items` | Gets a key/value collection that can be used to share data within the scope of this connection. You can store items in this collection and they will persist for that connection across different hub method invocations. |
 | `Features` | Gets the collection of [HTTP features](xref:fundamentals/request-features) available on the connection. |
 | `ConnectionAborted` | Gets a `CancellationToken` that notifies when the connection is aborted. |
 
@@ -54,7 +54,7 @@ Each instance of the `Hub` class has a property named `Context` that contains th
 
 | Method | Description |
 | ------ | ----------- |
-| `GetHttpContext` | Returns the `HttpContext` for the connection, or `null` if the connection is not associated with an HTTP request. For HTTP connections, you can use this method to get information such as HTTP header and query string data. |
+| `GetHttpContext` | Returns the `HttpContext` for the connection, or `null` if the connection is not associated with an HTTP request. For HTTP connections, you can use this method to get information such as HTTP headers and query strings. |
 | `Abort` | Aborts the connection. |
 
 ## The Clients object

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -44,8 +44,8 @@ Each instance of the `Hub` class has a property named `Context` that contains th
 | Property | Description |
 | ------ | ----------- |
 | `ConnectionId` | Gets the unique ID for the connection, assigned by SignalR. There is one connection ID for each connection, and the same connection ID is used by all hubs if there are multiple hubs in an application.|
-| `UserIdentifier` | Gets the user identifier. |
-| `User` | Gets the user (an instance of `ClaimsPrincipal`). |
+| `UserIdentifier` | Gets the user identifier. By default, SignalR uses the `ClaimTypes.NameIdentifier` from the `ClaimsPrincipal` associated with the connection as the user identifier. |
+| `User` | Gets the `ClaimsPrincipal`. |
 | `Items` | Gets a key/value collection that can be used to share data within the scope of this connection. |
 | `Features` | Gets the collection of [HTTP features](xref:fundamentals/request-features) available on the connection. |
 | `ConnectionAborted` | Gets a `CancellationToken` that notifies when the connection is aborted. |

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -39,15 +39,15 @@ You can specify a return type and parameters, including complex types and arrays
 
 ## The Context object
 
-Each instance of the `Hub` class has a property named `Context` that contains the following properties with information about the connection:
+The `Hub` class has a `Context` property that contains the following properties with information about the connection:
 
 | Property | Description |
 | ------ | ----------- |
 | `ConnectionId` | Gets the unique ID for the connection, assigned by SignalR. There is one connection ID for each connection.|
-| `UserIdentifier` | Gets the user identifier. By default, SignalR uses the `ClaimTypes.NameIdentifier` from the `ClaimsPrincipal` associated with the connection as the user identifier. |
-| `User` | Gets the `ClaimsPrincipal`. |
-| `Items` | Gets a key/value collection that can be used to share data within the scope of this connection. You can store items in this collection and they will persist for that connection across different hub method invocations. |
-| `Features` | Gets the collection of [HTTP features](xref:fundamentals/request-features) available on the connection. |
+| `UserIdentifier` | Gets the [user identifier](xref:signalr/groups). By default, SignalR uses the `ClaimTypes.NameIdentifier` from the `ClaimsPrincipal` associated with the connection as the user identifier. |
+| `User` | Gets the `ClaimsPrincipal` associated with the current user. |
+| `Items` | Gets a key/value collection that can be used to share data within the scope of this connection. Data can be stored in this collection and it will persist for the connection across different hub method invocations. |
+| `Features` | Gets the collection of features available on the connection. For now, this collection doesn't have anything you need to get or set, so it isn't documented in detail. |
 | `ConnectionAborted` | Gets a `CancellationToken` that notifies when the connection is aborted. |
 
 `Hub.Context` also contains the following methods:
@@ -59,7 +59,7 @@ Each instance of the `Hub` class has a property named `Context` that contains th
 
 ## The Clients object
 
-Each instance of the `Hub` class has a property named `Clients` that contains the following properties for communication between server and client:
+The `Hub` class has a `Clients` property that contains the following properties for communication between server and client:
 
 | Property | Description |
 | ------ | ----------- |

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -47,7 +47,7 @@ The `Hub` class has a `Context` property that contains the following properties 
 | `UserIdentifier` | Gets the [user identifier](xref:signalr/groups). By default, SignalR uses the `ClaimTypes.NameIdentifier` from the `ClaimsPrincipal` associated with the connection as the user identifier. |
 | `User` | Gets the `ClaimsPrincipal` associated with the current user. |
 | `Items` | Gets a key/value collection that can be used to share data within the scope of this connection. Data can be stored in this collection and it will persist for the connection across different hub method invocations. |
-| `Features` | Gets the collection of features available on the connection. For now, this collection doesn't have anything you need to get or set, so it isn't documented in detail. |
+| `Features` | Gets the collection of features available on the connection. For now, this collection isn't needed in most scenarios, so it isn't documented in detail yet. |
 | `ConnectionAborted` | Gets a `CancellationToken` that notifies when the connection is aborted. |
 
 `Hub.Context` also contains the following methods:

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -64,6 +64,26 @@ Additionally, `Hub.Clients` contains the following methods:
 
 Each property or method in the preceding tables returns an object with a `SendAsync` method. The `SendAsync` method allows you to supply the name and parameters of the client method to call.
 
+## The Context object
+
+Each instance of the `Hub` class has a property named `Context` that contains the following properties with information about the client and the connection:
+
+| Property | Description |
+| ------ | ----------- |
+| `ConnectionId` | Gets the connection ID. |
+| `UserIdentifier` | Gets the user identifier. |
+| `User` | Gets the user as an instance of `ClaimsPrincipal`. |
+| `Items` | Gets a key/value collection that can be used to share data within the scope of this connection. |
+| `Features` | Gets the collection of HTTP features available on the connection. |
+| `ConnectionAborted` | Gets a `CancellationToken` that notifies when the connection is aborted. |
+
+Additionally, `Hub.Context` contains the following methods:
+
+| Method | Description |
+| ------ | ----------- |
+| `GetHttpContext` | Returns the `HttpContext` for the connection, or `null` if the connection is not associated with an HTTP request. |
+| `Abort` | Aborts the connection. |
+
 ## Send messages to clients
 
 To make calls to specific clients, use the properties of the `Clients` object. In the following example, the `SendMessageToCaller` method demonstrates sending a message to the connection that invoked the hub method. The `SendMessageToGroups` method sends a message to the groups stored in a `List` named `groups`.

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -37,9 +37,29 @@ Create a hub by declaring a class that inherits from `Hub`, and add public metho
 
 You can specify a return type and parameters, including complex types and arrays, as you would in any C# method. SignalR handles the serialization and deserialization of complex objects and arrays in your parameters and return values.
 
+## The Context object
+
+Each instance of the `Hub` class has a property named `Context` that contains the following properties with information about the connection:
+
+| Property | Description |
+| ------ | ----------- |
+| `ConnectionId` | Gets the unique ID for the connection, assigned by SignalR. There is one connection ID for each connection, and the same connection ID is used by all hubs if there are multiple hubs in an application.|
+| `UserIdentifier` | Gets the user identifier. |
+| `User` | Gets the user (an instance of `ClaimsPrincipal`). |
+| `Items` | Gets a key/value collection that can be used to share data within the scope of this connection. |
+| `Features` | Gets the collection of [HTTP features](xref:fundamentals/request-features) available on the connection. |
+| `ConnectionAborted` | Gets a `CancellationToken` that notifies when the connection is aborted. |
+
+`Hub.Context` also contains the following methods:
+
+| Method | Description |
+| ------ | ----------- |
+| `GetHttpContext` | Returns the `HttpContext` for the connection, or `null` if the connection is not associated with an HTTP request. For HTTP connections, you can use this method to get information such as HTTP header and query string data. |
+| `Abort` | Aborts the connection. |
+
 ## The Clients object
 
-Each instance of the `Hub` class has a property named `Clients` that contains the following members for communication between server and client:
+Each instance of the `Hub` class has a property named `Clients` that contains the following properties for communication between server and client:
 
 | Property | Description |
 | ------ | ----------- |
@@ -48,7 +68,7 @@ Each instance of the `Hub` class has a property named `Clients` that contains th
 | `Others` | Calls a method on all connected clients except the client that invoked the method |
 
 
-Additionally, `Hub.Clients` contains the following methods:
+`Hub.Clients` also contains the following methods:
 
 | Method | Description |
 | ------ | ----------- |
@@ -63,26 +83,6 @@ Additionally, `Hub.Clients` contains the following methods:
 | `Users` | Calls a method to all connections associated with the specified users |
 
 Each property or method in the preceding tables returns an object with a `SendAsync` method. The `SendAsync` method allows you to supply the name and parameters of the client method to call.
-
-## The Context object
-
-Each instance of the `Hub` class has a property named `Context` that contains the following properties with information about the client and the connection:
-
-| Property | Description |
-| ------ | ----------- |
-| `ConnectionId` | Gets the connection ID. |
-| `UserIdentifier` | Gets the user identifier. |
-| `User` | Gets the user as an instance of `ClaimsPrincipal`. |
-| `Items` | Gets a key/value collection that can be used to share data within the scope of this connection. |
-| `Features` | Gets the collection of HTTP features available on the connection. |
-| `ConnectionAborted` | Gets a `CancellationToken` that notifies when the connection is aborted. |
-
-Additionally, `Hub.Context` contains the following methods:
-
-| Method | Description |
-| ------ | ----------- |
-| `GetHttpContext` | Returns the `HttpContext` for the connection, or `null` if the connection is not associated with an HTTP request. |
-| `Abort` | Aborts the connection. |
 
 ## Send messages to clients
 


### PR DESCRIPTION
Fixes #7629

@BrennanConroy -  added Context object section similar to Clients object section as suggested.

A few questions:
* How do things get into the `Items` collection?
* Any additional useful information we should add to the property and method descriptions?

[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/hubs?view=aspnetcore-2.1&branch=pr-en-us-8486)
