### PR TITLE
Response Compression updates (+Brotli)

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md
@@ -1,7 +1,7 @@
 ---
 title: Cache Tag Helper in ASP.NET Core MVC
 author: pkellner
-description: Shows how to work with Cache Tag Helper
+description: Learn how to use the Cache Tag Helper.
 ms.author: riande
 ms.date: 02/14/2017
 uid: mvc/views/tag-helpers/builtin-th/cache-tag-helper

--- a/aspnetcore/mvc/views/tag-helpers/built-in/distributed-cache-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/distributed-cache-tag-helper.md
@@ -1,7 +1,7 @@
 ---
 title: Distributed Cache Tag Helper in ASP.NET Core
 author: pkellner
-description: Shows how to work with Cache Tag Helper
+description: Learn how to use the Distributed Cache Tag Helper.
 ms.author: riande
 ms.date: 02/14/2017
 uid: mvc/views/tag-helpers/builtin-th/distributed-cache-tag-helper

--- a/aspnetcore/performance/caching/index.md
+++ b/aspnetcore/performance/caching/index.md
@@ -1,17 +1,27 @@
 ---
 title: Cache responses in ASP.NET Core
-author: ardalis
-description: Learn how to use caching to improve the performance of ASP.NET Core apps.
+author: guardrex
+description: Learn how to use data caching and response caching to improve the performance of ASP.NET Core apps.
 ms.author: riande
-ms.date: 10/14/2016
+ms.date: 09/16/2018
 uid: performance/caching/index
 ---
 # Cache responses in ASP.NET Core
 
-* [Cache in-memory](xref:performance/caching/memory)
-* [Work with a distributed cache](xref:performance/caching/distributed)
-* [Detect changes with change tokens](xref:fundamentals/primitives/change-tokens)
-* [Response caching](xref:performance/caching/response)
-* [Response Caching Middleware](xref:performance/caching/middleware)
-* [Cache Tag Helper](xref:mvc/views/tag-helpers/builtin-th/cache-tag-helper)
-* [Distributed Cache Tag Helper](xref:mvc/views/tag-helpers/builtin-th/distributed-cache-tag-helper)
+[Cache in-memory](xref:performance/caching/memory)  
+Learn how to cache data in memory in ASP.NET Core.
+
+[Work with a distributed cache](xref:performance/caching/distributed)  
+Learn how to use ASP.NET Core distributed caching to improve app performance and scalability, especially in a cloud or server farm environment.
+
+[Response caching](xref:performance/caching/response)  
+Learn how to use response caching to lower bandwidth requirements and increase performance of ASP.NET Core apps.
+
+[Response Caching Middleware](xref:performance/caching/middleware)  
+Learn how to configure and use Response Caching Middleware in ASP.NET Core.
+
+[Cache Tag Helper](xref:mvc/views/tag-helpers/builtin-th/cache-tag-helper)  
+Learn how to use the Cache Tag Helper.
+
+[Distributed Cache Tag Helper](xref:mvc/views/tag-helpers/builtin-th/distributed-cache-tag-helper)  
+Learn how to use the Distributed Cache Tag Helper.

--- a/aspnetcore/performance/index.md
+++ b/aspnetcore/performance/index.md
@@ -1,15 +1,18 @@
 ---
 title: Performance in ASP.NET Core
-author: ardalis
+author: guardrex
 description: Discover topics pertaining to ASP.NET Core app performance.
 ms.author: riande
-ms.date: 10/14/2016
+ms.custom: mvc
+ms.date: 09/16/2018
 uid: performance/index
 ---
 # Performance in ASP.NET Core
 
-* [Cache responses](caching/index.md)
-  * [Cache in-memory](caching/memory.md)
-  * [Work with a distributed cache](caching/distributed.md)
-  * [Response caching](caching/response.md)
-* [Response compression middleware](response-compression.md)
+The following topic areas cover performance scenarios in ASP.NET Core:
+
+[Cache responses](xref:performance/caching/index)  
+Learn how to cache data and responses in ASP.NET Core.
+
+[Response compression](xref:performance/response-compression)  
+Learn about response compression and how to use Response Compression Middleware in ASP.NET Core apps.

--- a/aspnetcore/performance/response-compression.md
+++ b/aspnetcore/performance/response-compression.md
@@ -5,7 +5,7 @@ description: Learn about response compression and how to use Response Compressio
 monikerRange: '>= aspnetcore-1.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/17/2018
+ms.date: 09/21/2018
 uid: performance/response-compression
 ---
 # Response compression in ASP.NET Core
