### PR TITLE
fix access token sample in SignalR auth document

### DIFF
--- a/aspnetcore/signalr/authn-and-authz.md
+++ b/aspnetcore/signalr/authn-and-authz.md
@@ -39,7 +39,7 @@ In the .NET client, there is a similar [AccessTokenProvider](xref:signalr/config
 var connection = new HubConnectionBuilder()
     .WithUrl("https://example.com/myhub", options =>
     { 
-        options.AccessTokenProvider = () => _myAccessToken;
+        options.AccessTokenProvider = () => Task.FromResult(_myAccessToken);
     })
     .Build();
 ```


### PR DESCRIPTION
Fixes #8631 

The `AccessTokenFactory` expects a `Task<string>` so we need to wrap it in `Task.FromResult` in the sample (which is synchronous).