### PR TITLE
CC71738: Escaping components names to avoid broken format in translation pages

### DIFF
--- a/aspnetcore/mvc/views/view-components.md
+++ b/aspnetcore/mvc/views/view-components.md
@@ -69,21 +69,20 @@ A view component defines its logic in an `InvokeAsync` method that returns an `I
 
 The runtime searches for the view in the following paths:
 
-* /Pages/Components/`<view_component_name>`/`<view_name>`
-* /Views/`<controller_name>`/Components/`<view_component_name>`/`<view_name>`
-* /Views/Shared/Components/`<view_component_name>`/`<view_name>`
-<!-- Could you please confirm if the components between < and > needs to be left as it or maybe they should be -->
+* /Pages/Components/{View Component Name}/{View Name}
+* /Views/{Controller Name}/Components/{View Component Name}/{View Name}
+* /Views/Shared/Components/{View Component Name}/{View Name}
 
 The default view name for a view component is *Default*, which means your view file will typically be named *Default.cshtml*. You can specify a different view name when creating the view component result or when calling the `View` method.
 
-We recommend you name the view file *Default.cshtml* and use the *Views/Shared/Components/`<view_component_name>`/`<view_name>`* path. The `PriorityList` view component used in this sample uses *Views/Shared/Components/PriorityList/Default.cshtml* for the view component view.
+We recommend you name the view file *Default.cshtml* and use the *Views/Shared/Components/{View Component Name}/{View Name}* path. The `PriorityList` view component used in this sample uses *Views/Shared/Components/PriorityList/Default.cshtml* for the view component view.
 
 ## Invoking a view component
 
 To use the view component, call the following inside a view:
 
 ```cshtml
-@Component.InvokeAsync("Name of view component", <anonymous type containing parameters>)
+@Component.InvokeAsync("Name of view component", {Anonymous Type Containing Parameters})
 ```
 
 The parameters will be passed to the `InvokeAsync` method. The `PriorityList` view component developed in the article is invoked from the *Views/Todo/Index.cshtml* view file. In the following, the `InvokeAsync` method is called with two parameters:

--- a/aspnetcore/mvc/views/view-components.md
+++ b/aspnetcore/mvc/views/view-components.md
@@ -69,13 +69,14 @@ A view component defines its logic in an `InvokeAsync` method that returns an `I
 
 The runtime searches for the view in the following paths:
 
-* /Pages/Components/\<view_component_name>/\<view_name>
-* /Views/\<controller_name>/Components/\<view_component_name>/\<view_name>
-* /Views/Shared/Components/\<view_component_name>/\<view_name>
+* /Pages/Components/`<view_component_name>`/`<view_name>`
+* /Views/`<controller_name>`/Components/`<view_component_name>`/`<view_name>`
+* /Views/Shared/Components/`<view_component_name>`/`<view_name>`
+<!-- Could you please confirm if the components between < and > needs to be left as it or maybe they should be -->
 
 The default view name for a view component is *Default*, which means your view file will typically be named *Default.cshtml*. You can specify a different view name when creating the view component result or when calling the `View` method.
 
-We recommend you name the view file *Default.cshtml* and use the *Views/Shared/Components/\<view_component_name>/\<view_name>* path. The `PriorityList` view component used in this sample uses *Views/Shared/Components/PriorityList/Default.cshtml* for the view component view.
+We recommend you name the view file *Default.cshtml* and use the *Views/Shared/Components/`<view_component_name>`/`<view_name>`* path. The `PriorityList` view component used in this sample uses *Views/Shared/Components/PriorityList/Default.cshtml* for the view component view.
 
 ## Invoking a view component
 


### PR DESCRIPTION
Hello, @rick-anderson,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description: Some of the "folder names" inside \<\> are not displaying well in localized pages, and also those terms are not blocked for localization.

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.