### PR TITLE
Add GitHub auto labeler config file

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -1,0 +1,7 @@
+{
+  "labels": {
+    "product": {
+      "(?i).*": "Source - Docs.ms"
+    }
+  }
+}


### PR DESCRIPTION
Add config file to support automatic labeling for "Source - Docs.ms".