### PR TITLE
Tag Helpers: Enhance cross-links and UE pass

### DIFF
--- a/aspnetcore/fundamentals/metapackage.md
+++ b/aspnetcore/fundamentals/metapackage.md
@@ -63,7 +63,7 @@ Any dependencies of the preceding packages that otherwise aren't dependencies of
 
 ## Update ASP.NET Core 2.1
 
-We recommend migrating migrating to the `Microsoft.AspNetCore.App` metapackage for 2.1 and later. To keep using the `Microsoft.AspNetCore.All` metapackage and ensure the latest patch version is deployed:
+We recommend migrating to the `Microsoft.AspNetCore.App` metapackage for 2.1 and later. To keep using the `Microsoft.AspNetCore.All` metapackage and ensure the latest patch version is deployed:
 
 * On development machines and build servers: Install the latest [.NET Core SDK](https://www.microsoft.com/net/download).
 * On deployment servers: Install the latest [.NET Core runtime](https://www.microsoft.com/net/download).

--- a/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
@@ -4,16 +4,18 @@ author: pkellner
 description: Discover the ASP.NET Core Anchor Tag Helper attributes and the role each attribute plays in extending behavior of the HTML anchor tag.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 01/31/2018
+ms.date: 10/10/2018
 uid: mvc/views/tag-helpers/builtin-th/anchor-tag-helper
 ---
 # Anchor Tag Helper in ASP.NET Core
 
 By [Peter Kellner](http://peterkellner.net) and [Scott Addie](https://github.com/scottaddie)
 
-[View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/mvc/views/tag-helpers/built-in/samples) ([how to download](xref:tutorials/index#how-to-download-a-sample))
-
 The [Anchor Tag Helper](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper) enhances the standard HTML anchor (`<a ... ></a>`) tag by adding new attributes. By convention, the attribute names are prefixed with `asp-`. The rendered anchor element's `href` attribute value is determined by the values of the `asp-` attributes.
+
+For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
+
+[View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/mvc/views/tag-helpers/built-in/samples) ([how to download](xref:tutorials/index#how-to-download-a-sample))
 
 *SpeakerController* is used in samples throughout this document:
 
@@ -165,7 +167,7 @@ Hash tags are useful when building client-side apps. They can be used for easy m
 
 The [asp-area](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.area) attribute sets the area name used to set the appropriate route. The following example depicts how the area attribute causes a remapping of routes. Setting `asp-area` to "Blogs" prefixes the directory *Areas/Blogs* to the routes of the associated controllers and views for this anchor tag.
 
-* **<Project name\>**
+* **{Project name}**
   * **wwwroot**
   * **Areas**
     * **Blogs**
@@ -175,7 +177,7 @@ The [asp-area](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.a
         * **Home**
           * *AboutBlog.cshtml*
           * *Index.cshtml*
-        * *_ViewStart.cshtml*
+        * *\_ViewStart.cshtml*
   * **Controllers**
 
 Given the preceding directory hierarchy, the markup to reference the *AboutBlog.cshtml* file is:
@@ -190,6 +192,7 @@ The generated HTML:
 
 > [!TIP]
 > For areas to work in an MVC app, the route template must include a reference to the area, if it exists. That template is represented by the second parameter of the `routes.MapRoute` method call in *Startup.Configure*:
+>
 > [!code-csharp[](samples/TagHelpersBuiltIn/Startup.cs?name=snippet_UseMvc&highlight=5)]
 
 ## asp-protocol
@@ -262,5 +265,5 @@ The generated HTML:
 
 ## Additional resources
 
-* [Areas](xref:mvc/controllers/areas)
-* [Intro to Razor Pages](xref:razor-pages/index)
+* <xref:mvc/controllers/areas>
+* <xref:razor-pages/index>

--- a/aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md
@@ -3,41 +3,35 @@ title: Cache Tag Helper in ASP.NET Core MVC
 author: pkellner
 description: Learn how to use the Cache Tag Helper.
 ms.author: riande
-ms.date: 02/14/2017
+ms.custom: mvc
+ms.date: 10/10/2018
 uid: mvc/views/tag-helpers/builtin-th/cache-tag-helper
 ---
 # Cache Tag Helper in ASP.NET Core MVC
 
-By [Peter Kellner](http://peterkellner.net) 
+By [Peter Kellner](http://peterkellner.net)
 
-The Cache Tag Helper provides the ability to dramatically improve the performance of your ASP.NET Core app by caching its content to the internal ASP.NET Core cache provider.
+The Cache Tag Helper provides the ability to improve the performance of your ASP.NET Core app by caching its content to the internal ASP.NET Core cache provider.
 
-The Razor View Engine sets the default `expires-after` to twenty minutes.
+For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
 
-The following Razor markup caches the date/time:
+The following Razor markup caches the current date:
 
 ```cshtml
 <cache>@DateTime.Now</cache>
 ```
 
-The first request to the page that contains `CacheTagHelper` will display the current date/time. Additional requests will show the cached value until the cache expires (default 20 minutes) or is evicted by memory pressure.
-
-You can set the cache duration with the following attributes:
+The first request to the page that contains the Tag Helper displays the current date. Additional requests show the cached value until the cache expires (default 20 minutes) or until the cached date is evicted from the cache.
 
 ## Cache Tag Helper Attributes
 
-- - -
+### enabled
 
-### enabled    
+| Attribute Type  | Examples        | Default |
+| --------------- | --------------- | ------- |
+| Boolean         | `true`, `false` | `true`  |
 
-
-| Attribute Type    | Valid Values      |
-|----------------   |----------------   |
-| boolean           | "true" (default)  |
-|                   | "false"   |
-
-
-Determines whether the content enclosed by the Cache Tag Helper is cached. The default is `true`.  If set to `false` this Cache Tag Helper will have no caching effect on the rendered output.
+`enabled` determines if the content enclosed by the Cache Tag Helper is cached. The default is `true`. If set to `false`, the Cache Tag Helper has no caching effect on the rendered output.
 
 Example:
 
@@ -47,17 +41,15 @@ Example:
 </cache>
 ```
 
-- - -
+### expires-on
 
-### expires-on 
+| Attribute Type   | Example                            |
+| ---------------- | ---------------------------------- |
+| `DateTimeOffset` | `@new DateTime(2025,1,29,17,02,0)` |
 
-| Attribute Type |           Example Value            |
-|----------------|------------------------------------|
-| DateTimeOffset | "@new DateTime(2025,1,29,17,02,0)" |
+`expires-on` sets an absolute expiration date for the cached item.
 
-Sets an absolute expiration date. The following example will cache the contents of the Cache Tag Helper until 5:02 PM on January 29, 2025.
-
-Example:
+The following example caches the contents of the Cache Tag Helper until 5:02 PM on January 29, 2025:
 
 ```cshtml
 <cache expires-on="@new DateTime(2025,1,29,17,02,0)">
@@ -65,15 +57,13 @@ Example:
 </cache>
 ```
 
-- - -
-
 ### expires-after
 
-| Attribute Type |        Example Value         |
-|----------------|------------------------------|
-|    TimeSpan    | "@TimeSpan.FromSeconds(120)" |
+| Attribute Type | Example                      | Default    |
+| -------------- | ---------------------------- | ---------- |
+| `TimeSpan`     | `@TimeSpan.FromSeconds(120)` | 20 minutes |
 
-Sets the length of time from the first request time to cache the contents. 
+`expires-after` sets the length of time from the first request time to cache the contents.
 
 Example:
 
@@ -83,15 +73,15 @@ Example:
 </cache>
 ```
 
-- - -
+The Razor View Engine sets the default `expires-after` value to twenty minutes.
 
 ### expires-sliding
 
-| Attribute Type |        Example Value        |
-|----------------|-----------------------------|
-|    TimeSpan    | "@TimeSpan.FromSeconds(60)" |
+| Attribute Type | Example                     |
+| -------------- | --------------------------- |
+| `TimeSpan`     | `@TimeSpan.FromSeconds(60)` |
 
-Sets the time that a cache entry should be evicted if it has not been accessed.
+Sets the time that a cache entry should be evicted if its value hasn't been accessed.
 
 Example:
 
@@ -101,18 +91,15 @@ Example:
 </cache>
 ```
 
-- - -
-
 ### vary-by-header
 
-| Attribute Type    | Example Values                |
-|----------------   |----------------               |
-| String            | "User-Agent"                  |
-|                   | "User-Agent,content-encoding" |
+| Attribute Type | Examples                                    |
+| -------------- | ------------------------------------------- |
+| String         | `User-Agent`, `User-Agent,content-encoding` |
 
-Accepts a single header value or a comma-separated list of header values that trigger a cache refresh when they change. The following example monitors the header value `User-Agent`. The example will cache the content for every different `User-Agent` presented to the web server.
+`vary-by-header` accepts a comma-delimited list of header values that trigger a cache refresh when they change.
 
-Example:
+The following example monitors the header value `User-Agent`. The example caches the content for every different `User-Agent` presented to the web server:
 
 ```cshtml
 <cache vary-by-header="User-Agent">
@@ -120,18 +107,15 @@ Example:
 </cache>
 ```
 
-- - -
-
 ### vary-by-query
 
-| Attribute Type    | Example Values                |
-|----------------   |----------------               |
-| String            | "Make"                |
-|                   | "Make,Model" |
+| Attribute Type | Examples             |
+| -------------- | -------------------- |
+| String         | `Make`, `Make,Model` |
 
-Accepts a single header value or a comma-separated list of header values that trigger a cache refresh when the header value changes. The following example looks at the values of `Make` and `Model`.
+`vary-by-query` accepts a comma-delimited list of header values that trigger a cache refresh when the header value changes.
 
-Example:
+The following example monitors the values of `Make` and `Model`. The example caches the content for every different `Make` and `Model` presented to the web server:
 
 ```cshtml
 <cache vary-by-query="Make,Model">
@@ -139,19 +123,17 @@ Example:
 </cache>
 ```
 
-- - -
-
 ### vary-by-route
 
-| Attribute Type    | Example Values                |
-|----------------   |----------------               |
-| String            | "Make"                |
-|                   | "Make,Model" |
+| Attribute Type | Examples             |
+| -------------- | -------------------- |
+| String         | `Make`, `Make,Model` |
 
-Accepts a single header value or a comma-separated list of header values that trigger a cache refresh when the route data parameter value(s) change. 
+`vary-by-route` accepts a comma-delimited list of header values that trigger a cache refresh when the route data parameter value changes.
+
 Example:
 
-*Startup.cs* 
+*Startup.cs*:
 
 ```csharp
 routes.MapRoute(
@@ -159,7 +141,7 @@ routes.MapRoute(
     template: "{controller=Home}/{action=Index}/{Make?}/{Model?}");
 ```
 
-*Index.cshtml*
+*Index.cshtml*:
 
 ```cshtml
 <cache vary-by-route="Make,Model">
@@ -167,18 +149,15 @@ routes.MapRoute(
 </cache>
 ```
 
-- - -
-
 ### vary-by-cookie
 
-| Attribute Type    | Example Values                |
-|----------------   |----------------               |
-| String            | ".AspNetCore.Identity.Application"                |
-|                   | ".AspNetCore.Identity.Application,HairColor" |
+| Attribute Type | Examples                                                                         |
+| -------------- | -------------------------------------------------------------------------------- |
+| String         | `.AspNetCore.Identity.Application`, `.AspNetCore.Identity.Application,HairColor` |
 
-Accepts a single header value or a comma-separated list of header values that trigger a cache refresh when the header values(s) change. The following example looks at the cookie associated with ASP.NET Core Identity. When a user is authenticated the request cookie to be set which triggers a cache refresh.
+`vary-by-cookie` accepts a comma-delimited list of header values that trigger a cache refresh when the header valuess change.
 
-Example:
+The following example monitors the cookie associated with ASP.NET Core Identity. When a user is authenticated, a change in the Identity cookie triggers a cache refresh:
 
 ```cshtml
 <cache vary-by-cookie=".AspNetCore.Identity.Application">
@@ -186,20 +165,15 @@ Example:
 </cache>
 ```
 
-- - -
-
 ### vary-by-user
 
-| Attribute Type    | Example Values                |
-|----------------   |----------------               |
-| Boolean             | "true"                  |
-|                     | "false" (default) |
+| Attribute Type  | Examples        | Default |
+| --------------- | --------------- | ------- |
+| Boolean         | `true`, `false` | `true`  |
 
-Specifies whether or not the cache should reset when the logged-in user (or Context Principal) changes. The current user is also known as the Request Context Principal and can be viewed in a Razor view by referencing `@User.Identity.Name`.
+`vary-by-user` specifies whether or not the cache resets when the signed-in user (or Context Principal) changes. The current user is also known as the Request Context Principal and can be viewed in a Razor view by referencing `@User.Identity.Name`.
 
-The following example looks at the current logged in user.  
-
-Example:
+The following example monitors the current logged in user to trigger a cache refresh:
 
 ```cshtml
 <cache vary-by-user="true">
@@ -207,26 +181,22 @@ Example:
 </cache>
 ```
 
-Using this attribute maintains the contents in cache through a log-in and log-out cycle.  When using `vary-by-user="true"`, a log-in and log-out action invalidates the cache for the authenticated user.  The cache is invalidated because a new unique cookie value is generated on login. Cache is maintained for the anonymous state when no cookie is present or has expired. This means if no user is logged in, the cache will be maintained.
-
-- - -
+Using this attribute maintains the contents in cache through a sign-in and sign-out cycle. When the value is set to `true`, an authentication cycle invalidates the cache for the authenticated user. The cache is invalidated because a new unique cookie value is generated when a user is authenticated. Cache is maintained for the anonymous state when no cookie is present or the cookie has expired. This means that if no user is authenticated, the cache is maintained.
 
 ### vary-by
 
-| Attribute Type | Example Values |
-|----------------|----------------|
-|     String     |    "@Model"    |
+| Attribute Type | Example  |
+| -------------- | -------- |
+| String         | `@Model` |
 
-Allows for customization of what data gets cached. When the object referenced by the attribute's string value changes, the content of the Cache Tag Helper is updated. Often a string-concatenation of model values are assigned to this attribute.  Effectively, that means an update to any of the concatenated values invalidates the cache.
+`vary-by` allows for customization of what data is cached. When the object referenced by the attribute's string value changes, the content of the Cache Tag Helper is updated. Often, a string-concatenation of model values are assigned to this attribute. Effectively, this results in a scenario where an update to any of the concatenated values invalidates the cache.
 
-The following example assumes the controller method rendering the view sums the integer value of the two route parameters, `myParam1` and `myParam2`, and returns that as the single model property. When this sum changes, the content of the Cache Tag Helper is rendered and cached again.  
-
-Example:
+The following example assumes the controller method rendering the view sums the integer value of the two route parameters, `myParam1` and `myParam2`, and returns the sum as the single model property. When this sum changes, the content of the Cache Tag Helper is rendered and cached again.  
 
 Action:
 
 ```csharp
-public IActionResult Index(string myParam1,string myParam2,string myParam3)
+public IActionResult Index(string myParam1, string myParam2, string myParam3)
 {
     int num1;
     int num2;
@@ -236,26 +206,21 @@ public IActionResult Index(string myParam1,string myParam2,string myParam3)
 }
 ```
 
-*Index.cshtml*
+*Index.cshtml*:
 
 ```cshtml
-<cache vary-by="@Model"">
+<cache vary-by="@Model">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </cache>
 ```
 
-- - -
-
 ### priority
 
-| Attribute Type    | Example Values                |
-|----------------   |----------------               |
-| CacheItemPriority  | "High"                   |
-|                    | "Low" |
-|                    | "NeverRemove" |
-|                    | "Normal" |
+| Attribute Type      | Examples                               | Default  |
+| ------------------- | -------------------------------------- | -------- |
+| `CacheItemPriority` | `High`, `Low`, `NeverRemove`, `Normal` | `Normal` |
 
-Provides cache eviction guidance to the built-in cache provider. The web server will evict `Low` cache entries first when it's under memory pressure.
+`priority` provides cache eviction guidance to the built-in cache provider. The web server evicts `Low` cache entries first when it's under memory pressure.
 
 Example:
 
@@ -265,11 +230,11 @@ Example:
 </cache>
 ```
 
-The `priority` attribute doesn't guarantee a specific level of cache retention. `CacheItemPriority` is only a suggestion. Setting this attribute to `NeverRemove` doesn't guarantee that the cache will always be retained. See [Additional Resources](#additional-resources) for more information.
+The `priority` attribute doesn't guarantee a specific level of cache retention. `CacheItemPriority` is only a suggestion. Setting this attribute to `NeverRemove` doesn't guarantee that cached items are always retained. See the topics in the [Additional Resources](#additional-resources) section for more information.
 
-The Cache Tag Helper is dependent on the [memory cache service](xref:performance/caching/memory). The Cache Tag Helper adds the service if it has not been added.
+The Cache Tag Helper is dependent on the [memory cache service](xref:performance/caching/memory). The Cache Tag Helper adds the service if it hasn't been added.
 
 ## Additional resources
 
-* [Cache in-memory](xref:performance/caching/memory)
-* [Introduction to Identity](xref:security/authentication/identity)
+* <xref:performance/caching/memory>
+* <xref:security/authentication/identity>

--- a/aspnetcore/mvc/views/tag-helpers/built-in/distributed-cache-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/distributed-cache-tag-helper.md
@@ -9,15 +9,15 @@ uid: mvc/views/tag-helpers/builtin-th/distributed-cache-tag-helper
 ---
 # Distributed Cache Tag Helper in ASP.NET Core
 
-By [Peter Kellner](http://peterkellner.net)
+By [Peter Kellner](http://peterkellner.net) and [Luke Latham](https://github.com/guardrex)
 
 The Distributed Cache Tag Helper provides the ability to dramatically improve the performance of your ASP.NET Core app by caching its content to a distributed cache source.
 
 For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
 
-The Distributed Cache Tag Helper inherits from the same base class as the Cache Tag Helper. All attributes associated with the Cache Tag Helper also work on the Distributed Tag Helper.
+The Distributed Cache Tag Helper inherits from the same base class as the Cache Tag Helper. All of the [Cache Tag Helper](xref:mvc/views/tag-helpers/builtin-th/cache-tag-helper) attributes are available to the Distributed Tag Helper.
 
-The Distributed Cache Tag Helper follows the [Explicit Dependencies Principle](/dotnet/standard/modern-web-apps-azure-architecture/architectural-principles#explicit-dependencies) known as *constructor injection*. Specifically, the `IDistributedCache` interface container is passed into the Distributed Cache Tag Helper's constructor. If no concrete implementation of `IDistributedCache` is created in `Startup.ConfigureServices` (*Startup.cs*), the Distributed Cache Tag Helper uses the same in-memory provider for storing cached data as the basic Cache Tag Helper.
+The Distributed Cache Tag Helper uses [constructor injection](xref:fundamentals/dependency-injection#constructor-injection-behavior). The <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache> interface is passed into the Distributed Cache Tag Helper's constructor. If no concrete implementation of `IDistributedCache` is created in `Startup.ConfigureServices` (*Startup.cs*), the Distributed Cache Tag Helper uses the same in-memory provider for storing cached data as the [Cache Tag Helper](xref:mvc/views/tag-helpers/builtin-th/cache-tag-helper).
 
 ## Distributed Cache Tag Helper Attributes
 
@@ -42,7 +42,7 @@ The Distributed Cache Tag Helper inherits from the same class as Cache Tag Helpe
 | -------------- | ------------------------------------- |
 | String         | `my-distributed-cache-unique-key-101` |
 
-`name` is required. The `name` attribute is used as a key for each stored cache instance. Unlike the basic Cache Tag Helper that assigns a key to each Cache Tag Helper instance based on the Razor page name and location of the Tag Helper in the razor page, the Distributed Cache Tag Helper only bases its key on the attribute `name`.
+`name` is required. The `name` attribute is used as a key for each stored cache instance. Unlike the Cache Tag Helper that assigns a cache key to each instance based on the Razor page name and location in the Razor page, the Distributed Cache Tag Helper only bases its key on the attribute `name`.
 
 Example:
 
@@ -54,7 +54,7 @@ Example:
 
 ## Distributed Cache Tag Helper IDistributedCache implementations
 
-There are two implementations of <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache> built in to ASP.NET Core. One is based on SQL Server, and the other is based on Redis. Details of these implementations can be found at <xref:performance/caching/distributed>. Both implementations involve setting an instance of `IDistributedCache` in ASP.NET Core's *Startup.cs*.
+There are two implementations of <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache> built in to ASP.NET Core. One is based on SQL Server, and the other is based on Redis. Details of these implementations can be found at <xref:performance/caching/distributed>. Both implementations involve setting an instance of `IDistributedCache` in `Startup`.
 
 There are no tag attributes specifically associated with using any specific implementation of `IDistributedCache`.
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/distributed-cache-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/distributed-cache-tag-helper.md
@@ -3,38 +3,48 @@ title: Distributed Cache Tag Helper in ASP.NET Core
 author: pkellner
 description: Learn how to use the Distributed Cache Tag Helper.
 ms.author: riande
-ms.date: 02/14/2017
+ms.custom: mvc
+ms.date: 10/10/2018
 uid: mvc/views/tag-helpers/builtin-th/distributed-cache-tag-helper
 ---
 # Distributed Cache Tag Helper in ASP.NET Core
 
-By [Peter Kellner](http://peterkellner.net) 
+By [Peter Kellner](http://peterkellner.net)
 
 The Distributed Cache Tag Helper provides the ability to dramatically improve the performance of your ASP.NET Core app by caching its content to a distributed cache source.
 
-The Distributed Cache Tag Helper inherits from the same base class as the Cache Tag Helper. All attributes associated with the Cache Tag Helper will also work on the Distributed Tag Helper.
+For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
 
-The Distributed Cache Tag Helper follows the **Explicit Dependencies Principle** known as **Constructor Injection**. Specifically, the `IDistributedCache` interface container is passed into the Distributed Cache Tag Helper's constructor. If no specific concrete implementation of `IDistributedCache` has been created in `ConfigureServices`, usually found in startup.cs, then the Distributed Cache Tag Helper will use the same in-memory provider for storing cached data as the basic Cache Tag Helper.
+The Distributed Cache Tag Helper inherits from the same base class as the Cache Tag Helper. All attributes associated with the Cache Tag Helper also work on the Distributed Tag Helper.
+
+The Distributed Cache Tag Helper follows the [Explicit Dependencies Principle](/dotnet/standard/modern-web-apps-azure-architecture/architectural-principles#explicit-dependencies) known as *constructor injection*. Specifically, the `IDistributedCache` interface container is passed into the Distributed Cache Tag Helper's constructor. If no concrete implementation of `IDistributedCache` is created in `Startup.ConfigureServices` (*Startup.cs*), the Distributed Cache Tag Helper uses the same in-memory provider for storing cached data as the basic Cache Tag Helper.
 
 ## Distributed Cache Tag Helper Attributes
 
-- - -
+### Attributes shared with the Cache Tag Helper
 
-### enabled expires-on expires-after expires-sliding vary-by-header vary-by-query vary-by-route vary-by-cookie vary-by-user vary-by priority
+* `enabled`
+* `expires-on`
+* `expires-after`
+* `expires-sliding`
+* `vary-by-header`
+* `vary-by-query`
+* `vary-by-route`
+* `vary-by-cookie`
+* `vary-by-user`
+* `vary-by priority`
 
-See Cache Tag Helper for definitions. Distributed Cache Tag Helper inherits from the same class as Cache Tag Helper so all these attributes are common from Cache Tag Helper.
+The Distributed Cache Tag Helper inherits from the same class as Cache Tag Helper. For descriptions of these attributes, see the [Cache Tag Helper](xref:mvc/views/tag-helpers/builtin-th/cache-tag-helper).
 
-- - -
+### name
 
-### name (required)
+| Attribute Type | Example                               |
+| -------------- | ------------------------------------- |
+| String         | `my-distributed-cache-unique-key-101` |
 
-| Attribute Type 	| Example Value   	|
-|----------------	|----------------	|
-| string    | "my-distributed-cache-unique-key-101" 	|
+`name` is required. The `name` attribute is used as a key for each stored cache instance. Unlike the basic Cache Tag Helper that assigns a key to each Cache Tag Helper instance based on the Razor page name and location of the Tag Helper in the razor page, the Distributed Cache Tag Helper only bases its key on the attribute `name`.
 
-The required `name` attribute is used as a key to that cache stored for each instance of a Distributed Cache Tag Helper. Unlike the basic Cache Tag Helper that assigns a key to each Cache Tag Helper instance based on the Razor page name and location of the Tag Helper in the razor page, the Distributed Cache Tag Helper only bases its key on the attribute `name`
-
-Usage Example:
+Example:
 
 ```cshtml
 <distributed-cache name="my-distributed-cache-unique-key-101">
@@ -44,7 +54,7 @@ Usage Example:
 
 ## Distributed Cache Tag Helper IDistributedCache implementations
 
-There are two implementations of `IDistributedCache` built in to ASP.NET Core. One is based on SQL Server and the other is based on Redis. Details of these implementations can be found at <xref:performance/caching/distributed>. Both implementations involve setting an instance of `IDistributedCache` in ASP.NET Core's *Startup.cs*.
+There are two implementations of <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache> built in to ASP.NET Core. One is based on SQL Server, and the other is based on Redis. Details of these implementations can be found at <xref:performance/caching/distributed>. Both implementations involve setting an instance of `IDistributedCache` in ASP.NET Core's *Startup.cs*.
 
 There are no tag attributes specifically associated with using any specific implementation of `IDistributedCache`.
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/environment-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/environment-tag-helper.md
@@ -9,7 +9,7 @@ uid: mvc/views/tag-helpers/builtin-th/environment-tag-helper
 ---
 # Environment Tag Helper in ASP.NET Core
 
-By [Peter Kellner](http://peterkellner.net) and [Hisham Bin Ateya](https://twitter.com/hishambinateya)
+By [Peter Kellner](http://peterkellner.net), [Hisham Bin Ateya](https://twitter.com/hishambinateya), and [Luke Latham](https://github.com/guardrex)
 
 The Environment Tag Helper conditionally renders its enclosed content based on the current [hosting environment](xref:fundamentals/environments). The Environment Tag Helper's single attribute, `names`, is a comma-separated list of environment names. If any of the provided environment names match the current environment, the enclosed content is rendered.
 
@@ -21,9 +21,9 @@ For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
 
 `names` accepts a single hosting environment name or a comma-separated list of hosting environment names that trigger the rendering of the enclosed content.
 
-Environment values are compared to the current value returned from the ASP.NET Core static property [IHostingEnvironment.EnvironmentName](xref:Microsoft.AspNetCore.Hosting.IHostingEnvironment.EnvironmentName*). The comparison ignores case.
+Environment values are compared to the current value returned by [IHostingEnvironment.EnvironmentName](xref:Microsoft.AspNetCore.Hosting.IHostingEnvironment.EnvironmentName*). The comparison ignores case.
 
-The following example shows an Environment Tag Helper in use. The content is rendered if the hosting environment is Staging or Production:
+The following example uses an Environment Tag Helper. The content is rendered if the hosting environment is Staging or Production:
 
 ```cshtml
 <environment names="Staging,Production">

--- a/aspnetcore/mvc/views/tag-helpers/built-in/environment-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/environment-tag-helper.md
@@ -3,54 +3,61 @@ title: Environment Tag Helper in ASP.NET Core
 author: pkellner
 description: ASP.NET Core Environment Tag Helper defined including all properties
 ms.author: riande
-ms.date: 07/14/2017
+ms.custom: mvc
+ms.date: 10/10/2018
 uid: mvc/views/tag-helpers/builtin-th/environment-tag-helper
 ---
 # Environment Tag Helper in ASP.NET Core
 
 By [Peter Kellner](http://peterkellner.net) and [Hisham Bin Ateya](https://twitter.com/hishambinateya)
 
-The Environment Tag Helper conditionally renders its enclosed content based on the current hosting environment. Its single attribute `names` is a comma separated list of environment names, that if any match to the current environment, will trigger the enclosed content to be rendered.
+The Environment Tag Helper conditionally renders its enclosed content based on the current [hosting environment](xref:fundamentals/environments). The Environment Tag Helper's single attribute, `names`, is a comma-separated list of environment names. If any of the provided environment names match the current environment, the enclosed content is rendered.
+
+For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
 
 ## Environment Tag Helper Attributes
 
 ### names
 
-Accepts a single hosting environment name or a comma-separated list of hosting environment names that trigger the rendering of the enclosed content.
+`names` accepts a single hosting environment name or a comma-separated list of hosting environment names that trigger the rendering of the enclosed content.
 
-These value(s) are compared to the current value returned from the ASP.NET Core static property `HostingEnvironment.EnvironmentName`.  This value is one of the following: **Staging**; **Development** or **Production**. The comparison ignores case.
+Environment values are compared to the current value returned from the ASP.NET Core static property [IHostingEnvironment.EnvironmentName](xref:Microsoft.AspNetCore.Hosting.IHostingEnvironment.EnvironmentName*). The comparison ignores case.
 
-An example of a valid `environment` tag helper is:
+The following example shows an Environment Tag Helper in use. The content is rendered if the hosting environment is Staging or Production:
 
 ```cshtml
 <environment names="Staging,Production">
-  <strong>HostingEnvironment.EnvironmentName is Staging or Production</strong>
+    <strong>HostingEnvironment.EnvironmentName is Staging or Production</strong>
 </environment>
 ```
+
+::: moniker range=">= aspnetcore-2.0"
 
 ## include and exclude attributes
 
-ASP.NET Core 2.x adds the `include` & `exclude` attributes. These attributes control rendering the enclosed content based on the included or excluded hosting environment names.
+`include` & `exclude` attributes control rendering the enclosed content based on the included or excluded hosting environment names.
 
-### include ASP.NET Core 2.0 and later
+### include
 
-The `include` property has a similar behavior of the `names` attribute in ASP.NET Core 1.0.
+The `include` property exhibits similar behavior to the `names` attribute. An environment listed in the `include` attribute value must match the app's hosting environment ([IHostingEnvironment.EnvironmentName](xref:Microsoft.AspNetCore.Hosting.IHostingEnvironment.EnvironmentName*)) to render the content of the `<environment>` tag.
 
 ```cshtml
 <environment include="Staging,Production">
-  <strong>HostingEnvironment.EnvironmentName is Staging or Production</strong>
+    <strong>HostingEnvironment.EnvironmentName is Staging or Production</strong>
 </environment>
 ```
 
-### exclude ASP.NET Core 2.0 and later
+### exclude
 
-In contrast, the `exclude` property lets the `EnvironmentTagHelper` render the enclosed content for all hosting environment names except the one(s) that you specified.
+In contrast to the `include` attribute, the content of the `<environment>` tag is rendered when the hosting environment doesn't match an environment listed in the `exclude` attribute value.
 
 ```cshtml
 <environment exclude="Development">
-  <strong>HostingEnvironment.EnvironmentName is Staging or Production</strong>
+    <strong>HostingEnvironment.EnvironmentName is not Development</strong>
 </environment>
 ```
+
+::: moniker-end
 
 ## Additional resources
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/image-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/image-tag-helper.md
@@ -1,52 +1,53 @@
 ---
 title: Image Tag Helper in ASP.NET Core
 author: pkellner
-description: Shows how to work with Image Tag Helper
+description: Shows how to work with Image Tag Helper.
 ms.author: riande
-ms.date: 02/14/2017
+ms.custom: mvc
+ms.date: 10/10/2018
 uid: mvc/views/tag-helpers/builtin-th/image-tag-helper
 ---
 # Image Tag Helper in ASP.NET Core
 
-By [Peter Kellner](http://peterkellner.net) 
+By [Peter Kellner](http://peterkellner.net)
 
-The Image Tag Helper enhances the `img` (`<img>`) tag. It requires a `src` tag as well as the `boolean` attribute `asp-append-version`.
+The Image Tag Helper enhances the `<img>` tag to provide cache-busting behavior for static image files.
 
-If the image source (`src`) is a static file on the host web server, a unique cache busting string is appended as a query parameter to the image source. This ensures that if the file on the host web server changes, a unique request URL is generated that includes the updated request parameter. The cache busting string is a unique value representing the hash of the static image file.
+For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
 
-If the image source (`src`) isn't a static file (for example a remote URL or the file doesn't exist on the server), the `<img>` tag's `src` attribute is generated with no cache busting query string parameter.
+The Image Tag Helper requires a `src` attribute and the boolean attribute `asp-append-version`.
+
+If the image source (`src`) is a static file on the host web server, a unique cache busting string is appended as a query parameter to the image source. If the file on the host web server changes, a unique request URL is generated that includes the updated request parameter. The cache busting string is a unique value representing the hash of the static image file.
+
+If the image source (`src`) isn't a static file (for example, a remote URL or the file doesn't exist on the server), the `<img>` tag's `src` attribute is generated with no cache busting query string parameter.
 
 ## Image Tag Helper Attributes
 
+### src
+
+To activate the Image Tag Helper, the `src` attribute is required on the `<img>` element.
 
 ### asp-append-version
 
-When specified along with a `src` attribute, the Image Tag Helper is invoked.
+When `asp-append-version` is specified with a `true` value along with a `src` attribute, the Image Tag Helper is invoked.
 
-An example of a valid `img` tag helper is:
+The following example shows an Image Tag Helper in use:
 
 ```cshtml
-<img src="~/images/asplogo.png" 
-    asp-append-version="true"  />
+<img src="~/images/asplogo.png" asp-append-version="true" />
 ```
 
-If the static file exists in the directory *..wwwroot/images/asplogo.png* the generated html is similar to the following (the hash will be different):
+If the static file exists in the directory */wwwroot/images/*, the generated HTML is similar to the following (the hash will be different):
 
 ```html
-<img 
-    src="/images/asplogo.png?v=Kl_dqr9NVtnMdsM2MUg4qthUnWZm5T1fCEimBPWDNgM"/>
+<img src="/images/asplogo.png?v=Kl_dqr9NVtnMdsM2MUg4qthUnWZm5T1fCEimBPWDNgM" />
 ```
 
-The value assigned to the parameter `v` is the hash value of the file on disk. If the web server is unable to obtain read access to the static file referenced,  no `v` parameters is added to the `src` attribute.
+The value assigned to the parameter `v` is the hash value of the *asplogo.png* file on disk. If the web server is unable to obtain read access to the static file, no `v` parameter is added to the `src` attribute in the rendered markup.
 
-- - -
+## Hash caching behavior
 
-### src
-
-To activate the Image Tag Helper, the src attribute is required on the `<img>` element. 
-
-> [!NOTE]
-> The Image Tag Helper uses the `Cache` provider on the local web server to store the calculated `Sha512` of a given file. If the file is requested again the `Sha512` doesn't need to be recalculated. The Cache is invalidated by a file watcher that's attached to the file when the file's `Sha512` is calculated.
+The Image Tag Helper uses the cache provider on the local web server to store the calculated `Sha512` hash of a given file. If the file is requested multiple times, the hash isn't recalculated. The cache is invalidated by a file watcher that's attached to the file when the file's `Sha512` hash is calculated. When the file changes on disk, a new hash is calculated and cached.
 
 ## Additional resources
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/image-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/image-tag-helper.md
@@ -13,13 +13,14 @@ By [Peter Kellner](http://peterkellner.net)
 
 The Image Tag Helper enhances the `<img>` tag to provide cache-busting behavior for static image files.
 
+A cache-busting string is a unique value representing the hash of the static image file appended to the asset's URL. The unique string prompts clients (and some proxies) to reload the image from the host web server and not from the client's cache.
+
+If the image source (`src`) is a static file on the host web server:
+
+* A unique cache-busting string is appended as a query parameter to the image source.
+* If the file on the host web server changes, a unique request URL is generated that includes the updated request parameter.
+
 For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
-
-The Image Tag Helper requires a `src` attribute and the boolean attribute `asp-append-version`.
-
-If the image source (`src`) is a static file on the host web server, a unique cache busting string is appended as a query parameter to the image source. If the file on the host web server changes, a unique request URL is generated that includes the updated request parameter. The cache busting string is a unique value representing the hash of the static image file.
-
-If the image source (`src`) isn't a static file (for example, a remote URL or the file doesn't exist on the server), the `<img>` tag's `src` attribute is generated with no cache busting query string parameter.
 
 ## Image Tag Helper Attributes
 
@@ -27,11 +28,13 @@ If the image source (`src`) isn't a static file (for example, a remote URL or th
 
 To activate the Image Tag Helper, the `src` attribute is required on the `<img>` element.
 
+The image source (`src`) must point to a physical static file on the server. If the `src` is a remote URI, the cache-busting query string parameter isn't generated.
+
 ### asp-append-version
 
 When `asp-append-version` is specified with a `true` value along with a `src` attribute, the Image Tag Helper is invoked.
 
-The following example shows an Image Tag Helper in use:
+The following example uses an Image Tag Helper:
 
 ```cshtml
 <img src="~/images/asplogo.png" asp-append-version="true" />

--- a/aspnetcore/mvc/views/tag-helpers/built-in/index.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/index.md
@@ -12,13 +12,6 @@ uid: mvc/views/tag-helpers/builtin-th/Index
 
 By [Peter Kellner](http://peterkellner.net)
 
-Tag Helpers:
-
-* Allow server-side code to participate in rendering HTML elements in Razor files.
-* Target HTML elements based on element and attribute names.
-* Reduce explicit transitions between HTML and C# in Razor files.
-* Take advantage of the composition and tooling benefits of HTML in Integrated Development Environments (IDEs).
-
 For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
 
 > [!NOTE]

--- a/aspnetcore/mvc/views/tag-helpers/built-in/index.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/index.md
@@ -12,7 +12,12 @@ uid: mvc/views/tag-helpers/builtin-th/Index
 
 By [Peter Kellner](http://peterkellner.net)
 
-ASP.NET Core includes built-in Tag Helpers to boost your productivity. This section provides a list of the built-in Tag Helpers.
+Tag Helpers:
+
+* Allow server-side code to participate in rendering HTML elements in Razor files.
+* Target HTML elements based on element and attribute names.
+* Reduce explicit transitions between HTML and C# in Razor files.
+* Take advantage of the composition and tooling benefits of HTML in Integrated Development Environments (IDEs).
 
 For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/index.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/index.md
@@ -3,7 +3,8 @@ title: ASP.NET Core built-in Tag Helpers
 author: pkellner
 description: Find out how ASP.NET Core built-in Tag Helpers boost your productivity.
 ms.author: riande
-ms.date: 09/18/2018
+ms.custom: mvc
+ms.date: 10/10/2018
 uid: mvc/views/tag-helpers/builtin-th/Index
 ---
 
@@ -11,10 +12,12 @@ uid: mvc/views/tag-helpers/builtin-th/Index
 
 By [Peter Kellner](http://peterkellner.net)
 
-ASP.NET Core includes many built-in Tag Helpers to boost your productivity. This section provides an overview of the built-in Tag Helpers.
+ASP.NET Core includes built-in Tag Helpers to boost your productivity. This section provides a list of the built-in Tag Helpers.
+
+For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
 
 > [!NOTE]
-> There are built-in Tag Helpers which aren't discussed, since they're used internally by the [Razor](xref:mvc/views/razor) view engine. This includes a Tag Helper for the ~ character, which expands to the root path of the website.
+> There are built-in Tag Helpers which aren't described in the documentation. These Tag Helpers are used internally by the [Razor](xref:mvc/views/razor) view engine. This includes a Tag Helper for the `~` (tilde) character, which expands to the root path of the website.
 
 ## Built-in ASP.NET Core Tag Helpers
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/partial-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/partial-tag-helper.md
@@ -12,6 +12,8 @@ uid: mvc/views/tag-helpers/builtin-th/partial-tag-helper
 
 By [Scott Addie](https://github.com/scottaddie)
 
+For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
+
 [View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/mvc/views/tag-helpers/built-in/samples) ([how to download](xref:tutorials/index#how-to-download-a-sample))
 
 ## Overview

--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -174,7 +174,7 @@
 #### [Create Tag Helpers](xref:mvc/views/tag-helpers/authoring)
 #### [Use Tag Helpers in forms](xref:mvc/views/working-with-forms)
 #### [Tag Helper Components](xref:mvc/views/tag-helpers/th-components)
-#### [Built-in Tag Helpers](xref:mvc/views/tag-helpers/builtin-th/Index)
+#### Built-in Tag Helpers
 ##### [Anchor Tag Helper](xref:mvc/views/tag-helpers/builtin-th/anchor-tag-helper)
 ##### [Cache Tag Helper](xref:mvc/views/tag-helpers/builtin-th/cache-tag-helper)
 ##### [Distributed Cache Tag Helper](xref:mvc/views/tag-helpers/builtin-th/distributed-cache-tag-helper)


### PR DESCRIPTION
Fixes #8771 

* Add cross-links back out to the main TH topic early in these built-in TH topics. This helps a dev who has landed directly into a built-in TH topic from an external link get back out to the basic overview.
* Hit some of these with a UE pass.