### PR TITLE
attribute-routing-in-web-api-2, RouteOrder=>Order

### DIFF
--- a/aspnet/web-api/overview/web-api-routing-and-actions/attribute-routing-in-web-api-2.md
+++ b/aspnet/web-api/overview/web-api-routing-and-actions/attribute-routing-in-web-api-2.md
@@ -239,11 +239,11 @@ To specify the route name, set the **Name** property on the attribute. The follo
 <a id="order"></a>
 ## Route Order
 
-When the framework tries to match a URI with a route, it evaluates the routes in a particular order. To specify the order, set the **RouteOrder** property on the route attribute. Lower values are evaluated first. The default order value is zero.
+When the framework tries to match a URI with a route, it evaluates the routes in a particular order. To specify the order, set the **Order** property on the route attribute. Lower values are evaluated first. The default order value is zero.
 
 Here is how the total ordering is determined:
 
-1. Compare the **RouteOrder** property of the route attribute.
+1. Compare the **Order** property of the route attribute.
 2. Look at each URI segment in the route template. For each segment, order as follows:
 
     1. Literal segments.
@@ -265,4 +265,4 @@ These routes are ordered as follows.
 4. orders/{\*date}
 5. orders/pending
 
-Notice that "details" is a literal segment and appears before "{id}", but "pending" appears last because the **RouteOrder** property is 1. (This example assumes there are no customers named "details" or "pending". In general, try to avoid ambiguous routes. In this example, a better route template for `GetByCustomer` is "customers/{customerName}" )
+Notice that "details" is a literal segment and appears before "{id}", but "pending" appears last because the **Order** property is 1. (This example assumes there are no customers named "details" or "pending". In general, try to avoid ambiguous routes. In this example, a better route template for `GetByCustomer` is "customers/{customerName}" )


### PR DESCRIPTION
Correct property name for route ordering in RouteAttribute is Order, not RouteOrder. Replace incorrect RouteOrder property name with correct name Order

source references:
https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/RouteAttribute.cs#L40
https://github.com/ASP-NET-MVC/aspnetwebstack/blob/master/src/System.Web.Http/RouteAttribute.cs#L40
