### PR TITLE
Fixed hyperlink so user routed to the correct page to create a new issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc-issue.md
+++ b/.github/ISSUE_TEMPLATE/doc-issue.md
@@ -9,7 +9,7 @@ If the issue is:
 
 - A simple typo or similar correction, you can submit a PR. See [the contributor guide](https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents) for instructions.
 - A general support question, consider asking on a support forum site.
-- A site design concern, create an issue at [MicrosoftDocs/Feedback](https://github.com/MicrosoftDocs/Feedback/Issues/new/choose).
+- A site design concern, create an issue at [MicrosoftDocs/Feedback](https://github.com/MicrosoftDocs/Feedback/issues/new/choose).
 - A problem completing a tutorial, compare your code with the completed sample.
 - A duplicate of an open or closed issue, leave a comment on that issue.
 


### PR DESCRIPTION
Noticed that in the template for creating a Doc Issue, the link navigating you to the page to choose which type of issue applies is not valid and returns a 404 error instead. this is due to the fact that in the url itself, "Issues" should not be capitalized -- Changing to lowercase fixes the problem.

**Live:** https://github.com/MicrosoftDocs/Feedback/Issues/new/choose
**PR Change:** https://github.com/MicrosoftDocs/Feedback/issues/new/choose
