### PR TITLE
Added using for clarity

### DIFF
--- a/aspnetcore/tutorials/razor-pages/search.md
+++ b/aspnetcore/tutorials/razor-pages/search.md
@@ -20,6 +20,7 @@ Update the Index page's `OnGetAsync` method with the following code:
 The first line of the `OnGetAsync` method creates a [LINQ](/dotnet/csharp/programming-guide/concepts/linq/) query to select the movies:
 
 ```csharp
+// using System.Linq;
 var movies = from m in _context.Movie
              select m;
 ```


### PR DESCRIPTION
Visual Studio does not recognize the query without using the `Microsoft.Linq` namespace, which isn't specified in the document.

Interestingly, without it - you get an error saying `Could not find an implementation of the query pattern for source type 'DbSet<Movie>.' 'Select' not found.` You can't even have VS easily import the namespace using `Ctrl` + `.` or similar methods.
