### PR TITLE
Adding Note about the implicit `AddHttpContextAccessor`

### DIFF
--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -89,7 +89,7 @@ public void ConfigureServices(IServiceCollection services)
 ```
 
 > [!NOTE]
-> `.AddIdenity()` is already providing the `.AddHttpContextAccessor()` registration. Sources: https://github.com/aspnet/Identity/blob/9b385180a9abcb264507efc23279f083bfc50520/src/Identity/IdentityServiceCollectionExtensions.cs#L79 . You can add the explicit registration without any problems related to the twice registration or performance. Discussion: https://github.com/aspnet/Hosting/issues/793#issuecomment-224831136
+> <xref:System.Security.Claims.ClaimsPrincipal.AddIdentity*> provides `AddHttpContextAccessor()` registration. Sources: https://github.com/aspnet/Identity/blob/9b385180a9abcb264507efc23279f083bfc50520/src/Identity/IdentityServiceCollectionExtensions.cs#L79. An additional explicit registration can be provided without generating an error or performance penalty. Discussion: https://github.com/aspnet/Hosting/issues/793#issuecomment-224831136
 
 ::: moniker-end
 

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -89,7 +89,7 @@ public void ConfigureServices(IServiceCollection services)
 ```
 
 > [!NOTE]
-> <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentity*> provides <xref:Microsoft.Extensions.DependencyInjection.HttpServiceCollectionExtensions.AddHttpContextAccessor*>` registration. An additional explicit registration can be added without generating an error or performance penalty.
+> <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentity*> provides <xref:Microsoft.Extensions.DependencyInjection.HttpServiceCollectionExtensions.AddHttpContextAccessor*> registration. An additional explicit registration can be added without generating an error or performance penalty.
 
 ::: moniker-end
 

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -89,7 +89,7 @@ public void ConfigureServices(IServiceCollection services)
 ```
 
 > [!NOTE]
-> <xref:System.Security.Claims.ClaimsPrincipal.AddIdentity*> provides `AddHttpContextAccessor()` registration. Sources: https://github.com/aspnet/Identity/blob/9b385180a9abcb264507efc23279f083bfc50520/src/Identity/IdentityServiceCollectionExtensions.cs#L79. An additional explicit registration can be provided without generating an error or performance penalty. Discussion: https://github.com/aspnet/Hosting/issues/793#issuecomment-224831136
+> <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentity*> provides `AddHttpContextAccessor` registration. An additional explicit registration can be provided without generating an error or performance penalty.
 
 ::: moniker-end
 

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -88,6 +88,9 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
+> [!NOTE]
+> `.AddIdenity()` is already providing the `.AddHttpContextAccessor()` registration. Sources: https://github.com/aspnet/Identity/blob/9b385180a9abcb264507efc23279f083bfc50520/src/Identity/IdentityServiceCollectionExtensions.cs#L79 . You can add the explicit registration without any problems related to the twice registration or performance. Discussion: https://github.com/aspnet/Hosting/issues/793#issuecomment-224831136
+
 ::: moniker-end
 
 ::: moniker range="<= aspnetcore-2.0"

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -89,7 +89,7 @@ public void ConfigureServices(IServiceCollection services)
 ```
 
 > [!NOTE]
-> <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentity*> provides <xref:Microsoft.Extensions.DependencyInjection.HttpServiceCollectionExtensions.AddHttpContextAccessor` registration. An additional explicit registration can be added without generating an error or performance penalty.
+> <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentity*> provides <xref:Microsoft.Extensions.DependencyInjection.HttpServiceCollectionExtensions.AddHttpContextAccessor*>` registration. An additional explicit registration can be added without generating an error or performance penalty.
 
 ::: moniker-end
 

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -89,7 +89,7 @@ public void ConfigureServices(IServiceCollection services)
 ```
 
 > [!NOTE]
-> <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentity*> provides `AddHttpContextAccessor` registration. An additional explicit registration can be provided without generating an error or performance penalty.
+> <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentity*> provides <xref:Microsoft.Extensions.DependencyInjection.HttpServiceCollectionExtensions.AddHttpContextAccessor` registration. An additional explicit registration can be added without generating an error or performance penalty.
 
 ::: moniker-end
 


### PR DESCRIPTION
`.AddIdenity()` is already providing the `.AddHttpContextAccessor()` registration. I have spent about 30 mins to understand how does it resolve the Accessor with no registration.