### PR TITLE
update ASP.NET SignalR docs to show observing send errors

### DIFF
--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server.md
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server.md
@@ -569,10 +569,9 @@ In VB.NET or in a strongly-typed hub, the caller state object can't be accessed 
 
 ## How to handle errors in the Hub class
 
-To handle errors that occur in your Hub class methods, use one or more of the following methods:
+To handle errors that occur in your Hub class methods, first ensure you "observe" any exceptions from async operations (such as invoking client methods) by using `await`. Then use one or more of the following methods:
 
 - Wrap your method code in try-catch blocks and log the exception object. For debugging purposes you can send the exception to the client, but for security reasons sending detailed information to clients in production is not recommended.
-- Use `await` when invoking client methods to ensure that any exceptions that occur while trying to send the message are observed and can be caught in a try-catch block.
 - Create a Hubs pipeline module that handles the [OnIncomingError](https://msdn.microsoft.com/library/microsoft.aspnet.signalr.hubs.hubpipelinemodule.onincomingerror(v=vs.111).aspx) method. The following example shows a pipeline module that logs errors, followed by code in Startup.cs that injects the module into the Hubs pipeline.
 
     [!code-csharp[Main](hubs-api-guide-server/samples/sample61.cs)]

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server.md
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server.md
@@ -298,6 +298,9 @@ To call client methods from the server, use the `Clients` property in a method i
 
 [!code-csharp[Main](hubs-api-guide-server/samples/sample23.cs?highlight=5)]
 
+> [!NOTE]
+> Invoking a client method is an asynchronous operation and returns a `Task`. Use `await` to ensure you wait for the message to be sent. If an error occurs while sending the message, `await` will also allow you to catch that exception using a try-catch block.
+
 **JavaScript client using generated proxy**
 
 [!code-html[Main](hubs-api-guide-server/samples/sample24.html?highlight=1)]
@@ -569,6 +572,7 @@ In VB.NET or in a strongly-typed hub, the caller state object can't be accessed 
 To handle errors that occur in your Hub class methods, use one or more of the following methods:
 
 - Wrap your method code in try-catch blocks and log the exception object. For debugging purposes you can send the exception to the client, but for security reasons sending detailed information to clients in production is not recommended.
+- Use `await` when invoking client methods to ensure that any exceptions that occur while trying to send the message are observed and can be caught in a try-catch block.
 - Create a Hubs pipeline module that handles the [OnIncomingError](https://msdn.microsoft.com/library/microsoft.aspnet.signalr.hubs.hubpipelinemodule.onincomingerror(v=vs.111).aspx) method. The following example shows a pipeline module that logs errors, followed by code in Startup.cs that injects the module into the Hubs pipeline.
 
     [!code-csharp[Main](hubs-api-guide-server/samples/sample61.cs)]

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample13.cs
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample13.cs
@@ -1,7 +1,7 @@
 public class ContosoChatHub : Hub
 {
-    public void NewContosoChatMessage(string name, string message)
+    public async Task NewContosoChatMessage(string name, string message)
     {
-        Clients.All.addNewMessageToPage(name, message);
+        await Clients.All.addNewMessageToPage(name, message);
     }
 }

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample23.cs
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample23.cs
@@ -1,7 +1,7 @@
 public class ContosoChatHub : Hub
 {
-    public void NewContosoChatMessage(string name, string message)
+    public async Task NewContosoChatMessage(string name, string message)
     {
-        Clients.All.addNewMessageToPage(name, message);
+        await Clients.All.addNewMessageToPage(name, message);
     }
 }

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample25.cs
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample25.cs
@@ -1,4 +1,4 @@
-public void SendMessage(string name, string message)
+public async Task SendMessage(string name, string message)
 {
-    Clients.All.addContosoChatMessageToPage(new ContosoChatMessage() { UserName = name, Message = message });
+    await Clients.All.addContosoChatMessageToPage(new ContosoChatMessage() { UserName = name, Message = message });
 }

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample41.cs
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample41.cs
@@ -1,5 +1,5 @@
 public async Task NewContosoChatMessage(string name, string message)
 {
     await Clients.Others.addContosoChatMessageToPage(data);
-    Clients.Caller.notifyMessageSent();
+    await Clients.Caller.notifyMessageSent();
 }

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample42.cs
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample42.cs
@@ -1,6 +1,6 @@
-public void NewContosoChatMessage(string name, string message)
+public async Task NewContosoChatMessage(string name, string message)
 {
     string methodToCall = "addContosoChatMessageToPage";
     IClientProxy proxy = Clients.All;
-    proxy.Invoke(methodToCall, name, message);
+    await proxy.Invoke(methodToCall, name, message);
 }

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample46.cs
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample46.cs
@@ -1,5 +1,5 @@
 public async Task JoinGroup(string groupName)
 {
     await Groups.Add(Context.ConnectionId, groupName);
-    Clients.Group(groupname).addContosoChatMessageToPage(Context.ConnectionId + " added to group");
+    await Clients.Group(groupname).addContosoChatMessageToPage(Context.ConnectionId + " added to group");
 }

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample58.cs
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample58.cs
@@ -1,6 +1,6 @@
-public void NewContosoChatMessage(string data)
+public async Task NewContosoChatMessage(string data)
 {
     string userName = Clients.Caller.userName;
     string computerName = Clients.Caller.computerName;
-    Clients.Others.addContosoChatMessageToPage(message, userName, computerName);
+    await Clients.Others.addContosoChatMessageToPage(message, userName, computerName);
 }

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample59.cs
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample59.cs
@@ -1,6 +1,6 @@
-public void NewContosoChatMessage(string data)
+public async Task NewContosoChatMessage(string data)
 {
     string userName = Clients.CallerState.userName;
     string computerName = Clients.CallerState.computerName;
-    Clients.Others.addContosoChatMessageToPage(data, userName, computerName);
+    await Clients.Others.addContosoChatMessageToPage(data, userName, computerName);
 }

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample60.vb
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample60.vb
@@ -1,5 +1,5 @@
-Public Sub NewContosoChatMessage(message As String)
+Public Async Function NewContosoChatMessage(message As String) As Task
     Dim userName As String = Clients.CallerState.userName
     Dim computerName As String = Clients.CallerState.computerName
-    Clients.Others.addContosoChatMessageToPage(message, userName, computerName)
+    Await Clients.Others.addContosoChatMessageToPage(message, userName, computerName)
 End Sub

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample63.cs
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample63.cs
@@ -1,12 +1,12 @@
 public class MyHub : Hub
 {
-    public void Send(string message)
+    public async Task Send(string message)
     {
         if(message.Contains("<script>"))
         {
             throw new HubException("This message will flow to the client", new { user = Context.User.Identity.Name, message = message });
         }
 
-        Clients.All.send(message);
+        await Clients.All.send(message);
     }
 }

--- a/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample7.cs
+++ b/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server/samples/sample7.cs
@@ -1,7 +1,7 @@
 public class ContosoChatHub : Hub
 {
-    public void NewContosoChatMessage(string name, string message)
+    public async Task NewContosoChatMessage(string name, string message)
     {
-        Clients.All.addNewMessageToPage(name, message);
+        await Clients.All.addNewMessageToPage(name, message);
     }
 }


### PR DESCRIPTION
Related: https://github.com/SignalR/SignalR/issues/4144

FYI: This is for **ASP.NET** SignalR, *not* ASP.NET Core SignalR. (The concepts are relative to both but the newer docs are better at showing the right pattern ;))

When SignalR fails to send a message (possibly due to an error in the backplane), the exception bubbles all the way up to the Client proxy (e.g. `Clients.All.foo()`). However, all our docs tell users to simply invoke these methods without `await`ing the task or otherwise observing it. This means that these errors can end up triggering the [`TaskScheduler.UnobservedTaskException`](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskscheduler.unobservedtaskexception?view=netframework-4.7.2) event.

This updates our docs on the Hubs API to show `await`ing the Client proxy invocation.

[Internal Review Version](https://review.docs.microsoft.com/en-us/aspnet/signalr/overview/guide-to-the-api/hubs-api-guide-server?branch=pr-en-us-8960)