@@ -350,14 +350,14 @@ Submit a request to the sample app with the `Accept-Encoding: mycustomcompressio
 
 The middleware specifies a default set of MIME types for compression:
 
-* `text/plain`
-* `text/css`
 * `application/javascript`
-* `text/html`
-* `application/xml`
-* `text/xml`
 * `application/json`
+* `application/xml`
+* `text/css`
+* `text/html`
 * `text/json`
+* `text/plain`
+* `text/xml`
 
 Replace or append MIME types with the Response Compression Middleware options. Note that wildcard MIME types, such as `text/*` aren't supported. The sample app adds a MIME type for `image/svg+xml` and compresses and serves the ASP.NET Core banner image (*banner.svg*).
 
@@ -422,7 +422,7 @@ If you have an active IIS Dynamic Compression Module configured at the server le
 
 ## Troubleshooting
 
-Use a tool like [Fiddler](http://www.telerik.com/fiddler), [Firebug](http://getfirebug.com/), or [Postman](https://www.getpostman.com/), which allow you to set the `Accept-Encoding` request header and study the response headers, size, and body. By default, Response Compression Middleware compresses responses that meet the following conditions:
+Use a tool like [Fiddler](https://www.telerik.com/fiddler), [Firebug](https://getfirebug.com/), or [Postman](https://www.getpostman.com/), which allow you to set the `Accept-Encoding` request header and study the response headers, size, and body. By default, Response Compression Middleware compresses responses that meet the following conditions:
 
 ::: moniker range=">= aspnetcore-2.2"
 

--- a/aspnetcore/performance/response-compression.md
+++ b/aspnetcore/performance/response-compression.md
@@ -1,14 +1,14 @@
 ---
-title: Response Compression Middleware for ASP.NET Core
+title: Response compression in ASP.NET Core
 author: guardrex
 description: Learn about response compression and how to use Response Compression Middleware in ASP.NET Core apps.
 monikerRange: '>= aspnetcore-1.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/20/2017
+ms.date: 09/17/2018
 uid: performance/response-compression
 ---
-# Response Compression Middleware for ASP.NET Core
+# Response compression in ASP.NET Core
 
 By [Luke Latham](https://github.com/guardrex)
 
@@ -36,16 +36,33 @@ Usually, any response not natively compressed can benefit from response compress
 
 When a client can process compressed content, the client must inform the server of its capabilities by sending the `Accept-Encoding` header with the request. When a server sends compressed content, it must include information in the `Content-Encoding` header on how the compressed response is encoded. Content encoding designations supported by the middleware are shown in the following table.
 
-| `Accept-Encoding` header values | Middleware Supported | Description                                                 |
-| ------------------------------- | :------------------: | ----------------------------------------------------------- |
-| `br`                            | No                   | Brotli Compressed Data Format                               |
-| `compress`                      | No                   | UNIX "compress" data format                                 |
-| `deflate`                       | No                   | "deflate" compressed data inside the "zlib" data format     |
-| `exi`                           | No                   | W3C Efficient XML Interchange                               |
-| `gzip`                          | Yes (default)        | gzip file format                                            |
+::: moniker range=">= aspnetcore-2.2"
+
+| `Accept-Encoding` header values | Middleware Supported | Description |
+| ------------------------------- | :------------------: | ----------- |
+| `br`                            | Yes (default)        | [Brotli compressed data format](https://tools.ietf.org/html/rfc7932) |
+| `deflate`                       | No                   | [DEFLATE compressed data format](https://www.ietf.org/rfc/rfc1951.txt) |
+| `exi`                           | No                   | [W3C Efficient XML Interchange](https://tools.ietf.org/id/draft-varga-netconf-exi-capability-00.html) |
+| `gzip`                          | Yes                  | [Gzip file format](https://tools.ietf.org/html/rfc1952) |
 | `identity`                      | Yes                  | "No encoding" identifier: The response must not be encoded. |
-| `pack200-gzip`                  | No                   | Network Transfer Format for Java Archives                   |
-| `*`                             | Yes                  | Any available content encoding not explicitly requested     |
+| `pack200-gzip`                  | No                   | [Network Transfer Format for Java Archives](https://jcp.org/aboutJava/communityprocess/review/jsr200/index.html) |
+| `*`                             | Yes                  | Any available content encoding not explicitly requested |
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.2"
+
+| `Accept-Encoding` header values | Middleware Supported | Description |
+| ------------------------------- | :------------------: | ----------- |
+| `br`                            | No                   | [Brotli compressed data format](https://tools.ietf.org/html/rfc7932) |
+| `deflate`                       | No                   | [DEFLATE compressed data format](https://www.ietf.org/rfc/rfc1951.txt) |
+| `exi`                           | No                   | [W3C Efficient XML Interchange](https://tools.ietf.org/id/draft-varga-netconf-exi-capability-00.html) |
+| `gzip`                          | Yes (default)        | [Gzip file format](https://tools.ietf.org/html/rfc1952) |
+| `identity`                      | Yes                  | "No encoding" identifier: The response must not be encoded. |
+| `pack200-gzip`                  | No                   | [Network Transfer Format for Java Archives](https://jcp.org/aboutJava/communityprocess/review/jsr200/index.html) |
+| `*`                             | Yes                  | Any available content encoding not explicitly requested |
+
+::: moniker-end
 
 For more information, see the [IANA Official Content Coding List](http://www.iana.org/assignments/http-parameters/http-parameters.xml#http-content-coding-registry).
 
@@ -66,28 +83,44 @@ The headers involved in requesting, sending, caching, and receiving compressed c
 | `Content-Type`     | Specifies the MIME type of the content. Every response should specify its `Content-Type`. The middleware checks this value to determine if the response should be compressed. The middleware specifies a set of [default MIME types](#mime-types) that it can encode, but you can replace or add MIME types. |
 | `Vary`             | When sent by the server with a value of `Accept-Encoding` to clients and proxies, the `Vary` header indicates to the client or proxy that it should cache (vary) responses based on the value of the `Accept-Encoding` header of the request. The result of returning content with the `Vary: Accept-Encoding` header is that both compressed and uncompressed responses are cached separately. |
 
-You can explore the features of the Response Compression Middleware with the [sample app](https://github.com/aspnet/Docs/tree/master/aspnetcore/performance/response-compression/samples). The sample illustrates:
+Explore the features of the Response Compression Middleware with the [sample app](https://github.com/aspnet/Docs/tree/master/aspnetcore/performance/response-compression/samples). The sample illustrates:
 
-* The compression of app responses using gzip and custom compression providers.
+* The compression of app responses using Gzip and custom compression providers.
 * How to add a MIME type to the default list of MIME types for compression.
 
 ## Package
 
-::: moniker range="< aspnetcore-2.1"
+::: moniker range=">= aspnetcore-2.1"
 
-To include the middleware in your project, add a reference to the [Microsoft.AspNetCore.ResponseCompression](https://www.nuget.org/packages/Microsoft.AspNetCore.ResponseCompression/) package. This feature is available for apps that target ASP.NET Core 1.1 or later.
+To include the middleware in a project, add a reference to the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app), which includes the [Microsoft.AspNetCore.ResponseCompression](https://www.nuget.org/packages/Microsoft.AspNetCore.ResponseCompression/) package.
 
 ::: moniker-end
 
-::: moniker range=">= aspnetcore-2.1"
+::: moniker range="= aspnetcore-2.0"
 
-To include the middleware in your project, add a reference to the [Microsoft.AspNetCore.ResponseCompression](https://www.nuget.org/packages/Microsoft.AspNetCore.ResponseCompression/) package or use the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app) (ASP.NET Core 2.1 or later).
+To include the middleware in a project, add a reference to the [Microsoft.AspNetCore.All metapackage](xref:fundamentals/metapackage), which includes the [Microsoft.AspNetCore.ResponseCompression](https://www.nuget.org/packages/Microsoft.AspNetCore.ResponseCompression/) package.
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.0"
+
+To include the middleware in a project, add a reference to the [Microsoft.AspNetCore.ResponseCompression](https://www.nuget.org/packages/Microsoft.AspNetCore.ResponseCompression/) package.
 
 ::: moniker-end
 
 ## Configuration
 
-The following code shows how to enable the Response Compression Middleware with the default gzip compression and for default MIME types.
+::: moniker range=">= aspnetcore-2.2"
+
+The following code shows how to enable the Response Compression Middleware for default MIME types and compression providers ([Brotli](#brotli-compression-provider) and [Gzip](#gzip-compression-provider)):
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.2"
+
+The following code shows how to enable the Response Compression Middleware for default MIME types and the [Gzip Compression Provider](#gzip-compression-provider):
+
+::: moniker-end
 
 ```csharp
 public class Startup
@@ -117,27 +150,201 @@ Submit a request to the sample app with the `Accept-Encoding: gzip` header and o
 
 ## Providers
 
-### GzipCompressionProvider
+::: moniker range=">= aspnetcore-2.2"
 
-Use the [GzipCompressionProvider](/dotnet/api/microsoft.aspnetcore.responsecompression.gzipcompressionprovider) to compress responses with gzip. This is the default compression provider if none are specified. You can set the compression level with the [GzipCompressionProviderOptions](/dotnet/api/microsoft.aspnetcore.responsecompression.gzipcompressionprovideroptions).
+### Brotli Compression Provider
 
-The gzip compression provider defaults to the fastest compression level ([CompressionLevel.Fastest](/dotnet/api/system.io.compression.compressionlevel)), which might not produce the most efficient compression. If the most efficient compression is desired, you can configure the middleware for optimal compression.
+Use the `BrotliCompressionProvider` to compress responses with the [Brotli compressed data format](https://tools.ietf.org/html/rfc7932).
+
+If no compression providers are explicitly added to the <xref:Microsoft.AspNetCore.ResponseCompression.CompressionProviderCollection>:
+
+* The Brotli Compression Provider is added by default to the array of compression providers along with the [Gzip compression provider](#gzip-compression-provider).
+* Compression defaults to Brotli compression when the Brotli compressed data format is supported by the client. If Brotli isn't supported by the client, compression defaults to Gzip when the client supports Gzip compression.
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddResponseCompression();
+}
+```
+
+The Brotoli Compression Provider must be added when any compression providers are explicitly added:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddResponseCompression(options =>
+    {
+        options.Providers.Add<BrotliCompressionProvider>();
+        options.Providers.Add<GzipCompressionProvider>();
+        options.Providers.Add<CustomCompressionProvider>();
+        options.MimeTypes = 
+            ResponseCompressionDefaults.MimeTypes.Concat(
+                new[] { "image/svg+xml" });
+    });
+}
+```
+
+Set the compression level with `BrotliCompressionProviderOptions`. The Brotli Compression Provider defaults to the fastest compression level ([CompressionLevel.Fastest](xref:System.IO.Compression.CompressionLevel)), which might not produce the most efficient compression. If the most efficient compression is desired, configure the middleware for optimal compression.
 
 | Compression Level | Description |
 | ----------------- | ----------- |
-| [CompressionLevel.Fastest](/dotnet/api/system.io.compression.compressionlevel) | Compression should complete as quickly as possible, even if the resulting output isn't optimally compressed. |
-| [CompressionLevel.NoCompression](/dotnet/api/system.io.compression.compressionlevel) | No compression should be performed. |
-| [CompressionLevel.Optimal](/dotnet/api/system.io.compression.compressionlevel) | Responses should be optimally compressed, even if the compression takes more time to complete. |
+| [CompressionLevel.Fastest](xref:System.IO.Compression.CompressionLevel) | Compression should complete as quickly as possible, even if the resulting output isn't optimally compressed. |
+| [CompressionLevel.NoCompression](xref:System.IO.Compression.CompressionLevel) | No compression should be performed. |
+| [CompressionLevel.Optimal](xref:System.IO.Compression.CompressionLevel) | Responses should be optimally compressed, even if the compression takes more time to complete. |
 
-# [ASP.NET Core 2.x](#tab/aspnetcore2x/)
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddResponseCompression();
 
-[!code-csharp[](response-compression/samples/2.x/Startup.cs?name=snippet1&highlight=5,12-15)]
+    services.Configure<BrotliCompressionProviderOptions>(options => 
+    {
+        options.Level = CompressionLevel.Fastest;
+    });
+}
+```
 
-# [ASP.NET Core 1.x](#tab/aspnetcore1x/)
+::: moniker-end
 
-[!code-csharp[](response-compression/samples/1.x/Startup.cs?name=snippet2&highlight=5,12-15)]
+### Gzip Compression Provider
 
----
+Use the <xref:Microsoft.AspNetCore.ResponseCompression.GzipCompressionProvider> to compress responses with the [Gzip file format](https://tools.ietf.org/html/rfc1952).
+
+If no compression providers are explicitly added to the <xref:Microsoft.AspNetCore.ResponseCompression.CompressionProviderCollection>:
+
+::: moniker range=">= aspnetcore-2.2"
+
+* The Gzip Compression Provider is added by default to the array of compression providers along with the [Brotli Compression Provider](#brotli-compression-provider).
+* Compression defaults to Brotli compression when the Brotli compressed data format is supported by the client. If Brotli isn't supported by the client, compression defaults to Gzip when the client supports Gzip compression.
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.2"
+
+* The Gzip Compression Provider is added by default to the array of compression providers.
+* Compression defaults to Gzip when the client supports Gzip compression.
+
+::: moniker-end
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddResponseCompression();
+}
+```
+
+The Gzip Compression Provider must be added when any compression providers are explicitly added:
+
+::: moniker range=">= aspnetcore-2.2"
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddResponseCompression(options =>
+    {
+        options.Providers.Add<BrotliCompressionProvider>();
+        options.Providers.Add<GzipCompressionProvider>();
+        options.Providers.Add<CustomCompressionProvider>();
+        options.MimeTypes = 
+            ResponseCompressionDefaults.MimeTypes.Concat(
+                new[] { "image/svg+xml" });
+    });
+}
+```
+
+::: moniker-end
+
+::: moniker range="= aspnetcore-2.0 || aspnetcore-2.1"
+
+[!code-csharp[](response-compression/samples/2.x/Startup.cs?name=snippet1&highlight=5)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.0"
+
+[!code-csharp[](response-compression/samples/1.x/Startup.cs?name=snippet2&highlight=5)]
+
+::: moniker-end
+
+Set the compression level with <xref:Microsoft.AspNetCore.ResponseCompression.GzipCompressionProviderOptions>. The Gzip Compression Provider defaults to the fastest compression level ([CompressionLevel.Fastest](xref:System.IO.Compression.CompressionLevel)), which might not produce the most efficient compression. If the most efficient compression is desired, configure the middleware for optimal compression.
+
+| Compression Level | Description |
+| ----------------- | ----------- |
+| [CompressionLevel.Fastest](xref:System.IO.Compression.CompressionLevel) | Compression should complete as quickly as possible, even if the resulting output isn't optimally compressed. |
+| [CompressionLevel.NoCompression](xref:System.IO.Compression.CompressionLevel) | No compression should be performed. |
+| [CompressionLevel.Optimal](xref:System.IO.Compression.CompressionLevel) | Responses should be optimally compressed, even if the compression takes more time to complete. |
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddResponseCompression();
+
+    services.Configure<GzipCompressionProviderOptions>(options => 
+    {
+        options.Level = CompressionLevel.Fastest;
+    });
+}
+```
+
+### Custom providers
+
+Create custom compression implementations with <xref:Microsoft.AspNetCore.ResponseCompression.ICompressionProvider>. The <xref:Microsoft.AspNetCore.ResponseCompression.ICompressionProvider.EncodingName*> represents the content encoding that this `ICompressionProvider` produces. The middleware uses this information to choose the provider based on the list specified in the `Accept-Encoding` header of the request.
+
+Using the sample app, the client submits a request with the `Accept-Encoding: mycustomcompression` header. The middleware uses the custom compression implementation and returns the response with a `Content-Encoding: mycustomcompression` header. The client must be able to decompress the custom encoding in order for a custom compression implementation to work.
+
+::: moniker range=">= aspnetcore-2.2"
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddResponseCompression(options =>
+    {
+        options.Providers.Add<BrotliCompressionProvider>();
+        options.Providers.Add<GzipCompressionProvider>();
+        options.Providers.Add<CustomCompressionProvider>();
+        options.MimeTypes = 
+            ResponseCompressionDefaults.MimeTypes.Concat(
+                new[] { "image/svg+xml" });
+    });
+}
+```
+
+```csharp
+public class CustomCompressionProvider : ICompressionProvider
+{
+    public string EncodingName => "mycustomcompression";
+    public bool SupportsFlush => true;
+
+    public Stream CreateStream(Stream outputStream)
+    {
+        // Create a custom compression stream wrapper here
+        return outputStream;
+    }
+}
+```
+
+::: moniker-end
+
+::: moniker range="= aspnetcore-2.0 || aspnetcore-2.1"
+
+[!code-csharp[](response-compression/samples/2.x/Startup.cs?name=snippet1&highlight=6,12-15)]
+
+[!code-csharp[](response-compression/samples/2.x/CustomCompressionProvider.cs?name=snippet1)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.0"
+
+[!code-csharp[](response-compression/samples/1.x/Startup.cs?name=snippet2&highlight=6,12-15)]
+
+[!code-csharp[](response-compression/samples/1.x/CustomCompressionProvider.cs?name=snippet1)]
+
+::: moniker-end
+
+Submit a request to the sample app with the `Accept-Encoding: mycustomcompression` header and observe the response headers. The `Vary` and `Content-Encoding` headers are present on the response. The response body (not shown) isn't compressed by the sample. There isn't a compression implementation in the `CustomCompressionProvider` class of the sample. However, the sample shows where you would implement such a compression algorithm.
+
+![Fiddler window showing result of a request with the Accept-Encoding header and a value of mycustomcompression. The Vary and Content-Encoding headers are added to the response.](response-compression/_static/request-custom-compression.png)
 
 ## MIME types
 
@@ -152,41 +359,38 @@ The middleware specifies a default set of MIME types for compression:
 * `application/json`
 * `text/json`
 
-You can replace or append MIME types with the Response Compression Middleware options. Note that wildcard MIME types, such as `text/*` aren't supported. The sample app adds a MIME type for `image/svg+xml` and compresses and serves the ASP.NET Core banner image (*banner.svg*).
+Replace or append MIME types with the Response Compression Middleware options. Note that wildcard MIME types, such as `text/*` aren't supported. The sample app adds a MIME type for `image/svg+xml` and compresses and serves the ASP.NET Core banner image (*banner.svg*).
 
-# [ASP.NET Core 2.x](#tab/aspnetcore2x/)
+::: moniker range=">= aspnetcore-2.2"
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddResponseCompression(options =>
+    {
+        options.Providers.Add<BrotliCompressionProvider>();
+        options.Providers.Add<GzipCompressionProvider>();
+        options.Providers.Add<CustomCompressionProvider>();
+        options.MimeTypes = 
+            ResponseCompressionDefaults.MimeTypes.Concat(
+                new[] { "image/svg+xml" });
+    });
+}
+```
+
+::: moniker-end
+
+::: moniker range="= aspnetcore-2.0 || aspnetcore-2.1"
 
 [!code-csharp[](response-compression/samples/2.x/Startup.cs?name=snippet1&highlight=7-9)]
 
-# [ASP.NET Core 1.x](#tab/aspnetcore1x/)
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.0"
 
 [!code-csharp[](response-compression/samples/1.x/Startup.cs?name=snippet2&highlight=7-9)]
 
----
-
-### Custom providers
-
-You can create custom compression implementations with [ICompressionProvider](/dotnet/api/microsoft.aspnetcore.responsecompression.icompressionprovider). The [EncodingName](/dotnet/api/microsoft.aspnetcore.responsecompression.icompressionprovider.encodingname) represents the content encoding that this `ICompressionProvider` produces. The middleware uses this information to choose the provider based on the list specified in the `Accept-Encoding` header of the request.
-
-Using the sample app, the client submits a request with the `Accept-Encoding: mycustomcompression` header. The middleware uses the custom compression implementation and returns the response with a `Content-Encoding: mycustomcompression` header. The client must be able to decompress the custom encoding in order for a custom compression implementation to work.
-
-# [ASP.NET Core 2.x](#tab/aspnetcore2x/)
-
-[!code-csharp[](response-compression/samples/2.x/Startup.cs?name=snippet1&highlight=5,12-15)]
-
-[!code-csharp[](response-compression/samples/2.x/CustomCompressionProvider.cs?name=snippet1)]
-
-# [ASP.NET Core 1.x](#tab/aspnetcore1x/)
-
-[!code-csharp[](response-compression/samples/1.x/Startup.cs?name=snippet2&highlight=5,12-15)]
-
-[!code-csharp[](response-compression/samples/1.x/CustomCompressionProvider.cs?name=snippet1)]
-
----
-
-Submit a request to the sample app with the `Accept-Encoding: mycustomcompression` header and observe the response headers. The `Vary` and `Content-Encoding` headers are present on the response. The response body (not shown) isn't compressed by the sample. There isn't a compression implementation in the `CustomCompressionProvider` class of the sample. However, the sample shows where you would implement such a compression algorithm.
-
-![Fiddler window showing result of a request with the Accept-Encoding header and a value of mycustomcompression. The Vary and Content-Encoding headers are added to the response.](response-compression/_static/request-custom-compression.png)
+::: moniker-end
 
 ## Compression with secure protocol
 
@@ -214,21 +418,34 @@ When a request is proxied by Nginx, the `Accept-Encoding` header is removed. Thi
 
 ## Working with IIS dynamic compression
 
-If you have an active IIS Dynamic Compression Module configured at the server level that you would like to disable for an app, you can do so with an addition to your *web.config* file. For more information, see [Disabling IIS modules](xref:host-and-deploy/iis/modules#disabling-iis-modules).
+If you have an active IIS Dynamic Compression Module configured at the server level that you would like to disable for an app, disable the module with an addition to the *web.config* file. For more information, see [Disabling IIS modules](xref:host-and-deploy/iis/modules#disabling-iis-modules).
 
 ## Troubleshooting
 
-Use a tool like [Fiddler](http://www.telerik.com/fiddler), [Firebug](http://getfirebug.com/), or [Postman](https://www.getpostman.com/), which allow you to set the `Accept-Encoding` request header and study the response headers, size, and body. The Response Compression Middleware compresses responses that meet the following conditions:
+Use a tool like [Fiddler](http://www.telerik.com/fiddler), [Firebug](http://getfirebug.com/), or [Postman](https://www.getpostman.com/), which allow you to set the `Accept-Encoding` request header and study the response headers, size, and body. By default, Response Compression Middleware compresses responses that meet the following conditions:
 
-* The `Accept-Encoding` header is present with a value of `gzip`, `*`, or custom encoding that matches a custom compression provider that you've established. The value must not be `identity` or have a quality value (qvalue, `q`) setting of 0 (zero).
-* The MIME type (`Content-Type`) must be set and must match a MIME type configured on the [ResponseCompressionOptions](/dotnet/api/microsoft.aspnetcore.responsecompression.responsecompressionoptions).
+::: moniker range=">= aspnetcore-2.2"
+
+* The `Accept-Encoding` header is present with a value of `br`, `gzip`, `*`, or custom encoding that matches a custom compression provider that you've established. The value must not be `identity` or have a quality value (qvalue, `q`) setting of 0 (zero).
+* The MIME type (`Content-Type`) must be set and must match a MIME type configured on the <xref:Microsoft.AspNetCore.ResponseCompression.ResponseCompressionOptions>.
 * The request must not include the `Content-Range` header.
 * The request must use insecure protocol (http), unless secure protocol (https) is configured in the Response Compression Middleware options. *Note the danger [described above](#compression-with-secure-protocol) when enabling secure content compression.*
 
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.2"
+
+* The `Accept-Encoding` header is present with a value of `gzip`, `*`, or custom encoding that matches a custom compression provider that you've established. The value must not be `identity` or have a quality value (qvalue, `q`) setting of 0 (zero).
+* The MIME type (`Content-Type`) must be set and must match a MIME type configured on the <xref:Microsoft.AspNetCore.ResponseCompression.ResponseCompressionOptions>.
+* The request must not include the `Content-Range` header.
+* The request must use insecure protocol (http), unless secure protocol (https) is configured in the Response Compression Middleware options. *Note the danger [described above](#compression-with-secure-protocol) when enabling secure content compression.*
+
+::: moniker-end
+
 ## Additional resources
 
-* [Application Startup](xref:fundamentals/startup)
-* [Middleware](xref:fundamentals/middleware/index)
+* <xref:fundamentals/startup>
+* <xref:fundamentals/middleware/index>
 * [Mozilla Developer Network: Accept-Encoding](https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Encoding)
 * [RFC 7231 Section 3.1.2.1: Content Codings](https://tools.ietf.org/html/rfc7231#section-3.1.2.1)
 * [RFC 7230 Section 4.2.3: Gzip Coding](https://tools.ietf.org/html/rfc7230#section-4.2.3)

--- a/aspnetcore/performance/response-compression.md
+++ b/aspnetcore/performance/response-compression.md
@@ -41,7 +41,7 @@ When a client can process compressed content, the client must inform the server 
 | `Accept-Encoding` header values | Middleware Supported | Description |
 | ------------------------------- | :------------------: | ----------- |
 | `br`                            | Yes (default)        | [Brotli compressed data format](https://tools.ietf.org/html/rfc7932) |
-| `deflate`                       | No                   | [DEFLATE compressed data format](https://www.ietf.org/rfc/rfc1951.txt) |
+| `deflate`                       | No                   | [DEFLATE compressed data format](https://tools.ietf.org/html/rfc1951) |
 | `exi`                           | No                   | [W3C Efficient XML Interchange](https://tools.ietf.org/id/draft-varga-netconf-exi-capability-00.html) |
 | `gzip`                          | Yes                  | [Gzip file format](https://tools.ietf.org/html/rfc1952) |
 | `identity`                      | Yes                  | "No encoding" identifier: The response must not be encoded. |
@@ -55,7 +55,7 @@ When a client can process compressed content, the client must inform the server 
 | `Accept-Encoding` header values | Middleware Supported | Description |
 | ------------------------------- | :------------------: | ----------- |
 | `br`                            | No                   | [Brotli compressed data format](https://tools.ietf.org/html/rfc7932) |
-| `deflate`                       | No                   | [DEFLATE compressed data format](https://www.ietf.org/rfc/rfc1951.txt) |
+| `deflate`                       | No                   | [DEFLATE compressed data format](https://tools.ietf.org/html/rfc1951) |
 | `exi`                           | No                   | [W3C Efficient XML Interchange](https://tools.ietf.org/id/draft-varga-netconf-exi-capability-00.html) |
 | `gzip`                          | Yes (default)        | [Gzip file format](https://tools.ietf.org/html/rfc1952) |
 | `identity`                      | Yes                  | "No encoding" identifier: The response must not be encoded. |

--- a/aspnetcore/performance/response-compression/samples/1.x/README.md
+++ b/aspnetcore/performance/response-compression/samples/1.x/README.md
@@ -3,11 +3,12 @@
 This sample illustrates the use of ASP.NET Core 1.x Response Compression Middleware to compress HTTP responses for. The sample demonstrates Gzip and custom compression providers for text and image responses and shows how to add a MIME type for compression. For the ASP.NET Core 2.x sample, see [Response compression sample application (ASP.NET Core 2.x)](https://github.com/aspnet/Docs/tree/master/aspnetcore/performance/response-compression/samples/2.x).
 
 ## Examples in this sample
+
 * `GzipCompressionProvider`
   * `text/plain`
     * **/** - Lorem Ipsum text file response at 2,044 bytes that will compress to 927 bytes
     * **/testfile1kb.txt** - Text file response at 1,033 bytes that will compress to 47 bytes
