### PR TITLE
Fix snippets in NSwag tutorial

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-NSwag.md
+++ b/aspnetcore/tutorials/getting-started-with-NSwag.md
@@ -91,11 +91,11 @@ dotnet add TodoApi.csproj package NSwag.AspNetCore
 
 Import the following namespaces in the `Startup` class:
 
-[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs?name=snippet_ConfigureServices&highlight=8-8)]
+[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs?name=snippet_StartupConfigureImports)]
 
 In the `Startup.ConfigureServices` method, register the required Swagger services: 
 
-[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs?name=snippet_Configure&highlight=6-10)]
+[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs?name=snippet_ConfigureServices&highlight=8-8)]
 
 In the `Startup.Configure` method, enable the middleware for serving the generated Swagger specification and the Swagger UI v3:
 

--- a/aspnetcore/tutorials/getting-started-with-NSwag.md
+++ b/aspnetcore/tutorials/getting-started-with-NSwag.md
@@ -95,7 +95,7 @@ Import the following namespaces in the `Startup` class:
 
 In the `Startup.ConfigureServices` method, register the required Swagger services: 
 
-[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs?name=snippet_ConfigureServices&highlight=8-8)]
+[!code-csharp[](../tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/Startup.cs?name=snippet_ConfigureServices&highlight=8)]
 
 In the `Startup.Configure` method, enable the middleware for serving the generated Swagger specification and the Swagger UI v3:
 


### PR DESCRIPTION
Fixes the used snippets in the NSwag tutorial (currently the imports are missing and the configure snippet is used twice). 