### PR TITLE
Update the 2.1 migration doc to instruct users to remove the version on Microsoft.AspNetCore.App

### DIFF
--- a/aspnetcore/migration/20_21.md
+++ b/aspnetcore/migration/20_21.md
@@ -61,7 +61,7 @@ The version specified by the package reference is the *minimum required* version
 
 Known issues for projects targeting the shared framework:
 
-* The .NET Core 2.1.300 SDK (first included in Visual Studio 15.6) set the implicit version of  `Microsoft.AspNetCore.App` to 2.1.0 which caused conflicts with Entity Framework Core 2.1.1. The recommended solution is to upgrade the .NET Core SDK to 2.1.301 or higher. For more information, see [Packages that share dependencies with Microsoft.AspNetCore.App cannot reference patch versions](https://github.com/aspnet/Universe/issues/1180).
+* The .NET Core 2.1.300 SDK (first included in Visual Studio 15.6) set the implicit version of  `Microsoft.AspNetCore.App` to 2.1.0 which caused conflicts with Entity Framework Core 2.1.1. The recommended solution is to upgrade the .NET Core SDK to 2.1.301 or later. For more information, see [Packages that share dependencies with Microsoft.AspNetCore.App cannot reference patch versions](https://github.com/aspnet/Universe/issues/1180).
 * All projects that must use `Microsoft.AspNetCore.All` or `Microsoft.AspNetCore.App` should add a package reference for the package in the project file, even if they contain a project reference to another project using `Microsoft.AspNetCore.All` or `Microsoft.AspNetCore.App`.
 
   Example:

--- a/aspnetcore/migration/20_21.md
+++ b/aspnetcore/migration/20_21.md
@@ -3,7 +3,7 @@ title: Migrate from ASP.NET Core 2.0 to 2.1
 author: rick-anderson
 description: This article covers the basics of migrating an ASP.NET Core 2.0 app to 2.1.
 ms.author: riande
-ms.date: 08/14/2018
+ms.date: 09/26/2018
 uid: migration/20_21
 ---
 # Migrate from ASP.NET Core 2.0 to 2.1
@@ -31,9 +31,9 @@ This article provides an overview on migration to ASP.NET Core 2.1. It doesn't c
 Update the project file:
 
 * Change the target framework to .NET Core 2.1 by updating the project file to `<TargetFramework>netcoreapp2.1</TargetFramework>`.
-* Replace the package reference for `Microsoft.AspNetCore.All` with a package reference for `Microsoft.AspNetCore.App`. You may need to add dependencies that were removed from `Microsoft.AspNetCore.All`. For more information, see <xref:fundamentals/metapackage#migrate> and <xref:fundamentals/metapackage-app>. For apps that target the .NET Framework:
-  * Add individual package references instead of a metapackage reference.
-  * Update each package reference to 2.1.
+* Replace the package reference for `Microsoft.AspNetCore.All` with a package reference for `Microsoft.AspNetCore.App`. You may need to add dependencies that were removed from `Microsoft.AspNetCore.All`. For more information, see <xref:fundamentals/metapackage#migrate> and <xref:fundamentals/metapackage-app>.
+* Remove the "Version" attribute on the package reference to `Microsoft.AspNetCore.App`. Projects which use `<Project Sdk="Microsoft.NET.Sdk.Web">` do not need to set the version. The version will be implied by the target framework and selected to best match the way ASP.NET Core 2.1 works. (See below for more information.)
+* For apps that target the .NET Framework, update each package reference to 2.1.
 * Remove references to **&lt;DotNetCliToolReference&gt;** elements for the following packages. These tools are bundled by default in the .NET Core CLI and don't need to be installed separately.
   * Microsoft.DotNet.Watcher.Tools (`dotnet watch`)
   * Microsoft.EntityFrameworkCore.Tools.DotNet (`dotnet ef`)
@@ -50,25 +50,25 @@ The following markup shows the template-generated 2.1 project file:
 
 [!code-xml[Main](20_21/sample/WebApp21.csproj)]
 
-## Rules for projects targeting the shared runtime
+## Rules for projects targeting the shared framework
 
-ASP.NET Core includes the following shared runtimes:
+ASP.NET Core 2.1 includes the following shared frameworks:
 
 * [Microsoft.AspNetCore.App](xref:fundamentals/metapackage-app)
 * [Microsoft.AspNetCore.All](xref:fundamentals/metapackage)
 
 The version specified by the package reference is the *minimum required* version. For example, a project referencing the 2.1.1 versions of these packages won't run on a machine with only the 2.1.0 runtime installed.
 
-Known issues for projects targeting the shared runtime:
+Known issues for projects targeting the shared framework:
 
-* Using `Microsoft.AspNetCore.App` 2.1.0 with Entity Framework Core 2.1.1 causes NuGet restore failures due to package conflicts. The recommended solution is to upgrade `Microsoft.AspNetCore.App` to 2.1.1. For more information, see [Packages that share dependencies with Microsoft.AspNetCore.App cannot reference patch versions](https://github.com/aspnet/Universe/issues/1180).
+* The .NET Core 2.1.300 SDK (first included in Visual Studio 15.6) set the implicit version of  `Microsoft.AspNetCore.App` to 2.1.0 which caused conflicts with Entity Framework Core 2.1.1. The recommended solution is to upgrade the .NET Core SDK to 2.1.301 or higher. For more information, see [Packages that share dependencies with Microsoft.AspNetCore.App cannot reference patch versions](https://github.com/aspnet/Universe/issues/1180).
 * All projects that must use `Microsoft.AspNetCore.All` or `Microsoft.AspNetCore.App` should add a package reference for the package in the project file, even if they contain a project reference to another project using `Microsoft.AspNetCore.All` or `Microsoft.AspNetCore.App`.
 
   Example:
 
   * `MyApp` has a package reference to `Microsoft.AspNetCore.App`.
   * `MyApp.Tests` has a project reference to `MyApp.csproj`.
-  
+
   Add a package reference for `Microsoft.AspNetCore.App` to `MyApp.Tests`. For more information, see [Integration testing is hard to set up and may break on shared framework servicing](https://github.com/aspnet/Home/issues/3156).
 
 ## Update to the 2.1 Docker images

--- a/aspnetcore/migration/20_21/sample/WebApp21.csproj
+++ b/aspnetcore/migration/20_21/sample/WebApp21.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Reverts https://github.com/aspnet/Docs/pull/7543

See https://github.com/aspnet/Home/issues/3292#issuecomment-424146341 for context