-    * **/trickle** - Response issued as single characters at 1 second intervals 
+    * **/trickle** - Response issued as single characters at 1 second intervals
   * `image/svg+xml`
     * **/banner.svg** - A Scalable Vector Graphics (SVG) image response at 9,707 bytes that will compress to 4,459 bytes
 * `CustomCompressionProvider`<br>Shows how to implement a custom compression provider for use with the middleware
@@ -15,6 +16,7 @@ This sample illustrates the use of ASP.NET Core 1.x Response Compression Middlew
 When the request includes the `Accept-Encoding` header, the sample adds a `Vary: Accept-Encoding` header to the response. The `Vary` header instructs caches to maintain multiple copies of the response based on alternative values of `Accept-Encoding`, so both a compressed (gzip) and uncompressed version are stored in caches for systems that can either accept the compressed or the uncompressed response.
 
 ## Using the sample
+
 1. Make a request using [Fiddler](http://www.telerik.com/fiddler), [Firebug](http://getfirebug.com/), or [Postman](https://www.getpostman.com/) to the application without an `Accept-Encoding` header and note the response payload, response size, and response headers.
-2. Add an `Accept-Encoding: gzip` header and note the compressed response size and response headers. You see the response size drop, and the `Content-Encoding: gzip` response header is included by the sample app. When you look at the response body for the Lorem Ipsum or **testfile1kb.txt** response, you see that the text is compressed and unreadable.
-3. Add an `Accept-Encoding: mycustomcompression` header and note the response headers. The `CustomCompressionProvider` is an empty implementation that doesn't actually compress the response, but you can create a custom compression stream wrapper for the `CreateStream()` method.
+1. Add an `Accept-Encoding: gzip` header and note the compressed response size and response headers. You see the response size drop, and the `Content-Encoding: gzip` response header is included by the sample app. When you look at the response body for the Lorem Ipsum or **testfile1kb.txt** response, you see that the text is compressed and unreadable.
+1. Add an `Accept-Encoding: mycustomcompression` header and note the response headers. The `CustomCompressionProvider` is an empty implementation that doesn't actually compress the response, but you can create a custom compression stream wrapper for the `CreateStream()` method.

--- a/aspnetcore/performance/response-compression/samples/1.x/Startup.cs
+++ b/aspnetcore/performance/response-compression/samples/1.x/Startup.cs
@@ -26,11 +26,6 @@ namespace ResponseCompressionSample
                     ResponseCompressionDefaults.MimeTypes.Concat(
                         new[] { "image/svg+xml" });
             });
