### PR TITLE
fixed link not rendered

### DIFF
--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
@@ -21,4 +21,4 @@ The package currently offers a method `KeyDerivation.Pbkdf2` which allows hashin
 
 [!code-csharp[](password-hashing/samples/passwordhasher.cs)]
 
-See the [source code]（https://github.com/aspnet/Identity/blob/master/src/Core/PasswordHasher.cs) for ASP.NET Core Identity's `PasswordHasher` type for a real-world use case.
+See the [source code](https://github.com/aspnet/Identity/blob/master/src/Core/PasswordHasher.cs) for ASP.NET Core Identity's `PasswordHasher` type for a real-world use case.


### PR DESCRIPTION
A non standard parenthesis was inserted on the left parenthesis of the link I added likely due to one of the foreign keyboards I use being activated when I entered it.

