### PR TITLE
Added context around HEAD requests

### DIFF
--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -242,7 +242,7 @@ See [Model validation](xref:mvc/models/validation) for more information.
 
 ## Manage HEAD requests with the OnGet handler
 
-HEAD requests allow you to retrieve the headers for a specific resource. Unlike GET requests, HEAD requests do not return a response body. 
+HEAD requests allow you to retrieve the headers for a specific resource. Unlike GET requests, HEAD requests don't return a response body. 
 
 Ordinarily, a HEAD handler is created and called for HEAD requests: 
 

--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -242,7 +242,9 @@ See [Model validation](xref:mvc/models/validation) for more information.
 
 ## Manage HEAD requests with the OnGet handler
 
-Ordinarily, a HEAD handler is created and called for HEAD requests:
+HEAD requests allow you to retrieve the headers for a specific resource. Unlike GET requests, HEAD requests do not return a response body. 
+
+Ordinarily, a HEAD handler is created and called for HEAD requests: 
 
 ```csharp
 public void OnHead()


### PR DESCRIPTION
I added a quick description of HEAD requests. It seems many developers don't know the difference between that and a GET, and a quick sentence to put it in context might help.
