### PR TITLE
Update instruction on picking up env var change

### DIFF
--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -239,7 +239,6 @@ To set the `ASPNETCORE_ENVIRONMENT` environment variable for an app running in a
 > [!IMPORTANT]
 > When hosting an app in IIS and adding or changing the `ASPNETCORE_ENVIRONMENT` environment variable, use any one of the following approaches to have the new value picked up by apps:
 >
-> * Restart an app's app pool.
 > * Execute `net stop was /y` followed by `net start w3svc` from a command prompt.
 > * Restart the server.
 


### PR DESCRIPTION
Fixes #8635 

Let me know if you'd prefer to see it just changed to something along the lines of ...

> Restart an app's app pool. This approach only works if the environment variable is set on the app pool. This approach doesn't work for a system-wide environment variable.

If we were to go that way, should it address the user env var case? (restart of app pool tied to a specific user account and the env var is set for that user)?

However, I removed the item on this PR because it's easier for a general audience to follow the simpler instructions for `net stop`/`net start` or restarting the server.