### PR TITLE
Fix broken VS 2013 download links

### DIFF
--- a/aspnet/aspnet/overview/owin-and-katana/host-owin-in-an-azure-worker-role.md
+++ b/aspnet/aspnet/overview/owin-and-katana/host-owin-in-an-azure-worker-role.md
@@ -14,15 +14,15 @@ Host OWIN in an Azure Worker Role
 by [Mike Wasson](https://github.com/MikeWasson)
 
 > This tutorial shows how to self-host OWIN in a Microsoft Azure worker role.
-> 
+>
 > [Open Web Interface for .NET](http://owin.org/) (OWIN) defines an abstraction between .NET web servers and web applications. OWIN decouples the web application from the server, which makes OWIN ideal for self-hosting a web application in your own process, outside of IIS–for example, inside an Azure worker role.
-> 
+>
 > In this tutorial, you'll learn how to self-host an OWIN applications inside a Microsoft Azure worker role. To learn more about worker roles, see [Azure Execution Models](https://azure.microsoft.com/documentation/articles/fundamentals-application-models/#CloudServices).
-> 
+>
 > ## Software versions used in the tutorial
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - [Azure SDK for .NET 2.3](https://azure.microsoft.com/downloads/)
 > - [Microsoft.Owin.Selfhost 2.1.0](http://www.nuget.org/packages/Microsoft.Owin.SelfHost/2.1.0)
 

--- a/aspnet/aspnet/overview/owin-and-katana/owin-oauth-20-authorization-server.md
+++ b/aspnet/aspnet/overview/owin-and-katana/owin-oauth-20-authorization-server.md
@@ -14,21 +14,21 @@ OWIN OAuth 2.0 Authorization Server
 by [Hongye Sun](https://github.com/hongyes), [Praburaj Thiagarajan](https://github.com/Praburaj), [Rick Anderson]((https://twitter.com/RickAndMSFT))
 
 > This tutorial will guide you on how to implement an OAuth 2.0 Authorization Server using OWIN OAuth middleware. This is an advanced tutorial that only outlines the steps to create an OWIN OAuth 2.0 Authorization Server. This is not a step by step tutorial. [Download the sample code](https://code.msdn.microsoft.com/OWIN-OAuth-20-Authorization-ba2b8783/file/114932/1/AuthorizationServer.zip).
-> 
+>
 > > [!NOTE]
 > > This outline should not be intended to be used for creating a secure production app. This tutorial is intended to provide only an outline on how to implement an OAuth 2.0 Authorization Server using OWIN OAuth middleware.
-> 
-> 
+>
+>
 > ## Software versions
-> 
+>
 > | **Shown in the tutorial** | **Also works with** |
 > | --- | --- |
 > | Windows 8.1 | Windows 8, Windows 7 |
-> | [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads) | [Visual Studio 2013 Express for Desktop](https://www.microsoft.com/visualstudio/eng/2013-downloads#d-2013-express). Visual Studio 2012 with the latest update should work, but the tutorial has not been tested with it, and some menu selections and dialog boxes are different. |
+> | [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013) | [Visual Studio 2013 Express for Desktop](https://my.visualstudio.com/Downloads?q=visual%20studio%202013#d-2013-express). Visual Studio 2012 with the latest update should work, but the tutorial has not been tested with it, and some menu selections and dialog boxes are different. |
 > | .NET 4.5 |  |
-> 
+>
 > ## Questions and Comments
-> 
+>
 > If you have questions that are not directly related to the tutorial, you can post them at [Katana Project on GitHub](https://github.com/aspnet/AspNetKatana/). For questions and comments regarding the tutorial itself, see the comments section at the bottom of the page.
 
 
@@ -75,11 +75,11 @@ The `UseOAuthAuthorizationServer` extension method is to setup the authorization
 
 - `AuthorizeEndpointPath`: The request path where client applications will redirect the user-agent in order to obtain the users consent to issue a token or code. It must begin with a leading slash, for example, "`/Authorize`".
 - `TokenEndpointPath`: The request path client applications directly communicate to obtain the access token. It must begin with a leading slash, like "/Token". If the client is issued a [client\_secret](http://tools.ietf.org/html/rfc6749#appendix-A.2), it must be provided to this endpoint.
-- `ApplicationCanDisplayErrors`: Set to `true` if the web application wants to generate a custom error page for the client validation errors on `/Authorize` endpoint. This is only needed for cases where the browser is not redirected back to the client application, for example, when the `client_id` or `redirect_uri` are incorrect. The `/Authorize` endpoint should expect to see the "oauth.Error", "oauth.ErrorDescription", and "oauth.ErrorUri" properties are added to the OWIN environment. 
+- `ApplicationCanDisplayErrors`: Set to `true` if the web application wants to generate a custom error page for the client validation errors on `/Authorize` endpoint. This is only needed for cases where the browser is not redirected back to the client application, for example, when the `client_id` or `redirect_uri` are incorrect. The `/Authorize` endpoint should expect to see the "oauth.Error", "oauth.ErrorDescription", and "oauth.ErrorUri" properties are added to the OWIN environment.
 
     > [!NOTE]
     > If not true, the authorization server will return a default error page with the error details.
-- `AllowInsecureHttp`: True to allow authorize and token requests to arrive on HTTP URI addresses, and to allow incoming `redirect_uri` authorize request parameters to have HTTP URI addresses. 
+- `AllowInsecureHttp`: True to allow authorize and token requests to arrive on HTTP URI addresses, and to allow incoming `redirect_uri` authorize request parameters to have HTTP URI addresses.
 
     > [!WARNING]
     > Security - This is for development only.
@@ -101,9 +101,9 @@ The login page is shown below:
 
 ![](owin-oauth-20-authorization-server/_static/image1.png)
 
-Review the IETF's OAuth 2 [Authorization Code Grant](http://tools.ietf.org/html/rfc6749#section-4.1) section now. 
+Review the IETF's OAuth 2 [Authorization Code Grant](http://tools.ietf.org/html/rfc6749#section-4.1) section now.
 
-**Provider** (in the table below) is [OAuthAuthorizationServerOptions](https://msdn.microsoft.com/library/microsoft.owin.security.oauth.oauthauthorizationserveroptions(v=vs.111).aspx).Provider, which is of type `OAuthAuthorizationServerProvider`, which contains all OAuth server events. 
+**Provider** (in the table below) is [OAuthAuthorizationServerOptions](https://msdn.microsoft.com/library/microsoft.owin.security.oauth.oauthauthorizationserveroptions(v=vs.111).aspx).Provider, which is of type `OAuthAuthorizationServerProvider`, which contains all OAuth server events.
 
 | Flow steps from Authorization Code Grant section | Sample download performs these steps with: |
 | --- | --- |
@@ -128,13 +128,13 @@ The `Authorize` action will first check if the user has logged in to the authori
 
 ![](owin-oauth-20-authorization-server/_static/image2.png)
 
-If the **Grant** button is selected, the `Authorize` action will create a new "Bearer" identity and sign in with it. It will trigger the authorization server to generate a bearer token and send it back to the client with JSON payload. 
+If the **Grant** button is selected, the `Authorize` action will create a new "Bearer" identity and sign in with it. It will trigger the authorization server to generate a bearer token and send it back to the client with JSON payload.
 
 ### Implicit Grant
 
 Refer to the IETF's OAuth 2 [Implicit Grant](http://tools.ietf.org/html/rfc6749#section-4.2) section now.
 
- The [Implicit Grant](http://tools.ietf.org/html/rfc6749#section-4.2) flow shown in Figure 4 is the flow and mapping which the OWIN OAuth middleware follows.  
+ The [Implicit Grant](http://tools.ietf.org/html/rfc6749#section-4.2) flow shown in Figure 4 is the flow and mapping which the OWIN OAuth middleware follows.
 
 | Flow steps from Implicit Grant section | Sample download performs these steps with: |
 | --- | --- |
@@ -153,7 +153,7 @@ Since we already implemented the authorization endpoint (`OAuthController.Author
 
 Refer to the IETF's OAuth 2 [Resource Owner Password Credentials Grant](http://tools.ietf.org/html/rfc6749#section-4.3) section now.
 
- The [Resource Owner Password Credentials Grant](http://tools.ietf.org/html/rfc6749#section-4.3) flow shown in Figure 5 is the flow and mapping which the OWIN OAuth middleware follows.  
+ The [Resource Owner Password Credentials Grant](http://tools.ietf.org/html/rfc6749#section-4.3) flow shown in Figure 5 is the flow and mapping which the OWIN OAuth middleware follows.
 
 | Flow steps from Resource Owner Password Credentials Grant section | Sample download performs these steps with: |
 | --- | --- |
@@ -176,7 +176,7 @@ Here is the sample implementation for `Provider.GrantResourceOwnerCredentials`:
 
 Refer to the IETF's OAuth 2 [Client Credentials Grant](http://tools.ietf.org/html/rfc6749#section-4.4) section now.
 
- The [Client Credentials Grant](http://tools.ietf.org/html/rfc6749#section-4.4) flow shown in Figure 6 is the flow and mapping which the OWIN OAuth middleware follows.  
+ The [Client Credentials Grant](http://tools.ietf.org/html/rfc6749#section-4.4) flow shown in Figure 6 is the flow and mapping which the OWIN OAuth middleware follows.
 
 | Flow steps from Client Credentials Grant section | Sample download performs these steps with: |
 | --- | --- |
@@ -197,7 +197,7 @@ Here is the sample implementation for `Provider.GrantClientCredentials`:
 
 Refer to the IETF's OAuth 2 [Refresh Token](http://tools.ietf.org/html/rfc6749#section-1.5) section now.
 
- The [Refresh Token](http://tools.ietf.org/html/rfc6749#section-1.5) flow shown in Figure 2 is the flow and mapping which the OWIN OAuth middleware follows.  
+ The [Refresh Token](http://tools.ietf.org/html/rfc6749#section-1.5) flow shown in Figure 2 is the flow and mapping which the OWIN OAuth middleware follows.
 
 | Flow steps from Client Credentials Grant section | Sample download performs these steps with: |
 | --- | --- |
@@ -206,7 +206,7 @@ Refer to the IETF's OAuth 2 [Refresh Token](http://tools.ietf.org/html/rfc6749#s
 |  |  |
 | (H) The authorization server authenticates the client and validates the refresh token, and if valid, issues a new access token (and, optionally, a new refresh token). |  |
 
-Here is the sample implementation for `Provider.GrantRefreshToken`: 
+Here is the sample implementation for `Provider.GrantRefreshToken`:
 
 [!code-csharp[Main](owin-oauth-20-authorization-server/samples/sample9.cs)]
 

--- a/aspnet/aspnet/overview/owin-and-katana/owin-startup-class-detection.md
+++ b/aspnet/aspnet/overview/owin-and-katana/owin-startup-class-detection.md
@@ -14,31 +14,31 @@ OWIN Startup Class Detection
 by [Praburaj Thiagarajan](https://github.com/Praburaj), [Rick Anderson]((https://twitter.com/RickAndMSFT))
 
 > This tutorial shows how to configure which OWIN startup class is loaded. For more information on OWIN, see [An Overview of Project Katana](an-overview-of-project-katana.md). This tutorial was written by Rick Anderson ( [@RickAndMSFT](https://twitter.com/#!/RickAndMSFT) ), Praburaj Thiagarajan, and Howard Dierking ( [@howard\_dierking](https://twitter.com/howard_dierking) ).
-> 
+>
 > ## Prerequisites
-> 
-> [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+> [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 
 
 ## OWIN Startup Class Detection
 
- Every OWIN Application has a startup class where you specify components for the application pipeline. There are different ways you can connect your startup class with the runtime, depending on the hosting model you choose (OwinHost, IIS, and IIS-Express). The startup class shown in this tutorial can be used in every hosting application. You connect the startup class with the hosting runtime using one of the these approaches:  
+ Every OWIN Application has a startup class where you specify components for the application pipeline. There are different ways you can connect your startup class with the runtime, depending on the hosting model you choose (OwinHost, IIS, and IIS-Express). The startup class shown in this tutorial can be used in every hosting application. You connect the startup class with the hosting runtime using one of the these approaches:
 
 1. **Naming Convention**: Katana looks for a class named `Startup` in namespace matching the assembly name or the global namespace.
-2. **OwinStartup Attribute**: This is the approach most developers will take to specify the startup class. The following attribute will set the startup class to the `TestStartup` class in the `StartupDemo` namespace. 
+2. **OwinStartup Attribute**: This is the approach most developers will take to specify the startup class. The following attribute will set the startup class to the `TestStartup` class in the `StartupDemo` namespace.
 
     [!code-csharp[Main](owin-startup-class-detection/samples/sample1.cs)]
 
    The `OwinStartup` attribute overrides the naming convention. You can also specify a friendly name with this attribute, however, using a friendly name requires you to also use the `appSetting` element in the configuration file.
-3. **The appSetting element in the Configuration file**: The `appSetting` element overrides the `OwinStartup` attribute and naming convention. You can have multiple startup classes (each using an `OwinStartup` attribute) and configure which startup class will be loaded in a configuration file using markup similar to the following:  
+3. **The appSetting element in the Configuration file**: The `appSetting` element overrides the `OwinStartup` attribute and naming convention. You can have multiple startup classes (each using an `OwinStartup` attribute) and configure which startup class will be loaded in a configuration file using markup similar to the following:
 
     [!code-xml[Main](owin-startup-class-detection/samples/sample2.xml)]
 
-   The following key, which explicitly specifies the startup class and assembly can also be used: 
+   The following key, which explicitly specifies the startup class and assembly can also be used:
 
     [!code-xml[Main](owin-startup-class-detection/samples/sample3.xml)]
 
-   The following XML in the configuration file specifies a friendly startup class name of `ProductionConfiguration`.  
+   The following XML in the configuration file specifies a friendly startup class name of `ProductionConfiguration`.
 
     [!code-xml[Main](owin-startup-class-detection/samples/sample4.xml)]
 
@@ -51,33 +51,33 @@ by [Praburaj Thiagarajan](https://github.com/Praburaj), [Rick Anderson]((https:/
 
 ## Create an ASP.NET Web App using OWIN Startup
 
-1. Create an empty Asp.Net web application and name it **StartupDemo**. - Install `Microsoft.Owin.Host.SystemWeb` using the NuGet package manager. From the **Tools** menu, select **Library Package Manager**, and then **Package Manager Console**. Enter the following command:  
+1. Create an empty Asp.Net web application and name it **StartupDemo**. - Install `Microsoft.Owin.Host.SystemWeb` using the NuGet package manager. From the **Tools** menu, select **Library Package Manager**, and then **Package Manager Console**. Enter the following command:
 
     [!code-powershell[Main](owin-startup-class-detection/samples/sample7.ps1)]
-2. Add an OWIN startup class. In Visual Studio 2013 right click the project and select **Add Class**.- In the **Add New Item** dialog box, enter *OWIN* in the search field, and change the name to Startup.cs, and then click **Add**.  
-  
-     ![](owin-startup-class-detection/_static/image1.png)   
-  
-   The next time you want to add an *Owin Startup class*, it will be in available from the **Add** menu.  
-   
-     ![](owin-startup-class-detection/_static/image2.png)  
-  
-   Alternatively, you can right click the project and select **Add**, then select **New Item**, and then select the **Owin Startup class**.  
-  
-     ![](owin-startup-class-detection/_static/image3.png)  
-  
-- Replace the generated code in the *Startup.cs* file with the following:  
+2. Add an OWIN startup class. In Visual Studio 2013 right click the project and select **Add Class**.- In the **Add New Item** dialog box, enter *OWIN* in the search field, and change the name to Startup.cs, and then click **Add**.
+
+     ![](owin-startup-class-detection/_static/image1.png)
+
+   The next time you want to add an *Owin Startup class*, it will be in available from the **Add** menu.
+
+     ![](owin-startup-class-detection/_static/image2.png)
+
+   Alternatively, you can right click the project and select **Add**, then select **New Item**, and then select the **Owin Startup class**.
+
+     ![](owin-startup-class-detection/_static/image3.png)
+
+- Replace the generated code in the *Startup.cs* file with the following:
 
     [!code-csharp[Main](owin-startup-class-detection/samples/sample8.cs?highlight=5,7,15-28,31-34)]
-  
+
   The `app.Use` lambda expression is used to register the specified middleware component to the OWIN pipeline. In this case we are setting up logging of incoming requests before responding to the incoming request. The `next` parameter is the delegate ( [Func](https://msdn.microsoft.com/library/bb534960(v=vs.100).aspx) &lt; [Task](https://msdn.microsoft.com/library/dd321424(v=vs.100).aspx) &gt; ) to the next component in the pipeline. The `app.Run` lambda expression hooks up the pipeline to incoming requests and provides the response mechanism.
 	 > [!NOTE]
-     > In the code above we have commented out the `OwinStartup` attribute and we're relying on the convention of running the class named `Startup` .- Press ***F5*** to run the application. Hit refresh a few times.  
-  
-    ![](owin-startup-class-detection/_static/image4.png)  
-  Note: The number shown in the images in this tutorial will not match the number you see. The millisecond string is used to show a new response when you refresh the page.  
-  You can see the trace information in the **Output** window.  
-  
+     > In the code above we have commented out the `OwinStartup` attribute and we're relying on the convention of running the class named `Startup` .- Press ***F5*** to run the application. Hit refresh a few times.
+
+    ![](owin-startup-class-detection/_static/image4.png)
+  Note: The number shown in the images in this tutorial will not match the number you see. The millisecond string is used to show a new response when you refresh the page.
+  You can see the trace information in the **Output** window.
+
     ![](owin-startup-class-detection/_static/image5.png)
 
 ## Add More Startup Classes
@@ -88,11 +88,11 @@ In this section we'll add another Startup class. You can add multiple OWIN start
 2. Replace the generated code with the following:
 
     [!code-csharp[Main](owin-startup-class-detection/samples/sample9.cs?highlight=14-18)]
-3. Press Control F5 to run the app. The `OwinStartup` attribute specifies the production startup class is run.  
-  
+3. Press Control F5 to run the app. The `OwinStartup` attribute specifies the production startup class is run.
+
     ![](owin-startup-class-detection/_static/image6.png)
 4. Create another OWIN Startup class and name it `TestStartup`.
-5. Replace the generated code with the following:  
+5. Replace the generated code with the following:
 
     [!code-csharp[Main](owin-startup-class-detection/samples/sample10.cs?highlight=6,14-18)]
 
@@ -100,8 +100,8 @@ In this section we'll add another Startup class. You can add multiple OWIN start
 6. Open the *web.config* file and add the OWIN App startup key which specifies the friendly name of the Startup class:
 
     [!code-xml[Main](owin-startup-class-detection/samples/sample11.xml?highlight=3-5)]
-7. Press Control F5 to run the app. The app settings element takes precedent, and the test configuration is run.  
-  
+7. Press Control F5 to run the app. The app settings element takes precedent, and the test configuration is run.
+
     ![](owin-startup-class-detection/_static/image7.png)
 8. Remove the *friendly* name from the `OwinStartup` attribute in the `TestStartup` class.
 
@@ -109,11 +109,11 @@ In this section we'll add another Startup class. You can add multiple OWIN start
 9. Replace the OWIN App startup key in the *web.config* file with the following:
 
     [!code-xml[Main](owin-startup-class-detection/samples/sample13.xml)]
-10. Revert the `OwinStartup` attribute in each class to the default attribute code generated by Visual Studio:  
+10. Revert the `OwinStartup` attribute in each class to the default attribute code generated by Visual Studio:
 
     [!code-csharp[Main](owin-startup-class-detection/samples/sample14.cs)]
 
-    Each of the OWIN App startup keys below will cause the production class to run. 
+    Each of the OWIN App startup keys below will cause the production class to run.
 
     [!code-xml[Main](owin-startup-class-detection/samples/sample15.xml)]
 
@@ -123,36 +123,36 @@ In this section we'll add another Startup class. You can add multiple OWIN start
 
 ## Using Owinhost.exe
 
-1. Replace the Web.config file with the following markup:  
+1. Replace the Web.config file with the following markup:
 
     [!code-xml[Main](owin-startup-class-detection/samples/sample17.xml?highlight=3-6)]
 
    The last key wins, so in this case `TestStartup` is specified.
-2. Install Owinhost from the PMC: 
+2. Install Owinhost from the PMC:
 
     [!code-console[Main](owin-startup-class-detection/samples/sample18.cmd)]
-3. Navigate to the application folder (the folder containing the *Web.config* file) and in a command prompt and type: 
+3. Navigate to the application folder (the folder containing the *Web.config* file) and in a command prompt and type:
 
     [!code-console[Main](owin-startup-class-detection/samples/sample19.cmd)]
 
-   The command window will show: 
+   The command window will show:
 
     [!code-console[Main](owin-startup-class-detection/samples/sample20.cmd)]
-4. Launch a browser with the URL `http://localhost:5000/`.  
-  
-    ![](owin-startup-class-detection/_static/image8.png)  
-  
+4. Launch a browser with the URL `http://localhost:5000/`.
+
+    ![](owin-startup-class-detection/_static/image8.png)
+
    OwinHost honored the startup conventions listed above.
 5. In the command window, press Enter to exit OwinHost.
 6. In the `ProductionStartup` class, add the following OwinStartup attribute which specifies a friendly name of *ProductionConfiguration*.
 
     [!code-csharp[Main](owin-startup-class-detection/samples/sample21.cs)]
-7. In the command prompt and type: 
+7. In the command prompt and type:
 
     [!code-console[Main](owin-startup-class-detection/samples/sample22.cmd)]
 
-   The Production startup class is loaded.  
-    ![](owin-startup-class-detection/_static/image9.png)  
+   The Production startup class is loaded.
+    ![](owin-startup-class-detection/_static/image9.png)
    Our application has multiple startup classes, and in this example we have deferred which startup class to load until runtime.
 8. Test the following runtime startup options:
 

--- a/aspnet/identity/overview/getting-started/developing-aspnet-apps-with-windows-azure-active-directory.md
+++ b/aspnet/identity/overview/getting-started/developing-aspnet-apps-with-windows-azure-active-directory.md
@@ -19,7 +19,7 @@ This tutorial will show you how to create an ASP.NET application that is configu
 
 ## Prerequisites
 
-1. [Visual Studio Express 2013 for Web](https://www.microsoft.com/visualstudio/eng/2013-downloads#d-2013-express) or [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads).
+1. [Visual Studio Express 2013 for Web](https://my.visualstudio.com/Downloads?q=visual%20studio%202013#d-2013-express) or [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013).
 2. [Visual Studio 2013 Update 4](https://www.microsoft.com/download/details.aspx?id=44921) - Update 3 or higher is required.
 3. An Azure account. [Click here](https://azure.microsoft.com/pricing/free-trial/) for a free trial if you do not already have an account.
 
@@ -27,21 +27,21 @@ This tutorial will show you how to create an ASP.NET application that is configu
 
 1. Sign in to the [Azure Management Portal](https://manage.windowsazure.com/).
 2. All Azure accounts contain a **Default Directory** -- click on it, then click the **Users** tab at the top of the page (see image below).
-3. Click Add User.  
+3. Click Add User.
     ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image1.png)
 4. Create a new user with the **Global Administrator** role. Click **Users** from the top menu, and then click the **Add User** button on the command bar.
-5. In the **Add User** dialog, enter a name for the new user and then click the right arrow.  
-  
+5. In the **Add User** dialog, enter a name for the new user and then click the right arrow.
+
     ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image2.png)
-6. Enter the user name and set the role to **Global Administrator**. Global administrators require an alternate email address for password recovery purposes. After you're finished, click the right arrow.  
-  
+6. Enter the user name and set the role to **Global Administrator**. Global administrators require an alternate email address for password recovery purposes. After you're finished, click the right arrow.
+
     ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image3.png)
-7. On the next page of the dialog, click **Create**. A temporary password will be created for the new user and displayed in the dialog.   
-  
-    ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image4.png)  
-  
-   Save the password, you will be required to change the password after the first log in. The following image shows the new admin account. You must use the Azure Active Directory to log into your app, not the Microsoft account also shown on this page.  
-  
+7. On the next page of the dialog, click **Create**. A temporary password will be created for the new user and displayed in the dialog.
+
+    ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image4.png)
+
+   Save the password, you will be required to change the password after the first log in. The following image shows the new admin account. You must use the Azure Active Directory to log into your app, not the Microsoft account also shown on this page.
+
     ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image5.png)
 
 ## Create an ASP.NET Application
@@ -49,25 +49,25 @@ This tutorial will show you how to create an ASP.NET application that is configu
 The following steps use [Visual Studio Express 2013 for Web](https://www.microsoft.com/download/details.aspx?id=40747), and requires [Visual Studio 2013 Update 3](https://www.microsoft.com/download/details.aspx?id=43721).
 
 1. In Visual Studio, click **File** and then **New Project**. On the **New Project** dialog, select the Visual C# Web project from the left menu and click **OK**. You may also want to uncheck the **Add Application Insights to Project** if you don't want the functionality for your application.
-2. In the **New ASP.NET Project** dialog, select **MVC**, and then click **Change Authentication**.   
-  
+2. In the **New ASP.NET Project** dialog, select **MVC**, and then click **Change Authentication**.
+
     ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image6.png)
-3. On the **Change Authentication** dialog, select **Organizational Accounts**. These options can be used to automatically register your application with Azure AD as well as automatically configure your application to integrate with Azure AD. You don't have to use the **Change Authentication** dialog to register and configure your application, but it makes it much easier. If you are using Visual Studio 2012 for example, you can still manually register the application in the Azure Management Portal and update its configuration to integrate with Azure AD.  
-   In the drop-down menus, select **Cloud - Single Organization** and **Single Sign On, Read directory data**. Enter the domain for your Azure AD directory, for example (in the images below) *aricka0yahoo.onmicrosoft.com*, and then click **OK**. You can get the domain name from the Domains tab for the Default Directory on the azure portal (see the next image down).   
-  
-    ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image7.png)  
-  
-   The following image shows the domain name from the Azure portal.  
-  
-    ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image8.png)  
+3. On the **Change Authentication** dialog, select **Organizational Accounts**. These options can be used to automatically register your application with Azure AD as well as automatically configure your application to integrate with Azure AD. You don't have to use the **Change Authentication** dialog to register and configure your application, but it makes it much easier. If you are using Visual Studio 2012 for example, you can still manually register the application in the Azure Management Portal and update its configuration to integrate with Azure AD.
+   In the drop-down menus, select **Cloud - Single Organization** and **Single Sign On, Read directory data**. Enter the domain for your Azure AD directory, for example (in the images below) *aricka0yahoo.onmicrosoft.com*, and then click **OK**. You can get the domain name from the Domains tab for the Default Directory on the azure portal (see the next image down).
+
+    ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image7.png)
+
+   The following image shows the domain name from the Azure portal.
+
+    ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image8.png)
 
     > [!NOTE]
     > You can optionally configure the Application ID URI that will be registered in Azure AD by clicking **More Options**. The App ID URI is the unique identifier for an application, which is registered in Azure AD and used by the application to identify itself when communicating with Azure AD. For more information about the App ID URI and other properties of registered applications, see [this topic](https://msdn.microsoft.com/library/azure/dn499820.aspx#BKMK_Registering). By clicking the checkbox below the App ID URI field, you can also choose to overwrite an existing registration in Azure AD that uses the same App ID URI.
-4. After clicking **OK**, a sign-in dialog will appear, and you'll need to sign in using a Global Administrator account (not the Microsoft account associated with your subscription). If you created a new Administrator account earlier, you'll be required to change the password and then sign in again using the new password.   
-  
+4. After clicking **OK**, a sign-in dialog will appear, and you'll need to sign in using a Global Administrator account (not the Microsoft account associated with your subscription). If you created a new Administrator account earlier, you'll be required to change the password and then sign in again using the new password.
+
     ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image9.png)
-5. After you've successfully authenticated, the **New ASP.NET Project** dialog will show your authentication choice (**Organizational** ) and the directory where the new application will be registered (*aricka0yahoo.onmicrosoft.com* in the image below). Below this information, select the checkbox labeled **Host in the cloud**. If this checkbox is selected, the project will be provisioned as an Azure web app and will be enabled for easy publishing later. Click **OK**.   
-  
+5. After you've successfully authenticated, the **New ASP.NET Project** dialog will show your authentication choice (**Organizational** ) and the directory where the new application will be registered (*aricka0yahoo.onmicrosoft.com* in the image below). Below this information, select the checkbox labeled **Host in the cloud**. If this checkbox is selected, the project will be provisioned as an Azure web app and will be enabled for easy publishing later. Click **OK**.
+
     ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image10.png)
 6. The **Configure Azure Website** dialog will appear, using an auto-generated site name and region. Also note the account you're currently signed into in the dialog. You want to make sure that this account is the one that your Azure subscription is attached to, typically a Microsoft account.
 
@@ -75,27 +75,27 @@ The following steps use [Visual Studio Express 2013 for Web](https://www.microso
     > This project requires a database. You need to select one of your existing databases, or create a new one. A database is required because the project already uses a local database file to store a small amount of authentication configuration data. When you deploy the application to an Azure Website, this database isn't packaged with the deployment, so you need to choose one that's accessible in the cloud. Click **OK**.
 
     ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image11.png)
-7. The project will be created, and your authentication options and web app options will be automatically configured with the project. Once this process has completed, run the project locally by pressing **^F5**. You will be required to sign in using your organizational account. Provide the username and password for the account you created earlier and click **Sign in**.   
-  
+7. The project will be created, and your authentication options and web app options will be automatically configured with the project. Once this process has completed, run the project locally by pressing **^F5**. You will be required to sign in using your organizational account. Provide the username and password for the account you created earlier and click **Sign in**.
+
     ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image12.png)
-8. After successful sign in, the ASP.NET site will show that you've authenticated by displaying the username in the top right corner of the page.  
-  
-    ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image13.png)  
-  
-   If you get the error:  
-   Value cannot be null or empty. Parameter name: linkText   
-    ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image14.png)  
-  
+8. After successful sign in, the ASP.NET site will show that you've authenticated by displaying the username in the top right corner of the page.
+
+    ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image13.png)
+
+   If you get the error:
+   Value cannot be null or empty. Parameter name: linkText
+    ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image14.png)
+
    see the [debug](#dbg) section at the end of the tutorial.
 
 ## Basics of the Graph API
 
 [The Graph API](https://msdn.microsoft.com/library/azure/hh974476.aspx) is the programmatic interface used to perform CRUD and other operations on objects in your Azure AD directory. If you select an Organizational Account option for authentication when creating a new project in Visual Studio 2013, your application will already be configured to call the Graph API. This section briefly shows you how the Graph API works.
 
-1. In your running application, click on the name of the signed-in user at the top right of the page. This will take you to the User Profile page, which is an action on the Home Controller. You'll notice that the table contains user information about the administrator account you created earlier. This information is stored in your directory, and the Graph API is called to retrieve this information when the page loads.   
-  
+1. In your running application, click on the name of the signed-in user at the top right of the page. This will take you to the User Profile page, which is an action on the Home Controller. You'll notice that the table contains user information about the administrator account you created earlier. This information is stored in your directory, and the Graph API is called to retrieve this information when the page loads.
+
     ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image15.png)
-2. Go back to Visual Studio and expand the **Controllers** folder and then open the **HomeController.cs** file. You'll see a **UserProfile()** action that contains code to retrieve a token and then call the Graph API. This code is duplicated below: 
+2. Go back to Visual Studio and expand the **Controllers** folder and then open the **HomeController.cs** file. You'll see a **UserProfile()** action that contains code to retrieve a token and then call the Graph API. This code is duplicated below:
 
     [!code-csharp[Main](developing-aspnet-apps-with-windows-azure-active-directory/samples/sample1.cs?highlight=22)]
 
@@ -109,24 +109,24 @@ The following steps use [Visual Studio Express 2013 for Web](https://www.microso
 
 The following steps will show you how to deploy the application to Azure. In the earlier steps, you connected your new project with a web app on Azure, so it's ready to be published in just a few steps.
 
-1. In Visual Studio, right-click on the project and select **Publish**. The **Publish Web** dialog will appear with each setting already configured. Click on the **Next** button to go to the **Settings** page. You may be prompted to authenticate; make sure you authenticate using your Azure subscription account (typically a Microsoft account) and not the organizational account you created earlier.  
-  
+1. In Visual Studio, right-click on the project and select **Publish**. The **Publish Web** dialog will appear with each setting already configured. Click on the **Next** button to go to the **Settings** page. You may be prompted to authenticate; make sure you authenticate using your Azure subscription account (typically a Microsoft account) and not the organizational account you created earlier.
+
     ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image16.png)
-2. Check the **Enable Organizational Authentication** option. In the **Domain** field, enter the domain for your directory. From the **Access Level** drop-down, select **Single Sign On, Read directory data**. You'll notice that the previous database you used is already populated in the **Databases** section. Click **Publish**.  
-  
+2. Check the **Enable Organizational Authentication** option. In the **Domain** field, enter the domain for your directory. From the **Access Level** drop-down, select **Single Sign On, Read directory data**. You'll notice that the previous database you used is already populated in the **Databases** section. Click **Publish**.
+
     ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image17.png)
-3. Visual Studio will begin deploying your website, and then a new browser window will appear. You may be prompted to authenticate to your directory once again. Once you've authenticated, you'll be redirected to your newly published website on Azure.  
-  
+3. Visual Studio will begin deploying your website, and then a new browser window will appear. You may be prompted to authenticate to your directory once again. Once you've authenticated, you'll be redirected to your newly published website on Azure.
+
     ![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image18.png)
 
 <a id="dbg"></a>
 ## Debugging the app
 
-If you get the following error:   
- Value cannot be null or empty. Parameter name: linkText   
-   
-![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image19.png)  
-  
+If you get the following error:
+ Value cannot be null or empty. Parameter name: linkText
+
+![](developing-aspnet-apps-with-windows-azure-active-directory/_static/image19.png)
+
 
 Replace the code in the *Views\Shared\\_LoginPartial.cshtml* file with the following:
 

--- a/aspnet/mvc/overview/older-versions-1/getting-started-with-mvc/getting-started-with-mvc-part1.md
+++ b/aspnet/mvc/overview/older-versions-1/getting-started-with-mvc/getting-started-with-mvc-part1.md
@@ -14,9 +14,9 @@ Intro to ASP.NET MVC
 by [Scott Hanselman](https://github.com/shanselman)
 
 > > [!NOTE]
-> > An updated version if this tutorial is available [here](../../getting-started/introduction/getting-started.md) using [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads). The new tutorial uses ASP.NET MVC 5, which provides many improvements over this tutorial.
-> 
-> 
+> > An updated version if this tutorial is available [here](../../getting-started/introduction/getting-started.md) using [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013). The new tutorial uses ASP.NET MVC 5, which provides many improvements over this tutorial.
+>
+>
 > This is a beginner tutorial that introduces the basics of ASP.NET MVC. You'll create a simple web application that reads and writes from a database. Visit the [ASP.NET MVC learning center](../../../index.md) to find other ASP.NET MVC tutorials and samples.
 
 

--- a/aspnet/mvc/overview/older-versions-1/getting-started-with-mvc/getting-started-with-mvc-part2.md
+++ b/aspnet/mvc/overview/older-versions-1/getting-started-with-mvc/getting-started-with-mvc-part2.md
@@ -14,9 +14,9 @@ Adding a Controller
 by [Scott Hanselman](https://github.com/shanselman)
 
 > > [!NOTE]
-> > An updated version if this tutorial is available [here](../../getting-started/introduction/getting-started.md) using [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads). The new tutorial uses ASP.NET MVC 5, which provides many improvements over this tutorial.
-> 
-> 
+> > An updated version if this tutorial is available [here](../../getting-started/introduction/getting-started.md) using [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013). The new tutorial uses ASP.NET MVC 5, which provides many improvements over this tutorial.
+>
+>
 > This is a beginner tutorial that introduces the basics of ASP.NET MVC. You'll create a simple web application that reads and writes from a database. Visit the [ASP.NET MVC learning center](../../../index.md) to find other ASP.NET MVC tutorials and samples.
 
 

--- a/aspnet/mvc/overview/older-versions/getting-started-with-aspnet-mvc4/intro-to-aspnet-mvc-4.md
+++ b/aspnet/mvc/overview/older-versions/getting-started-with-aspnet-mvc4/intro-to-aspnet-mvc-4.md
@@ -13,28 +13,28 @@ Intro to ASP.NET MVC 4
 ====================
 by [Rick Anderson]((https://twitter.com/RickAndMSFT))
 
-> An updated version if this tutorial is available [here](../../getting-started/introduction/getting-started.md) using [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads). The new tutorial uses ASP.NET MVC 5, which provides many improvements over this tutorial.
-> 
+> An updated version if this tutorial is available [here](../../getting-started/introduction/getting-started.md) using [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013). The new tutorial uses ASP.NET MVC 5, which provides many improvements over this tutorial.
+>
 > This tutorial will teach you the basics of building an ASP.NET MVC 4 Web application using Microsoft [Visual Studio Express 2012](https://www.microsoft.com/visualstudio/11/products/express) or Visual Web Developer 2010 Express Service Pack 1. Visual Studio 2012 is recommended, you won't need to install anything to complete the tutorial. If you are using Visual Studio 2010 you must install the components below. You can install all of them by clicking the following links:
-> 
+>
 > - [Visual Studio Web Developer Express SP1 prerequisites](https://www.microsoft.com/web/gallery/install.aspx?appid=VWD2010SP1Pack)
 > - [WPI installer for ASP.NET MVC 4](https://go.microsoft.com/fwlink/?LinkId=243392)
 > - [LocalDB](https://www.microsoft.com/web/gallery/install.aspx?appid=SQLLocalDBOnly_11_0)
 > - [SSDT](https://blogs.msdn.com/b/rickandy/archive/2012/08/02/installing-and-using-sql-server-data-tools-ssdt-on-visual-studio-2010-and-vwd.aspx)
-> 
+>
 > If you're using Visual Studio 2010 instead of Visual Web Developer 2010, install the [WPI installer for ASP.NET MVC 4](https://go.microsoft.com/fwlink/?LinkId=243392) and the: [Visual Studio 2010 prerequisites](https://www.microsoft.com/web/gallery/install.aspx?appsxml=&amp;appid=VS2010SP1Pack)
-> 
+>
 > A Visual Web Developer project with C# source code is available to accompany this topic. [Download the C# version](https://code.msdn.microsoft.com/Intro-to-ASPNET-MVC-4-61d0219d/file/114480/1/MvcMovie.zip).
-> 
+>
 > In the tutorial you run the application in Visual Studio. You can also make the application available over the Internet by deploying it to a hosting provider. Microsoft offers free web hosting for up to 10 web sites in a [free Windows Azure trial account](https://www.windowsazure.com/pricing/free-trial/?WT.mc_id=A443DD604). For information about how to deploy a Visual Studio web project to a Windows Azure Web Site, see [Create and deploy an ASP.NET web site and SQL Database with Visual Studio](https://docs.microsoft.com/dotnet/azure/). That tutorial also shows how to use Entity Framework Code First Migrations to deploy your SQL Server database to Windows Azure SQL Database (formerly SQL Azure).
-> 
+>
 > This tutorial was written by Rick Anderson ( [@RickAndMSFT](https://twitter.com/#!/RickAndMSFT) ).
 
 
 ## What You'll Build
 
 > [!NOTE]
-> An updated version if this tutorial is available [here](../../getting-started/introduction/getting-started.md) using [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads). The new tutorial uses ASP.NET MVC 5, which provides many improvements over this tutorial.
+> An updated version if this tutorial is available [here](../../getting-started/introduction/getting-started.md) using [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013). The new tutorial uses ASP.NET MVC 5, which provides many improvements over this tutorial.
 
 
 You'll implement a simple movie-listing application that supports creating, editing, searching and listing movies from a database. Below are two screenshots of the application you'll build. It includes a page that displays a list of movies from a database:

--- a/aspnet/signalr/overview/advanced/dependency-injection.md
+++ b/aspnet/signalr/overview/advanced/dependency-injection.md
@@ -14,20 +14,20 @@ Dependency Injection in SignalR
 by [Mike Wasson](https://github.com/MikeWasson), [Patrick Fletcher](https://github.com/pfletcher)
 
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 

--- a/aspnet/signalr/overview/deployment/tutorial-signalr-self-host.md
+++ b/aspnet/signalr/overview/deployment/tutorial-signalr-self-host.md
@@ -16,29 +16,29 @@ by [Patrick Fletcher](https://github.com/pfletcher)
 [Download Completed Project](http://code.msdn.microsoft.com/SignalR-Self-Host-Sample-6da0f383)
 
 > This tutorial shows how to create a self-hosted SignalR 2 server, and how to connect to it with a JavaScript client.
-> 
+>
 > ## Software versions used in the tutorial
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Using Visual Studio 2012 with this tutorial
-> 
-> 
+>
+>
 > To use Visual Studio 2012 with this tutorial, do the following:
-> 
+>
 > - Update your [Package Manager](http://docs.nuget.org/docs/start-here/installing-nuget) to the latest version.
 > - Install the [Web Platform Installer](https://www.microsoft.com/web/downloads/platform.aspx).
 > - In the Web Platform Installer, search for and install **ASP.NET and Web Tools 2013.1 for Visual Studio 2012**. This will install Visual Studio templates for SignalR classes such as **Hub**.
 > - Some templates (such as **OWIN Startup Class**) will not be available; for these, use a Class file instead.
-> 
-> 
+>
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 

--- a/aspnet/signalr/overview/deployment/using-signalr-with-azure-web-sites.md
+++ b/aspnet/signalr/overview/deployment/using-signalr-with-azure-web-sites.md
@@ -14,19 +14,19 @@ Using SignalR with Web Apps in Azure App Service
 by [Patrick Fletcher](https://github.com/pfletcher)
 
 > This document describes how to configure a SignalR application that runs on Microsoft Azure.
-> 
+>
 > ## Software versions used in the tutorial
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads) or Visual Studio 2012
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013) or Visual Studio 2012
 > - .NET 4.5
 > - SignalR version 2
 > - Azure SDK 2.3 for Visual Studio 2013 or 2012
->   
-> 
-> 
+>
+>
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR), [StackOverflow.com](http://stackoverflow.com/), or the [Microsoft Azure forums](https://social.msdn.microsoft.com/Forums/windowsazure/home?category=windowsazureplatform).
 
 

--- a/aspnet/signalr/overview/getting-started/tutorial-getting-started-with-signalr-and-mvc.md
+++ b/aspnet/signalr/overview/getting-started/tutorial-getting-started-with-signalr-and-mvc.md
@@ -15,35 +15,35 @@ by [Patrick Fletcher](https://github.com/pfletcher), [Tim Teebken](https://githu
 
 [Download Completed Project](http://code.msdn.microsoft.com/Getting-Started-with-c366b2f3)
 
-> This tutorial shows how to use ASP.NET SignalR 2 to create a real-time chat application. You will add SignalR to an MVC 5 application and create a chat view to send and display messages. 
-> 
+> This tutorial shows how to use ASP.NET SignalR 2 to create a real-time chat application. You will add SignalR to an MVC 5 application and create a chat view to send and display messages.
+>
 > ## Software versions used in the tutorial
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - MVC 5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Using Visual Studio 2012 with this tutorial
-> 
-> 
+>
+>
 > To use Visual Studio 2012 with this tutorial, do the following:
-> 
+>
 > - Update your [Package Manager](http://docs.nuget.org/docs/start-here/installing-nuget) to the latest version.
 > - Install the [Web Platform Installer](https://www.microsoft.com/web/downloads/platform.aspx).
 > - In the Web Platform Installer, search for and install **ASP.NET and Web Tools 2013.1 for Visual Studio 2012**. This will install Visual Studio templates for SignalR classes such as **Hub**.
 > - Some templates (such as **OWIN Startup Class**) will not be available; for these, use a Class file instead.
-> 
-> 
+>
+>
 > ## Tutorial Versions
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 

--- a/aspnet/signalr/overview/getting-started/tutorial-high-frequency-realtime-with-signalr.md
+++ b/aspnet/signalr/overview/getting-started/tutorial-high-frequency-realtime-with-signalr.md
@@ -16,37 +16,37 @@ by [Patrick Fletcher](https://github.com/pfletcher)
 [Download Completed Project](http://code.msdn.microsoft.com/SignalR-20-MoveShape-Demo-6285b83a)
 
 > This tutorial shows how to create a web application that uses ASP.NET SignalR 2 to provide high-frequency messaging functionality. High-frequency messaging in this case means updates that are sent at a fixed rate; in the case of this application, up to 10 messages a second.
-> 
+>
 > The application you'll create in this tutorial displays a shape that users can drag. The position of the shape in all other connected browsers will then be updated to match the position of the dragged shape using timed updates.
-> 
+>
 > Concepts introduced in this tutorial have applications in real-time gaming and other simulation applications.
-> 
+>
 > ## Software versions used in the tutorial
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Using Visual Studio 2012 with this tutorial
-> 
-> 
+>
+>
 > To use Visual Studio 2012 with this tutorial, do the following:
-> 
+>
 > - Update your [Package Manager](http://docs.nuget.org/docs/start-here/installing-nuget) to the latest version.
 > - Install the [Web Platform Installer](https://www.microsoft.com/web/downloads/platform.aspx).
 > - In the Web Platform Installer, search for and install **ASP.NET and Web Tools 2013.1 for Visual Studio 2012**. This will install Visual Studio templates for SignalR classes such as **Hub**.
 > - Some templates (such as **OWIN Startup Class**) will not be available; for these, use a Class file instead.
-> 
-> 
+>
+>
 > ## Tutorial Versions
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 
@@ -98,7 +98,7 @@ The following steps use Visual Studio 2013 to create an ASP.NET Empty Web Applic
     > [!NOTE]
     > You can also add SignalR to a project by clicking **Tools | Library Package Manager | Package Manager Console** and running a command:
 
-    `install-package Microsoft.AspNet.SignalR`. 
+    `install-package Microsoft.AspNet.SignalR`.
 
     If you use the console to add SignalR, create the SignalR hub class as a separate step after you add SignalR.
 4. Click **Tools | Library Package Manager | Package Manager Console**. In the package manager window, run the following command:

--- a/aspnet/signalr/overview/getting-started/tutorial-server-broadcast-with-signalr.md
+++ b/aspnet/signalr/overview/getting-started/tutorial-server-broadcast-with-signalr.md
@@ -14,37 +14,37 @@ Tutorial: Server Broadcast with SignalR 2
 by [Tom Dykstra](https://github.com/tdykstra), [Tom FitzMacken](https://github.com/tfitzmac)
 
 > This tutorial shows how to create a web application that uses ASP.NET SignalR 2 to provide server broadcast functionality. Server broadcast means that communications sent to clients are initiated by the server. This scenario requires a different programming approach than peer-to-peer scenarios such as chat applications, in which communications sent to clients are initiated by one or more of the clients.
-> 
+>
 > The application that you'll create in this tutorial simulates a stock ticker, a typical scenario for server broadcast functionality.
-> 
+>
 > This topic was originally written by Patrick Fletcher.
-> 
+>
 > ## Software versions used in the tutorial
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Using Visual Studio 2012 with this tutorial
-> 
-> 
+>
+>
 > To use Visual Studio 2012 with this tutorial, do the following:
-> 
+>
 > - Update your [Package Manager](http://docs.nuget.org/docs/start-here/installing-nuget) to the latest version.
 > - Install the [Web Platform Installer](https://www.microsoft.com/web/downloads/platform.aspx).
 > - In the Web Platform Installer, search for and install **ASP.NET and Web Tools 2013.1 for Visual Studio 2012**. This will install Visual Studio templates for SignalR classes such as **Hub**.
 > - Some templates (such as **OWIN Startup Class**) will not be available; for these, use a Class file instead.
-> 
-> 
+>
+>
 > ## Tutorial Versions
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 

--- a/aspnet/signalr/overview/guide-to-the-api/handling-connection-lifetime-events.md
+++ b/aspnet/signalr/overview/guide-to-the-api/handling-connection-lifetime-events.md
@@ -14,28 +14,28 @@ Understanding and Handling Connection Lifetime Events in SignalR
 by [Patrick Fletcher](https://github.com/pfletcher), [Tom Dykstra](https://github.com/tdykstra)
 
 > This article provides an overview of the SignalR connection, reconnection, and disconnection events that you can handle, and timeout and keepalive settings that you can configure.
-> 
+>
 > The article assumes you already have some knowledge of SignalR and connection lifetime events. For an introduction to SignalR, see [Introduction to SignalR](../getting-started/introduction-to-signalr.md). For lists of connection lifetime events, see the following resources:
-> 
+>
 > - [How to handle connection lifetime events in the Hub class](hubs-api-guide-server.md#connectionlifetime)
 > - [How to handle connection lifetime events in JavaScript clients](hubs-api-guide-javascript-client.md#connectionlifetime)
 > - [How to handle connection lifetime events in .NET clients](hubs-api-guide-net-client.md#connectionlifetime)
-> 
+>
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 
@@ -138,8 +138,8 @@ Transport connection interruptions that are not detected by the transport API an
 
 Some network environments deliberately close idle connections, and another function of the keepalive packets is to help prevent this by letting these networks know that a SignalR connection is in use. In extreme cases the default frequency of keepalive pings might not be enough to prevent closed connections. In that case you can configure keepalive pings to be sent more often. For more information, see [Timeout and keepalive settings](#timeoutkeepalive) later in this topic.
 
-> [!NOTE] 
-> 
+> [!NOTE]
+>
 > **Important**: The sequence of events described here is not guaranteed. SignalR makes every attempt to raise connection lifetime events in a predictable manner according to this scheme, but there are many variations of network events and many ways in which underlying communications frameworks such as transport APIs handle them. For example, the `Reconnected` event might not be raised when the client reconnects, or the `OnConnected` handler on the server might run when the attempt to establish a connection is unsuccessful. This topic describes only the effects that would normally be produced by certain typical circumstances.
 
 

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-javascript-client.md
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-javascript-client.md
@@ -14,26 +14,26 @@ ASP.NET SignalR Hubs API Guide - JavaScript Client
 by [Patrick Fletcher](https://github.com/pfletcher), [Tom Dykstra](https://github.com/tdykstra)
 
 > This document provides an introduction to using the Hubs API for SignalR version 2 in JavaScript clients, such as browsers and Windows Store (WinJS) applications.
-> 
+>
 > The SignalR Hubs API enables you to make remote procedure calls (RPCs) from a server to connected clients and from clients to the server. In server code, you define methods that can be called by clients, and you call methods that run on the client. In client code, you define methods that can be called from the server, and you call methods that run on the server. SignalR takes care of all of the client-to-server plumbing for you.
-> 
+>
 > SignalR also offers a lower-level API called Persistent Connections. For an introduction to SignalR, Hubs, and Persistent Connections, see [Introduction to SignalR](../getting-started/introduction-to-signalr.md).
-> 
+>
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 
@@ -228,7 +228,7 @@ This command will add the 2.1.0 version of the package to your project.
 
 ### Calling UseCors
 
- The following code snippet demonstrates how to implement cross-domain connections in SignalR 2. 
+ The following code snippet demonstrates how to implement cross-domain connections in SignalR 2.
 
 **Implementing cross-domain requests in SignalR 2**
 
@@ -236,12 +236,12 @@ The following code demonstrates how to enable CORS or JSONP in a SignalR 2 proje
 
 [!code-csharp[Main](hubs-api-guide-javascript-client/samples/sample11.cs)]
 
-> [!NOTE] 
-> 
+> [!NOTE]
+>
 > - Don't set `jQuery.support.cors` to true in your code.
-> 
+>
 >     ![Don't set jQuery.support.cors to true](hubs-api-guide-javascript-client/_static/image7.png)
-> 
+>
 >     SignalR handles the use of CORS. Setting `jQuery.support.cors` to true disables JSONP because it causes SignalR to assume the browser supports CORS.
 > - When you're connecting to a localhost URL, Internet Explorer 10 won't consider it a cross-domain connection, so the application will work locally with IE 10 even if you haven't enabled cross-domain connections on the server.
 > - For information about using cross-domain connections with Internet Explorer 9, see [this StackOverflow thread](http://stackoverflow.com/questions/13573397/siganlr-ie9-cross-domain-request-dont-work).

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-net-client.md
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-net-client.md
@@ -14,26 +14,26 @@ ASP.NET SignalR Hubs API Guide - .NET Client (C#)
 by [Patrick Fletcher](https://github.com/pfletcher), [Tom Dykstra](https://github.com/tdykstra)
 
 > This document provides an introduction to using the Hubs API for SignalR version 2 in .NET clients, such as Windows Store (WinRT), WPF, Silverlight, and console applications.
-> 
+>
 > The SignalR Hubs API enables you to make remote procedure calls (RPCs) from a server to connected clients and from clients to the server. In server code, you define methods that can be called by clients, and you call methods that run on the client. In client code, you define methods that can be called from the server, and you call methods that run on the server. SignalR takes care of all of the client-to-server plumbing for you.
-> 
+>
 > SignalR also offers a lower-level API called Persistent Connections. For an introduction to SignalR, Hubs, and Persistent Connections, or for a tutorial that shows how to build a complete SignalR application, see [SignalR - Getting Started](../getting-started/index.md).
-> 
+>
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 

--- a/aspnet/signalr/overview/guide-to-the-api/mapping-users-to-connections.md
+++ b/aspnet/signalr/overview/guide-to-the-api/mapping-users-to-connections.md
@@ -14,24 +14,24 @@ Mapping SignalR Users to Connections
 by [Tom FitzMacken](https://github.com/tfitzmac)
 
 > This topic shows how to retain information about users and their connections.
-> 
+>
 > Patrick Fletcher helped write this topic.
-> 
+>
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 

--- a/aspnet/signalr/overview/guide-to-the-api/working-with-groups.md
+++ b/aspnet/signalr/overview/guide-to-the-api/working-with-groups.md
@@ -13,23 +13,23 @@ Working with Groups in SignalR
 ====================
 by [Patrick Fletcher](https://github.com/pfletcher), [Tom FitzMacken](https://github.com/tfitzmac)
 
-> This topic describes how to add users to groups and persist group membership information. 
-> 
+> This topic describes how to add users to groups and persist group membership information.
+>
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 
@@ -75,13 +75,13 @@ In general, you should not include `await` when calling the `Groups.Remove` meth
 
 You can send messages to all of the members of a group or only specified members of the group, as shown in the following examples.
 
-- **All** connected clients in a specified group. 
+- **All** connected clients in a specified group.
 
     [!code-css[Main](working-with-groups/samples/sample3.css)]
-- All connected clients in a specified group **except the specified clients**, identified by connection ID. 
+- All connected clients in a specified group **except the specified clients**, identified by connection ID.
 
     [!code-csharp[Main](working-with-groups/samples/sample4.cs)]
-- All connected clients in a specified group **except the calling client**. 
+- All connected clients in a specified group **except the calling client**.
 
     [!code-css[Main](working-with-groups/samples/sample5.css)]
 

--- a/aspnet/signalr/overview/performance/scaleout-in-signalr.md
+++ b/aspnet/signalr/overview/performance/scaleout-in-signalr.md
@@ -14,20 +14,20 @@ Introduction to Scaleout in SignalR
 by [Mike Wasson](https://github.com/MikeWasson), [Patrick Fletcher](https://github.com/pfletcher)
 
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 

--- a/aspnet/signalr/overview/performance/scaleout-with-redis.md
+++ b/aspnet/signalr/overview/performance/scaleout-with-redis.md
@@ -14,20 +14,20 @@ SignalR Scaleout with Redis
 by [Mike Wasson](https://github.com/MikeWasson), [Patrick Fletcher](https://github.com/pfletcher)
 
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 
@@ -46,8 +46,8 @@ If you don't have three physical servers to use, you can create VMs on Hyper-V. 
 
 Although this tutorial uses the official Redis implementation, there is also a [Windows port of Redis](https://github.com/MSOpenTech/redis) from MSOpenTech. Setup and configuration are different, but otherwise the steps are the same.
 
-> [!NOTE] 
-> 
+> [!NOTE]
+>
 > SignalR scaleout with Redis does not support Redis clusters.
 
 
@@ -56,12 +56,12 @@ Although this tutorial uses the official Redis implementation, there is also a [
 Before we get to the detailed tutorial, here is a quick overview of what you will do.
 
 1. Install Redis and start the Redis server.
-2. Add these NuGet packages to your application: 
+2. Add these NuGet packages to your application:
 
     - [Microsoft.AspNet.SignalR](http://nuget.org/packages/Microsoft.AspNet.SignalR)
     - [Microsoft.AspNet.SignalR.Redis](http://nuget.org/packages/Microsoft.AspNet.SignalR.Redis)
 3. Create a SignalR application.
-4. Add the following code to Startup.cs to configure the backplane: 
+4. Add the following code to Startup.cs to configure the backplane:
 
     [!code-csharp[Main](scaleout-with-redis/samples/sample1.cs)]
 

--- a/aspnet/signalr/overview/performance/scaleout-with-sql-server.md
+++ b/aspnet/signalr/overview/performance/scaleout-with-sql-server.md
@@ -14,20 +14,20 @@ SignalR Scaleout with SQL Server
 by [Mike Wasson](https://github.com/MikeWasson), [Patrick Fletcher](https://github.com/pfletcher)
 
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 
@@ -44,16 +44,16 @@ Microsoft SQL Server 2005 or later. The backplane supports both desktop and serv
 Before we get to the detailed tutorial, here is a quick overview of what you will do.
 
 1. Create a new empty database. The backplane will create the necessary tables in this database.
-2. Add these NuGet packages to your application: 
+2. Add these NuGet packages to your application:
 
     - [Microsoft.AspNet.SignalR](http://nuget.org/packages/Microsoft.AspNet.SignalR)
     - [Microsoft.AspNet.SignalR.SqlServer](http://nuget.org/packages/Microsoft.AspNet.SignalR.SqlServer)
 3. Create a SignalR application.
-4. Add the following code to Startup.cs to configure the backplane: 
+4. Add the following code to Startup.cs to configure the backplane:
 
     [!code-csharp[Main](scaleout-with-sql-server/samples/sample1.cs)]
 
-   This code configures the backplane with the default values for [TableCount](https://msdn.microsoft.com/library/microsoft.aspnet.signalr.sqlscaleoutconfiguration.tablecount(v=vs.118).aspx) and [MaxQueueLength](https://msdn.microsoft.com/library/microsoft.aspnet.signalr.messaging.scaleoutconfiguration.maxqueuelength(v=vs.118).aspx). For information on changing these values, see [SignalR Performance: Scaleout Metrics](signalr-performance.md#scaleout_metrics). 
+   This code configures the backplane with the default values for [TableCount](https://msdn.microsoft.com/library/microsoft.aspnet.signalr.sqlscaleoutconfiguration.tablecount(v=vs.118).aspx) and [MaxQueueLength](https://msdn.microsoft.com/library/microsoft.aspnet.signalr.messaging.scaleoutconfiguration.maxqueuelength(v=vs.118).aspx). For information on changing these values, see [SignalR Performance: Scaleout Metrics](signalr-performance.md#scaleout_metrics).
 
 ## Configure the Database
 

--- a/aspnet/signalr/overview/performance/signalr-performance.md
+++ b/aspnet/signalr/overview/performance/signalr-performance.md
@@ -14,22 +14,22 @@ SignalR Performance
 by [Patrick Fletcher](https://github.com/pfletcher)
 
 > This topic describes how to design for, measure, and improve performance in a SignalR application.
-> 
+>
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 

--- a/aspnet/signalr/overview/releases/upgrading-signalr-1x-projects-to-20.md
+++ b/aspnet/signalr/overview/releases/upgrading-signalr-1x-projects-to-20.md
@@ -14,29 +14,29 @@ Upgrading SignalR 1.x Projects to version 2
 by [Patrick Fletcher](https://github.com/pfletcher)
 
 > This topic describes how to upgrade an existing SignalR 1.x project to SignalR 2.x, and how to troubleshoot issues that may arise during the upgrade process.
-> 
+>
 > ## Software versions used in the tutorial
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR versions 1 and 2
->   
-> 
-> 
+>
+>
+>
 > ## Using Visual Studio 2012 with this tutorial
-> 
-> 
+>
+>
 > To use Visual Studio 2012 with this tutorial, do the following:
-> 
+>
 > - Update your [Package Manager](http://docs.nuget.org/docs/start-here/installing-nuget) to the latest version.
 > - Install the [Web Platform Installer](https://www.microsoft.com/web/downloads/platform.aspx).
 > - In the Web Platform Installer, search for and install **ASP.NET and Web Tools 2013.1 for Visual Studio 2012**. This will install Visual Studio templates for SignalR classes such as **Hub**.
 > - Some templates (such as **OWIN Startup Class**) will not be available; for these, use a Class file instead.
-> 
-> 
+>
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 

--- a/aspnet/signalr/overview/security/hub-authorization.md
+++ b/aspnet/signalr/overview/security/hub-authorization.md
@@ -13,23 +13,23 @@ Authentication and Authorization for SignalR Hubs
 ====================
 by [Patrick Fletcher](https://github.com/pfletcher), [Tom FitzMacken](https://github.com/tfitzmac)
 
-> This topic describes how to restrict which users or roles can access hub methods. 
-> 
+> This topic describes how to restrict which users or roles can access hub methods.
+>
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 

--- a/aspnet/signalr/overview/security/introduction-to-security.md
+++ b/aspnet/signalr/overview/security/introduction-to-security.md
@@ -13,23 +13,23 @@ Introduction to SignalR Security
 ====================
 by [Patrick Fletcher](https://github.com/pfletcher), [Tom FitzMacken](https://github.com/tfitzmac)
 
-> This article describes the security issues you must consider when developing a SignalR application. 
-> 
+> This article describes the security issues you must consider when developing a SignalR application.
+>
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 
@@ -102,7 +102,7 @@ Here is an example of a CSRF attack:
 
 1. A user logs into www.example.com, using forms authentication.
 2. The server authenticates the user. The response from the server includes an authentication cookie.
-3. Without logging out, the user visits a malicious web site. This malicious site contains the following HTML form: 
+3. Without logging out, the user visits a malicious web site. This malicious site contains the following HTML form:
 
     [!code-html[Main](introduction-to-security/samples/sample1.html)]
 
@@ -118,11 +118,11 @@ Typically, CSRF attacks are possible against web sites that use cookies for auth
 
 SignalR takes the following steps to prevent a malicious site from creating valid requests to your application. SignalR takes these steps by default, you do not need to take any action in your code.
 
-- **Disable cross domain requests**  
+- **Disable cross domain requests**
  SignalR disables cross domain requests to prevent users from calling a SignalR endpoint from an external domain. SignalR considers any request from an external domain to be invalid and blocks the request. We recommend that you keep this default behavior; otherwise, a malicious site could trick users into sending commands to your site. If you need to use cross domain requests, see     [How to establish a cross-domain connection](../guide-to-the-api/hubs-api-guide-javascript-client.md#crossdomain) .
-- **Pass connection token in query string, not cookie**  
+- **Pass connection token in query string, not cookie**
  SignalR passes the connection token as a query string value, instead of as a cookie. Storing the connection token in a cookie is unsafe because the browser can inadvertently forward the connection token when malicious code is encountered. Also, passing the connection token in the query string prevents the connection token from persisting beyond the current connection. Therefore, a malicious user cannot make a request under another user's authentication credentials.
-- **Verify connection token**  
+- **Verify connection token**
  As described in the     [Connection token](#connectiontoken) section, the server knows which connection id is associated with each authenticated user. The server does not process any request from a connection id that does not match the user name. It is unlikely a malicious user could guess a valid request because the malicious user would have to know the user name and the current randomly-generated connection id. That connection id becomes invalid as soon as the connection is ended. Anonymous users should not have access to any sensitive information.
 
 <a id="recommendations"></a>

--- a/aspnet/signalr/overview/security/persistent-connection-authorization.md
+++ b/aspnet/signalr/overview/security/persistent-connection-authorization.md
@@ -13,23 +13,23 @@ Authentication and Authorization for SignalR Persistent Connections
 ====================
 by [Patrick Fletcher](https://github.com/pfletcher), [Tom FitzMacken](https://github.com/tfitzmac)
 
-> This topic describes how to enforce authorization on a persistent connection. For general information about integrating security into a SignalR application, see [Introduction to Security](introduction-to-security.md). 
-> 
+> This topic describes how to enforce authorization on a persistent connection. For general information about integrating security into a SignalR application, see [Introduction to Security](introduction-to-security.md).
+>
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 

--- a/aspnet/signalr/overview/testing-and-debugging/enabling-signalr-tracing.md
+++ b/aspnet/signalr/overview/testing-and-debugging/enabling-signalr-tracing.md
@@ -14,20 +14,20 @@ Enabling SignalR Tracing
 by [Tom FitzMacken](https://github.com/tfitzmac)
 
 > This document describes how to enable and configure tracing for SignalR servers and clients. Tracing enables you to view diagnostic information about events in your SignalR application.
-> 
+>
 > This topic was originally written by Patrick Fletcher.
-> 
+>
 > ## Software versions used in the tutorial
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET Framework 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 
@@ -128,7 +128,7 @@ The following output shows entries from the `ClientLog.txt` file for an applicat
 <a id="phone"></a>
 ## Enabling tracing in Windows Phone 8 clients
 
-SignalR applications for Windows Phone apps use the same .NET client as desktop apps, but [Console.Out](https://msdn.microsoft.com/library/system.console.out(v=vs.110).aspx) and writing to a file with [StreamWriter](https://msdn.microsoft.com/library/system.io.streamwriter(v=vs.110).aspx) are not available. Instead, you need to create a custom implementation of [TextWriter](https://msdn.microsoft.com/library/system.io.textwriter(v=vs.110).aspx) for tracing. 
+SignalR applications for Windows Phone apps use the same .NET client as desktop apps, but [Console.Out](https://msdn.microsoft.com/library/system.console.out(v=vs.110).aspx) and writing to a file with [StreamWriter](https://msdn.microsoft.com/library/system.io.streamwriter(v=vs.110).aspx) are not available. Instead, you need to create a custom implementation of [TextWriter](https://msdn.microsoft.com/library/system.io.textwriter(v=vs.110).aspx) for tracing.
 
 <a id="phone_ui"></a>
 ### Logging Windows Phone client events to the UI

--- a/aspnet/signalr/overview/testing-and-debugging/troubleshooting.md
+++ b/aspnet/signalr/overview/testing-and-debugging/troubleshooting.md
@@ -14,22 +14,22 @@ SignalR Troubleshooting
 by [Patrick Fletcher](https://github.com/pfletcher)
 
 > This document describes common troubleshooting issues with SignalR.
-> 
+>
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Previous versions of this topic
-> 
+>
 > For information about earlier versions of SignalR, see [SignalR Older Versions](../older-versions/index.md).
-> 
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 
@@ -288,7 +288,7 @@ This error can result from using data types that cannot be discovered in a JSON 
 
 ## Compilation and server-side errors
 
- The following section contains possible solutions to compiler and server-side runtime errors. 
+ The following section contains possible solutions to compiler and server-side runtime errors.
 
 ### Reference to Hub instance is null
 

--- a/aspnet/signalr/overview/testing-and-debugging/unit-testing-signalr-applications.md
+++ b/aspnet/signalr/overview/testing-and-debugging/unit-testing-signalr-applications.md
@@ -13,19 +13,19 @@ Unit Testing SignalR Applications
 ====================
 by [Patrick Fletcher](https://github.com/pfletcher)
 
-> This article describes using the Unit Testing features of SignalR 2. 
-> 
+> This article describes using the Unit Testing features of SignalR 2.
+>
 > ## Software versions used in this topic
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - .NET 4.5
 > - SignalR version 2
->   
-> 
-> 
+>
+>
+>
 > ## Questions and comments
-> 
+>
 > Please leave feedback on how you liked this tutorial and what we could improve in the comments at the bottom of the page. If you have questions that are not directly related to the tutorial, you can post them to the [ASP.NET SignalR forum](https://forums.asp.net/1254.aspx/1?ASP+NET+SignalR) or [StackOverflow.com](http://stackoverflow.com/).
 
 

--- a/aspnet/web-api/overview/hosting-aspnet-web-api/host-aspnet-web-api-in-an-azure-worker-role.md
+++ b/aspnet/web-api/overview/hosting-aspnet-web-api/host-aspnet-web-api-in-an-azure-worker-role.md
@@ -14,15 +14,15 @@ Host ASP.NET Web API 2 in an Azure Worker Role
 by [Mike Wasson](https://github.com/MikeWasson)
 
 > This tutorial shows how to host ASP.NET Web API in an Azure Worker Role, using OWIN to self-host the Web API framework.
-> 
+>
 > [Open Web Interface for .NET](http://owin.org/) (OWIN) defines an abstraction between .NET web servers and web applications. OWIN decouples the web application from the server, which makes OWIN ideal for self-hosting a web application in your own process, outside of IIS–for example, inside an Azure worker role.
-> 
+>
 > In this tutorial, you'll use the Microsoft.Owin.Host.HttpListener package, which provides an HTTP server that be used to self-host OWIN applications.
-> 
+>
 > ## Software versions used in the tutorial
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - Web API 2
 > - [Azure SDK for .NET 2.3](https://azure.microsoft.com/downloads/)
 

--- a/aspnet/web-api/overview/hosting-aspnet-web-api/use-owin-to-self-host-web-api.md
+++ b/aspnet/web-api/overview/hosting-aspnet-web-api/use-owin-to-self-host-web-api.md
@@ -14,13 +14,13 @@ Use OWIN to Self-Host ASP.NET Web API 2
 by [Kanchan Mehrotra](https://twitter.com/kanchanmeh)
 
 > This tutorial shows how to host ASP.NET Web API in a console application, using OWIN to self-host the Web API framework.
-> 
+>
 > [Open Web Interface for .NET](http://owin.org) (OWIN) defines an abstraction between .NET web servers and web applications. OWIN decouples the web application from the server, which makes OWIN ideal for self-hosting a web application in your own process, outside of IIS.
-> 
+>
 > ## Software versions used in the tutorial
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads) (also works with Visual Studio 2012)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013) (also works with Visual Studio 2012)
 > - Web API 2
 
 

--- a/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v3/calling-an-odata-service-from-a-net-client.md
+++ b/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v3/calling-an-odata-service-from-a-net-client.md
@@ -16,11 +16,11 @@ by [Mike Wasson](https://github.com/MikeWasson)
 [Download Completed Project](http://code.msdn.microsoft.com/ASPNET-Web-API-OData-cecdb524)
 
 > This tutorial shows how to call an OData service from a C# client application.
-> 
+>
 > ## Software versions used in the tutorial
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads) (works with Visual Studio 2012)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013) (works with Visual Studio 2012)
 > - [WCF Data Services Client Library](https://msdn.microsoft.com/library/cc668772.aspx)
 > - Web API 2. (The example OData service is built using Web API 2, but the client application does not depend on Web API.)
 

--- a/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v3/creating-an-odata-endpoint.md
+++ b/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v3/creating-an-odata-endpoint.md
@@ -16,18 +16,18 @@ by [Mike Wasson](https://github.com/MikeWasson)
 [Download Completed Project](http://code.msdn.microsoft.com/ASPNET-Web-API-OData-cecdb524)
 
 > The [Open Data Protocol](http://www.odata.org/) (OData) is a data access protocol for the web. OData provides a uniform way to structure data, query the data, and manipulate the data set through CRUD operations (create, read, update, and delete). OData supports both AtomPub (XML) and JSON formats. OData also defines a way to expose metadata about the data. Clients can use the metadata to discover the type information and relationships for the data set.
-> 
+>
 > ASP.NET Web API makes it easy to create an OData endpoint for a data set. You can control exactly which OData operations the endpoint supports. You can host multiple OData endpoints, alongside non-OData endpoints. You have full control over your data model, back-end business logic, and data layer.
-> 
+>
 > ## Software versions used in the tutorial
-> 
-> 
-> - [Visual Studio 2013](https://www.microsoft.com/visualstudio/eng/2013-downloads)
+>
+>
+> - [Visual Studio 2013](https://my.visualstudio.com/Downloads?q=visual%20studio%202013)
 > - Web API 2
 > - OData Version 3
 > - Entity Framework 6
 > - [Fiddler Web Debugging Proxy (Optional)](http://www.fiddler2.com)
-> 
+>
 > Web API OData support was added in [ASP.NET and Web Tools 2012.2 Update](https://go.microsoft.com/fwlink/?LinkId=282650). However, this tutorial uses scaffolding that was added in Visual Studio 2013.
 
 
@@ -234,7 +234,7 @@ OData supports several serialization formats:
 - JSON "light" (introduced in OData v3)
 - JSON "verbose" (OData v2)
 
-By default, Web API uses AtomPubJSON "light" format. 
+By default, Web API uses AtomPubJSON "light" format.
 
 To get AtomPub format, set the Accept header to "application/atom+xml". Here is an example response body:
 


### PR DESCRIPTION
- replace Visual Studio 2013 download link with a valid link
- none of these topics meet the >13K page view per month threshold for further updates at this time, so I'm just updating these bad URLs
- PR also includes automatic whitespace trimming