### PR TITLE
Enhance KnownProxies/Networks content

### DIFF
--- a/aspnetcore/host-and-deploy/linux-apache.md
+++ b/aspnetcore/host-and-deploy/linux-apache.md
@@ -91,7 +91,7 @@ app.UseFacebookAuthentication(new FacebookOptions()
 
 If no [ForwardedHeadersOptions](/dotnet/api/microsoft.aspnetcore.builder.forwardedheadersoptions) are specified to the middleware, the default headers to forward are `None`.
 
-Additional configuration might be required for apps hosted behind proxy servers and load balancers. For more information, see [Configure ASP.NET Core to work with proxy servers and load balancers](xref:host-and-deploy/proxy-load-balancer).
+If trusted proxies or networks within the organization handle requests between the Internet and the web server, add them to the list of <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownProxies*> or <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownNetworks*> with <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions>. For more information, see <xref:host-and-deploy/proxy-load-balancer>.
 
 ### Install Apache
 

--- a/aspnetcore/host-and-deploy/linux-apache.md
+++ b/aspnetcore/host-and-deploy/linux-apache.md
@@ -96,7 +96,6 @@ Only proxies running on localhost (127.0.0.1, [::1]) are trusted by default. If 
 ```csharp
 services.Configure<ForwardedHeadersOptions>(options =>
 {
-    options.ForwardLimit = 2;
     options.KnownProxies.Add(IPAddress.Parse("10.0.0.100"));
 });
 ```

--- a/aspnetcore/host-and-deploy/linux-apache.md
+++ b/aspnetcore/host-and-deploy/linux-apache.md
@@ -91,7 +91,17 @@ app.UseFacebookAuthentication(new FacebookOptions()
 
 If no [ForwardedHeadersOptions](/dotnet/api/microsoft.aspnetcore.builder.forwardedheadersoptions) are specified to the middleware, the default headers to forward are `None`.
 
-If trusted proxies or networks within the organization handle requests between the Internet and the web server, add them to the list of <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownProxies*> or <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownNetworks*> with <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions>. For more information, see <xref:host-and-deploy/proxy-load-balancer>.
+Only proxies running on localhost (127.0.0.1, [::1]) are trusted by default. If other trusted proxies or networks within the organization handle requests between the Internet and the web server, add them to the list of <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownProxies*> or <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownNetworks*> with <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions>. The following example adds a trusted proxy server at IP address 10.0.0.100 to the Forwarded Headers Middleware `KnownProxies` in `Startup.ConfigureServices`:
+
+```csharp
+services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardLimit = 2;
+    options.KnownProxies.Add(IPAddress.Parse("10.0.0.100"));
+});
+```
+
+For more information, see <xref:host-and-deploy/proxy-load-balancer>.
 
 ### Install Apache
 

--- a/aspnetcore/host-and-deploy/linux-nginx.md
+++ b/aspnetcore/host-and-deploy/linux-nginx.md
@@ -112,7 +112,7 @@ app.UseFacebookAuthentication(new FacebookOptions()
 
 If no [ForwardedHeadersOptions](/dotnet/api/microsoft.aspnetcore.builder.forwardedheadersoptions) are specified to the middleware, the default headers to forward are `None`.
 
-Additional configuration might be required for apps hosted behind proxy servers and load balancers. For more information, see [Configure ASP.NET Core to work with proxy servers and load balancers](xref:host-and-deploy/proxy-load-balancer).
+If trusted proxies or networks within the organization handle requests between the Internet and the web server, add them to the list of <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownProxies*> or <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownNetworks*> with <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions>. For more information, see <xref:host-and-deploy/proxy-load-balancer>.
 
 ### Install Nginx
 

--- a/aspnetcore/host-and-deploy/linux-nginx.md
+++ b/aspnetcore/host-and-deploy/linux-nginx.md
@@ -112,7 +112,17 @@ app.UseFacebookAuthentication(new FacebookOptions()
 
 If no [ForwardedHeadersOptions](/dotnet/api/microsoft.aspnetcore.builder.forwardedheadersoptions) are specified to the middleware, the default headers to forward are `None`.
 
-If trusted proxies or networks within the organization handle requests between the Internet and the web server, add them to the list of <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownProxies*> or <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownNetworks*> with <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions>. For more information, see <xref:host-and-deploy/proxy-load-balancer>.
+Only proxies running on localhost (127.0.0.1, [::1]) are trusted by default. If other trusted proxies or networks within the organization handle requests between the Internet and the web server, add them to the list of <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownProxies*> or <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownNetworks*> with <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersOptions>. The following example adds a trusted proxy server at IP address 10.0.0.100 to the Forwarded Headers Middleware `KnownProxies` in `Startup.ConfigureServices`:
+
+```csharp
+services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardLimit = 2;
+    options.KnownProxies.Add(IPAddress.Parse("10.0.0.100"));
+});
+```
+
+For more information, see <xref:host-and-deploy/proxy-load-balancer>.
 
 ### Install Nginx
 

--- a/aspnetcore/host-and-deploy/linux-nginx.md
+++ b/aspnetcore/host-and-deploy/linux-nginx.md
@@ -117,7 +117,6 @@ Only proxies running on localhost (127.0.0.1, [::1]) are trusted by default. If 
 ```csharp
 services.Configure<ForwardedHeadersOptions>(options =>
 {
-    options.ForwardLimit = 2;
     options.KnownProxies.Add(IPAddress.Parse("10.0.0.100"));
 });
 ```

--- a/aspnetcore/host-and-deploy/proxy-load-balancer.md
+++ b/aspnetcore/host-and-deploy/proxy-load-balancer.md
@@ -303,7 +303,7 @@ app.Use(async (context, next) =>
 });
 ```
 
-When processed, `X-Forwarded-{For|Proto|Host}` values are moved to `X-Original-{For|Proto|Host}`. If there are multiple values in a given header, note Forwarded Headers Middleware processes headers in reverse order from right to left. The default `ForwardLimit` is 1 (one), so only the rightmost value from the headers is processed unless the value of `ForwardLimit` is increased (an example follows).
+When processed, `X-Forwarded-{For|Proto|Host}` values are moved to `X-Original-{For|Proto|Host}`. If there are multiple values in a given header, note Forwarded Headers Middleware processes headers in reverse order from right to left. The default `ForwardLimit` is 1 (one), so only the rightmost value from the headers is processed unless the value of `ForwardLimit` is increased.
 
 The request's original remote IP must match an entry in the `KnownProxies` or `KnownNetworks` lists before forwarded headers are processed. This limits header spoofing by not accepting forwarders from untrusted proxies. When an unknown proxy is detected, logging indicates the address of the proxy:
 
@@ -316,7 +316,6 @@ In the preceding example if the server at 10.0.0.100 is a trusted proxy server, 
 ```csharp
 services.Configure<ForwardedHeadersOptions>(options =>
 {
-    options.ForwardLimit = 2;
     options.KnownProxies.Add(IPAddress.Parse("10.0.0.100"));
 });
 ```

--- a/aspnetcore/host-and-deploy/proxy-load-balancer.md
+++ b/aspnetcore/host-and-deploy/proxy-load-balancer.md
@@ -311,7 +311,7 @@ The request's original remote IP must match an entry in the `KnownProxies` or `K
 September 20th 2018, 15:49:44.168 Unknown proxy: 10.0.0.100:54321
 ```
 
-In the preceding example if the server at 10.0.0.100 is a trusted proxy server, add the IP address to `KnownProxies` (or add a trusted network to `KnownNetworks`) in `Startup.ConfigureServices`. For more information, see the [Forwarded Headers Middleware options](#forwarded-headers-middleware-options) section.
+In the preceding example if the server at 10.0.0.100 is a trusted proxy server, add the server's IP address to `KnownProxies` (or add a trusted network to `KnownNetworks`) in `Startup.ConfigureServices`. For more information, see the [Forwarded Headers Middleware options](#forwarded-headers-middleware-options) section.
 
 ```csharp
 services.Configure<ForwardedHeadersOptions>(options =>

--- a/aspnetcore/host-and-deploy/proxy-load-balancer.md
+++ b/aspnetcore/host-and-deploy/proxy-load-balancer.md
@@ -243,44 +243,85 @@ services.Configure<ForwardedHeadersOptions>(options =>
 
 ## Troubleshoot
 
-When headers aren't forwarded as expected, enable [logging](xref:fundamentals/logging/index). If the logs don't provide sufficient information to troubleshoot the problem, enumerate the request headers received by the server. The headers can be written to an app response using inline middleware:
+When headers aren't forwarded as expected, enable [logging](xref:fundamentals/logging/index). If the logs don't provide sufficient information to troubleshoot the problem, enumerate the request headers received by the server. Use inline middleware to write request headers to an app response or log the headers. Place either of the following code examples immediately after the call to <xref:Microsoft.AspNetCore.Builder.ForwardedHeadersExtensions.UseForwardedHeaders*> in `Startup.Configure`.
+
+To write the headers to the app's response, use the following terminal inline middleware:
 
 ```csharp
-public void Configure(IApplicationBuilder app, ILoggerFactory loggerfactory)
+app.Run(async (context) =>
 {
-    app.Run(async (context) =>
+    context.Response.ContentType = "text/plain";
+
+    // Request method, scheme, and path
+    await context.Response.WriteAsync(
+        $"Request Method: {context.Request.Method}{Environment.NewLine}");
+    await context.Response.WriteAsync(
+        $"Request Scheme: {context.Request.Scheme}{Environment.NewLine}");
+    await context.Response.WriteAsync(
+        $"Request Path: {context.Request.Path}{Environment.NewLine}");
+
+    // Headers
+    await context.Response.WriteAsync($"Request Headers:{Environment.NewLine}");
+
+    foreach (var header in context.Request.Headers)
     {
-        context.Response.ContentType = "text/plain";
+        await context.Response.WriteAsync($"{header.Key}: " +
+            $"{header.Value}{Environment.NewLine}");
+    }
 
-        // Request method, scheme, and path
-        await context.Response.WriteAsync(
-            $"Request Method: {context.Request.Method}{Environment.NewLine}");
-        await context.Response.WriteAsync(
-            $"Request Scheme: {context.Request.Scheme}{Environment.NewLine}");
-        await context.Response.WriteAsync(
-            $"Request Path: {context.Request.Path}{Environment.NewLine}");
+    await context.Response.WriteAsync(Environment.NewLine);
 
-        // Headers
-        await context.Response.WriteAsync($"Request Headers:{Environment.NewLine}");
-
-        foreach (var header in context.Request.Headers)
-        {
-            await context.Response.WriteAsync($"{header.Key}: " +
-                $"{header.Value}{Environment.NewLine}");
-        }
-
-        await context.Response.WriteAsync(Environment.NewLine);
-
-        // Connection: RemoteIp
-        await context.Response.WriteAsync(
-            $"Request RemoteIp: {context.Connection.RemoteIpAddress}");
-    });
-}
+    // Connection: RemoteIp
+    await context.Response.WriteAsync(
+        $"Request RemoteIp: {context.Connection.RemoteIpAddress}");
+});
 ```
 
-Ensure that the X-Forwarded-* headers are received by the server with the expected values. If there are multiple values in a given header, note Forwarded Headers Middleware processes headers in reverse order from right to left.
+To log the headers, use the following inline middleware (requests continue to process after the headers are logged):
 
-The request's original remote IP must match an entry in the `KnownProxies` or `KnownNetworks` lists before `X-Forwarded-For` is processed. This limits header spoofing by not accepting forwarders from untrusted proxies.
+```csharp
+var logger = _loggerFactory.CreateLogger<Startup>();
+
+app.Use(async (context, next) =>
+{
+    // Request method, scheme, and path
+    logger.LogDebug("Request Method: {METHOD}", context.Request.Method);
+    logger.LogDebug("Request Scheme: {SCHEME}", context.Request.Scheme);
+    logger.LogDebug("Request Path: {PATH}", context.Request.Path);
+
+    // Headers
+    foreach (var header in context.Request.Headers)
+    {
+        logger.LogDebug("Header: {KEY}: {VALUE}", header.Key, header.Value);
+    }
+
+    // Connection: RemoteIp
+    logger.LogDebug("Request RemoteIp: {REMOTE_IP_ADDRESS}", 
+        context.Connection.RemoteIpAddress);
+
+    await next();
+});
+```
+
+Ensure that the `X-Forwarded-{For|Proto|Host}` headers are received by the server with the expected values. If there are multiple values in a given header, note Forwarded Headers Middleware processes headers in reverse order from right to left.
+
+The request's original remote IP must match an entry in the `KnownProxies` or `KnownNetworks` lists before forwarded headers are processed. This limits header spoofing by not accepting forwarders from untrusted proxies. When an unknown proxy is detected, logging indicates the address of the proxy:
+
+```console
+September 20th 2018, 15:49:44.168 Unknown proxy: 10.0.0.100:54321
+```
+
+In the preceding example, the server at 10.0.0.100 is a trusted proxy server. Add the trusted proxy address to `KnownProxies` (or add a trusted network to `KnownNetworks`) in `Startup.ConfigureServices`. For more information, see the [Forwarded Headers Middleware options](#forwarded-headers-middleware-options) section.
+
+```csharp
+services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardLimit = 2;
+    options.KnownProxies.Add(IPAddress.Parse("10.0.0.100"));
+});
+```
+
+**Only allow trusted proxies and networks to forward headers. Otherwise, [IP spoofing](https://www.iplocation.net/ip-spoofing) attacks are possible.**
 
 ## Additional resources
 

--- a/aspnetcore/host-and-deploy/proxy-load-balancer.md
+++ b/aspnetcore/host-and-deploy/proxy-load-balancer.md
@@ -320,7 +320,8 @@ services.Configure<ForwardedHeadersOptions>(options =>
 });
 ```
 
-**Only allow trusted proxies and networks to forward headers. Otherwise, [IP spoofing](https://www.iplocation.net/ip-spoofing) attacks are possible.**
+> [!IMPORTANT]
+> Only allow trusted proxies and networks to forward headers. Otherwise, [IP spoofing](https://www.iplocation.net/ip-spoofing) attacks are possible.
 
 ## Additional resources
 

--- a/aspnetcore/host-and-deploy/proxy-load-balancer.md
+++ b/aspnetcore/host-and-deploy/proxy-load-balancer.md
@@ -277,7 +277,7 @@ app.Run(async (context) =>
 });
 ```
 
-To log the headers, use the following inline middleware (requests continue to process after the headers are logged):
+You can also write to logs instead of the response body by using the following inline middleware. This allows the site to function normally while debugging.
 
 ```csharp
 var logger = _loggerFactory.CreateLogger<Startup>();
@@ -303,7 +303,7 @@ app.Use(async (context, next) =>
 });
 ```
 
-Ensure that the `X-Forwarded-{For|Proto|Host}` headers are received by the server with the expected values. If there are multiple values in a given header, note Forwarded Headers Middleware processes headers in reverse order from right to left.
+When processed, `X-Forwarded-{For|Proto|Host}` values are moved to `X-Original-{For|Proto|Host}`. If there are multiple values in a given header, note Forwarded Headers Middleware processes headers in reverse order from right to left. The default `ForwardLimit` is 1 (one), so only the rightmost value from the headers is processed unless the value of `ForwardLimit` is increased (an example follows).
 
 The request's original remote IP must match an entry in the `KnownProxies` or `KnownNetworks` lists before forwarded headers are processed. This limits header spoofing by not accepting forwarders from untrusted proxies. When an unknown proxy is detected, logging indicates the address of the proxy:
 
@@ -311,7 +311,7 @@ The request's original remote IP must match an entry in the `KnownProxies` or `K
 September 20th 2018, 15:49:44.168 Unknown proxy: 10.0.0.100:54321
 ```
 
-In the preceding example, the server at 10.0.0.100 is a trusted proxy server. Add the trusted proxy address to `KnownProxies` (or add a trusted network to `KnownNetworks`) in `Startup.ConfigureServices`. For more information, see the [Forwarded Headers Middleware options](#forwarded-headers-middleware-options) section.
+In the preceding example if the server at 10.0.0.100 is a trusted proxy server, add the IP address to `KnownProxies` (or add a trusted network to `KnownNetworks`) in `Startup.ConfigureServices`. For more information, see the [Forwarded Headers Middleware options](#forwarded-headers-middleware-options) section.
 
 ```csharp
 services.Configure<ForwardedHeadersOptions>(options =>

--- a/aspnetcore/host-and-deploy/proxy-load-balancer.md
+++ b/aspnetcore/host-and-deploy/proxy-load-balancer.md
@@ -311,7 +311,7 @@ The request's original remote IP must match an entry in the `KnownProxies` or `K
 September 20th 2018, 15:49:44.168 Unknown proxy: 10.0.0.100:54321
 ```
 
-In the preceding example if the server at 10.0.0.100 is a trusted proxy server, add the server's IP address to `KnownProxies` (or add a trusted network to `KnownNetworks`) in `Startup.ConfigureServices`. For more information, see the [Forwarded Headers Middleware options](#forwarded-headers-middleware-options) section.
+In the preceding example, 10.0.0.100 is a proxy server. If the server is a trusted proxy, add the server's IP address to `KnownProxies` (or add a trusted network to `KnownNetworks`) in `Startup.ConfigureServices`. For more information, see the [Forwarded Headers Middleware options](#forwarded-headers-middleware-options) section.
 
 ```csharp
 services.Configure<ForwardedHeadersOptions>(options =>


### PR DESCRIPTION
Fixes #8632 

[Internal Review Topic (Nginx; Apache topic has the same text)](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/linux-nginx?view=aspnetcore-1.0&branch=pr-en-us-8634#use-a-reverse-proxy-server)
[Internal Review Topic (Forwarded Headers topic)](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-1.0&branch=pr-en-us-8634#troubleshoot)

* Enhances `KnownProxies`/`KnownNetworks` line in Nginx and Apache topics.
* Enhances troubleshooting content in Forwarded Headers topic.

cc: @michaelkrog @LindaLawton - You'll need to look at the diff to see the changes. The internal review topics are only available to MS folks.