-
-            services.Configure<GzipCompressionProviderOptions>(options => 
-            {
-                options.Level = CompressionLevel.Fastest;
-            });
         }
         #endregion
 

--- a/aspnetcore/performance/response-compression/samples/2.x/README.md
+++ b/aspnetcore/performance/response-compression/samples/2.x/README.md
@@ -3,11 +3,12 @@
 This sample illustrates the use of ASP.NET Core 2.x Response Compression Middleware to compress HTTP responses for. The sample demonstrates Gzip and custom compression providers for text and image responses and shows how to add a MIME type for compression. For the ASP.NET Core 1.x sample, see [Response compression sample application (ASP.NET Core 1.x)](https://github.com/aspnet/Docs/tree/master/aspnetcore/performance/response-compression/samples/1.x).
 
 ## Examples in this sample
+
 * `GzipCompressionProvider`
   * `text/plain`
     * **/** - Lorem Ipsum text file response at 2,044 bytes that will compress to 927 bytes
     * **/testfile1kb.txt** - Text file response at 1,033 bytes that will compress to 47 bytes
-    * **/trickle** - Response issued as single characters at 1 second intervals 
+    * **/trickle** - Response issued as single characters at 1 second intervals
   * `image/svg+xml`
     * **/banner.svg** - A Scalable Vector Graphics (SVG) image response at 9,707 bytes that will compress to 4,459 bytes
 * `CustomCompressionProvider`<br>Shows how to implement a custom compression provider for use with the middleware
@@ -15,6 +16,7 @@ This sample illustrates the use of ASP.NET Core 2.x Response Compression Middlew
 When the request includes the `Accept-Encoding` header and response compression is successful, the middleware automatically adds a `Vary: Accept-Encoding` header to the response. The `Vary` header instructs caches to maintain multiple copies of the response based on alternative values of `Accept-Encoding`, so both a compressed (gzip) and uncompressed version are stored in caches for systems that can either accept the compressed or the uncompressed response.
 
 ## Using the sample
+
 1. Make a request using [Fiddler](http://www.telerik.com/fiddler), [Firebug](http://getfirebug.com/), or [Postman](https://www.getpostman.com/) to the application without an `Accept-Encoding` header and note the response payload, response size, and response headers.
-2. Add an `Accept-Encoding: gzip` header and note the compressed response size and response headers. The response size drops, and the `Content-Encoding: gzip` response header is included by the middleware. When you look at the response body for the Lorem Ipsum or **testfile1kb.txt** response, you see that the text is compressed and unreadable.
-3. Add an `Accept-Encoding: mycustomcompression` header and note the response headers. The `CustomCompressionProvider` is an empty implementation that doesn't actually compress the response, but you can create a custom compression stream wrapper for the `CreateStream()` method.
+1. Add an `Accept-Encoding: gzip` header and note the compressed response size and response headers. The response size drops, and the `Content-Encoding: gzip` response header is included by the middleware. When you look at the response body for the Lorem Ipsum or **testfile1kb.txt** response, you see that the text is compressed and unreadable.
+1. Add an `Accept-Encoding: mycustomcompression` header and note the response headers. The `CustomCompressionProvider` is an empty implementation that doesn't actually compress the response, but you can create a custom compression stream wrapper for the `CreateStream()` method.

--- a/aspnetcore/performance/response-compression/samples/2.x/Startup.cs
+++ b/aspnetcore/performance/response-compression/samples/2.x/Startup.cs
@@ -23,11 +23,6 @@ namespace ResponseCompressionSample
                     ResponseCompressionDefaults.MimeTypes.Concat(
                         new[] { "image/svg+xml" });
             });
-
-            services.Configure<GzipCompressionProviderOptions>(options => 
-            {
-                options.Level = CompressionLevel.Fastest;
-            });
         }
         #endregion
 

--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -401,7 +401,7 @@
 ### [Work with a distributed cache](xref:performance/caching/distributed)
 ### [Response caching](xref:performance/caching/response)
 ### [Response caching middleware](xref:performance/caching/middleware)
-## [Response compression middleware](xref:performance/response-compression)
+## [Response compression](xref:performance/response-compression)
 
 # [Migration](xref:migration/index)
 ## [ASP.NET Core 2.0 to 2.1](xref:migration/20_21)


### PR DESCRIPTION
Fixes #7715 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/performance/response-compression?view=aspnetcore-1.1&branch=pr-en-us-8560)

* A number of topic UE updates are provided.
* Brotli content is added to the topic.
* I use inline code examples over snapshot files because this will only in need of a quick sample update + some sample link changes when 2.2 RTMs, and that's right around the corner.
* Opened **Add Brotli compression to the sample app** #8559 to deal with sample app update later.

cc: @khellang ... do u want to take a look at the Brotli bits before I call for engineering to take a look?