### PR TITLE
Corrected download link for Visual Studio

### DIFF
--- a/aspnetcore/includes/net-core-prereqs-windows.md
+++ b/aspnetcore/includes/net-core-prereqs-windows.md
@@ -1,4 +1,4 @@
-[Visual Studio 2017 version 15.7.3 or later](https://www.microsoft.com/net/download/windows) with the following workloads:
+[Visual Studio 2017 version 15.7.3 or later](https://visualstudio.microsoft.com/downloads/) with the following workloads:
 
 * **ASP.NET and web development**
 * **.NET Core cross-platform development**


### PR DESCRIPTION
The download link for Visual Studio only takes you to the .NET/.NET Core downloads page like the second link. This page has no links to download Visual Studio.

Corrected to take you to the Visual Studio download page just like this page [https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/docs/install/install-visual-studio.md] does.