### PR TITLE
Use API Explorer based NSwag generator and middlewares

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-NSwag.md
+++ b/aspnetcore/tutorials/getting-started-with-NSwag.md
@@ -23,9 +23,9 @@ By [Christoph Nienaber](https://twitter.com/zuckerthoben) and [Rico Suter](https
 
 ::: moniker-end
 
-Using [NSwag](https://github.com/RSuter/NSwag) with ASP.NET Core middleware requires the [NSwag.AspNetCore](https://www.nuget.org/packages/NSwag.AspNetCore/) NuGet package. The package consists of a Swagger generator, Swagger UI (v2 and v3), and [ReDoc UI](https://github.com/Rebilly/ReDoc).
+First, we register the NSwag middlewares to generate the Swagger specification for the implemented Web API and serve the Swagger UI to browse and test the API. To use the [NSwag](https://github.com/RSuter/NSwag) ASP.NET Core middlewares you have to install the [NSwag.AspNetCore](https://www.nuget.org/packages/NSwag.AspNetCore/) NuGet package: This package contains the middlewares to generate and serve the Swagger specification, Swagger UI (v2 and v3) and [ReDoc UI](https://github.com/Rebilly/ReDoc).
 
-It's highly recommended to make use of NSwag's code generation capabilities. Choose one of the following options for code generation:
+Additionally, it is highly recommended to make use of NSwag's code generation capabilities. Choose one of the following options to use the code generation capabilities:
 
 * Use [NSwagStudio](https://github.com/NSwag/NSwag/wiki/NSwagStudio), a Windows desktop app for generating client code in C# and TypeScript for your API.
 * Use the [NSwag.CodeGeneration.CSharp](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) or [NSwag.CodeGeneration.TypeScript](https://www.nuget.org/packages/NSwag.CodeGeneration.TypeScript/) NuGet packages to do code generation inside your project.
@@ -34,7 +34,7 @@ It's highly recommended to make use of NSwag's code generation capabilities. Cho
 
 ## Features
 
-The main reason to use NSwag is the ability to not only introduce the Swagger UI and Swagger generator, but to make use of the flexible code generation capabilities. You don't need an existing API&mdash;you can use third-party APIs that incorporate Swagger and let NSwag generate a client implementation. Either way, the development cycle is expedited and you can more easily adapt to API changes.
+The main reason to use NSwag is the ability to not only introduce the Swagger UI and Swagger generator, but to also make use of the flexible code generation capabilities. You don't need an existing API&mdash;you can use third-party APIs that incorporate Swagger and let NSwag generate a client implementation. Either way, the development cycle is expedited and you can more easily adapt to API changes.
 
 ## Package installation
 
@@ -86,9 +86,13 @@ dotnet add TodoApi.csproj package NSwag.AspNetCore
 
 Import the following namespaces in the `Startup` class:
 
-[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs?name=snippet_StartupConfigureImports)]
+[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs?name=snippet_ConfigureServices&highlight=8-8)]
 
-In the `Startup.Configure` method, enable the middleware for serving the generated Swagger specification and the Swagger UI:
+In the `Startup.ConfigureServices` method, register the required Swagger services: 
+
+[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs?name=snippet_Configure&highlight=6-10)]
+
+In the `Startup.Configure` method, enable the middleware for serving the generated Swagger specification and the Swagger UI v3:
 
 [!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs?name=snippet_Configure&highlight=6-10)]
 

--- a/aspnetcore/tutorials/getting-started-with-NSwag.md
+++ b/aspnetcore/tutorials/getting-started-with-NSwag.md
@@ -4,7 +4,7 @@ author: zuckerthoben
 description: Learn how to use NSwag to generate documentation and help pages for an ASP.NET Core web API.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 06/29/2018
+ms.date: 09/20/2018
 uid: tutorials/get-started-with-nswag
 ---
 # Get started with NSwag and ASP.NET Core
@@ -23,9 +23,14 @@ By [Christoph Nienaber](https://twitter.com/zuckerthoben) and [Rico Suter](https
 
 ::: moniker-end
 
-First, we register the NSwag middlewares to generate the Swagger specification for the implemented Web API and serve the Swagger UI to browse and test the API. To use the [NSwag](https://github.com/RSuter/NSwag) ASP.NET Core middlewares you have to install the [NSwag.AspNetCore](https://www.nuget.org/packages/NSwag.AspNetCore/) NuGet package: This package contains the middlewares to generate and serve the Swagger specification, Swagger UI (v2 and v3) and [ReDoc UI](https://github.com/Rebilly/ReDoc).
+Register the NSwag middlewares to:
 
-Additionally, it is highly recommended to make use of NSwag's code generation capabilities. Choose one of the following options to use the code generation capabilities:
+* Generate the Swagger specification for the implemented web API.
+* Serve the Swagger UI to browse and test the web API.
+
+To use the [NSwag](https://github.com/RSuter/NSwag) ASP.NET Core middlewares, install the [NSwag.AspNetCore](https://www.nuget.org/packages/NSwag.AspNetCore/) NuGet package. This package contains the middlewares to generate and serve the Swagger specification, Swagger UI (v2 and v3), and [ReDoc UI](https://github.com/Rebilly/ReDoc).
+
+Additionally, it's highly recommended to make use of NSwag's code generation capabilities. Choose one of the following options to use the code generation capabilities:
 
 * Use [NSwagStudio](https://github.com/NSwag/NSwag/wiki/NSwagStudio), a Windows desktop app for generating client code in C# and TypeScript for your API.
 * Use the [NSwag.CodeGeneration.CSharp](https://www.nuget.org/packages/NSwag.CodeGeneration.CSharp/) or [NSwag.CodeGeneration.TypeScript](https://www.nuget.org/packages/NSwag.CodeGeneration.TypeScript/) NuGet packages to do code generation inside your project.

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
@@ -4,7 +4,7 @@ author: rsuter
 description: This tutorial provides a walkthrough of adding Swagger to generate documentation and help pages for a Web API app.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 03/09/2018
+ms.date: 09/20/2018
 uid: tutorials/web-api-help-pages-using-swagger
 ---
 # ASP.NET Core Web API help pages with Swagger / OpenAPI
@@ -17,7 +17,7 @@ In this article, the [Swashbuckle.AspNetCore](https://github.com/domaindrivendev
 
 * **Swashbuckle.AspNetCore** is an open source project for generating Swagger documents for ASP.NET Core Web APIs.
 
-* **NSwag** is another open source project for generating Swagger documents and integrating [Swagger UI](https://swagger.io/swagger-ui/) or [ReDoc](https://github.com/Rebilly/ReDoc) into ASP.NET Core Web APIs. Additionally it offers approaches to generate C# and TypeScript client code for your API.
+* **NSwag** is another open source project for generating Swagger documents and integrating [Swagger UI](https://swagger.io/swagger-ui/) or [ReDoc](https://github.com/Rebilly/ReDoc) into ASP.NET Core web APIs. Additionally, NSwag offers approaches to generate C# and TypeScript client code for your API.
 
 ## What is Swagger / OpenAPI?
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger.md
@@ -1,5 +1,5 @@
 ---
-title: ASP.NET Core Web API help pages with Swagger / Open API
+title: ASP.NET Core Web API help pages with Swagger / OpenAPI
 author: rsuter
 description: This tutorial provides a walkthrough of adding Swagger to generate documentation and help pages for a Web API app.
 ms.author: scaddie
@@ -7,21 +7,21 @@ ms.custom: mvc
 ms.date: 03/09/2018
 uid: tutorials/web-api-help-pages-using-swagger
 ---
-# ASP.NET Core Web API help pages with Swagger / Open API
+# ASP.NET Core Web API help pages with Swagger / OpenAPI
 
 By [Christoph Nienaber](https://twitter.com/zuckerthoben) and [Rico Suter](http://rsuter.com)
 
-When consuming a Web API, understanding its various methods can be challenging for a developer. [Swagger](https://swagger.io/), also known as Open API, solves the problem of generating useful documentation and help pages for Web APIs. It provides benefits such as interactive documentation, client SDK generation, and API discoverability.
+When consuming a Web API, understanding its various methods can be challenging for a developer. [Swagger](https://swagger.io/), also known as [OpenAPI](https://www.openapis.org/), solves the problem of generating useful documentation and help pages for Web APIs. It provides benefits such as interactive documentation, client SDK generation, and API discoverability.
 
 In this article, the [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) and [NSwag](https://github.com/RSuter/NSwag) .NET Swagger implementations are showcased:
 
 * **Swashbuckle.AspNetCore** is an open source project for generating Swagger documents for ASP.NET Core Web APIs.
 
-* **NSwag** is another open source project for integrating [Swagger UI](https://swagger.io/swagger-ui/) or [ReDoc](https://github.com/Rebilly/ReDoc) into ASP.NET Core Web APIs. It offers approaches to generate C# and TypeScript client code for your API.
+* **NSwag** is another open source project for generating Swagger documents and integrating [Swagger UI](https://swagger.io/swagger-ui/) or [ReDoc](https://github.com/Rebilly/ReDoc) into ASP.NET Core Web APIs. Additionally it offers approaches to generate C# and TypeScript client code for your API.
 
-## What is Swagger / Open API?
+## What is Swagger / OpenAPI?
 
-Swagger is a language-agnostic specification for describing [REST](https://en.wikipedia.org/wiki/Representational_state_transfer) APIs. The Swagger project was donated to the [OpenAPI Initiative](https://www.openapis.org/), where it's now referred to as Open API. Both names are used interchangeably; however, Open API is preferred. It allows both computers and humans to understand the capabilities of a service without any direct access to the implementation (source code, network access, documentation). One goal is to minimize the amount of work needed to connect disassociated services. Another goal is to reduce the amount of time needed to accurately document a service.
+Swagger is a language-agnostic specification for describing [REST](https://en.wikipedia.org/wiki/Representational_state_transfer) APIs. The Swagger project was donated to the [OpenAPI Initiative](https://www.openapis.org/), where it's now referred to as OpenAPI. Both names are used interchangeably; however, OpenAPI is preferred. It allows both computers and humans to understand the capabilities of a service without any direct access to the implementation (source code, network access, documentation). One goal is to minimize the amount of work needed to connect disassociated services. Another goal is to reduce the amount of time needed to accurately document a service.
 
 ## Swagger specification (swagger.json)
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs
@@ -18,6 +18,9 @@ namespace TodoApi
             services.AddDbContext<TodoContext>(opt => 
                 opt.UseInMemoryDatabase("TodoList"));
             services.AddMvc();
+
+            // Register the Swagger services
+            services.AddSwagger();
         }
         #endregion snippet_ConfigureServices
 
@@ -26,8 +29,8 @@ namespace TodoApi
         {
             app.UseStaticFiles();
 
-            // Enable the Swagger UI middleware and the Swagger generator
-            app.UseSwaggerUi(typeof(Startup).GetTypeInfo().Assembly, settings =>
+            // Register the Swagger generator and the Swagger UI middlewares
+            app.UseSwaggerUi3WithApiExplorer(settings =>
             {
                 settings.GeneratorSettings.DefaultPropertyNameHandling = 
                     PropertyNameHandling.CamelCase;

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup2.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup2.cs
@@ -18,6 +18,9 @@ namespace TodoApi
             services.AddDbContext<TodoContext>(opt =>
                 opt.UseInMemoryDatabase("TodoList"));
             services.AddMvc();
+
+            // Register the Swagger services
+            services.AddSwagger();
         }
         #endregion snippet_ConfigureServices
 
@@ -27,8 +30,8 @@ namespace TodoApi
             app.UseStaticFiles();
 
             #region snippet_UseSwagger
-            // Register the Swagger generator
-            app.UseSwagger(typeof(Startup).Assembly, settings =>
+            // Register the Swagger generator middleware
+            app.UseSwaggerWithApiExplorer(settings =>
             {
                 settings.PostProcess = document =>
                 {
@@ -51,12 +54,8 @@ namespace TodoApi
             });
             #endregion snippet_UseSwagger
 
-            // Enable the Swagger UI middleware and the Swagger generator
-            app.UseSwaggerUi(typeof(Startup).GetTypeInfo().Assembly, settings =>
-            {
-                settings.GeneratorSettings.DefaultPropertyNameHandling =
-                    PropertyNameHandling.CamelCase;
-            });
+            // Register the Swagger UI middleware
+            app.UseSwaggerUi3();
 
             app.UseMvc();
         }

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/TodoApi.csproj
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/TodoApi.csproj
@@ -13,8 +13,8 @@
   <!-- </snippet_DocumentationFileElement> -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
-    <PackageReference Include="NSwag.AspNetCore" Version="11.16.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="NSwag.AspNetCore" Version="11.19.2" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.NSwag/Startup.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.NSwag/Startup.cs
@@ -20,6 +20,9 @@ namespace TodoApi
                 opt.UseInMemoryDatabase("TodoList"));
             services.AddMvc()
                     .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+
+            // Register the Swagger services
+            services.AddSwagger();
         }
         #endregion snippet_ConfigureServices
 
@@ -28,8 +31,8 @@ namespace TodoApi
         {
             app.UseStaticFiles();
 
-            // Enable the Swagger UI middleware and the Swagger generator
-            app.UseSwaggerUi(typeof(Startup).GetTypeInfo().Assembly, settings =>
+            // Register the Swagger generator and the Swagger UI middlewares
+            app.UseSwaggerUi3WithApiExplorer(settings =>
             {
                 settings.GeneratorSettings.DefaultPropertyNameHandling = 
                     PropertyNameHandling.CamelCase;

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.NSwag/TodoApi.csproj
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.1/TodoApi.NSwag/TodoApi.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
-    <PackageReference Include="NSwag.AspNetCore" Version="11.17.3" />
+    <PackageReference Include="NSwag.AspNetCore" Version="11.19.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Upgrade NSwag (samples) and use new API Explorer based generators (the reflection based generators are deprecated soon)
- Some text improvements
- Change "Open API" to "OpenAPI" (correct name)
- Use new Swagger UI 3 in samples

[Internal Review Page](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-nswag?view=aspnetcore-2.1&branch=pr-en-us-8572&tabs=visual-studio%2Cvisual-studio-xml)