### PR TITLE
Update crud.md with fixed typo

### DIFF
--- a/aspnetcore/data/ef-rp/crud.md
+++ b/aspnetcore/data/ef-rp/crud.md
@@ -51,7 +51,7 @@ In much of the scaffolded code, [FindAsync](/dotnet/api/microsoft.entityframewor
 * Finds an entity with the primary key (PK). If an entity with the PK is being tracked by the context, it's returned without a request to the DB.
 * Is simple and concise.
 * Is optimized to look up a single entity.
-* Can have perf benefits in some situations, but they rarely happens for typical web apps.
+* Can have perf benefits in some situations, but that rarely happens for typical web apps.
 * Implicitly uses [FirstAsync](/dotnet/api/microsoft.entityframeworkcore.entityframeworkqueryableextensions.firstasync#Microsoft_EntityFrameworkCore_EntityFrameworkQueryableExtensions_FirstAsync__1_System_Linq_IQueryable___0__System_Linq_Expressions_Expression_System_Func___0_System_Boolean___System_Threading_CancellationToken_) instead of [SingleAsync](/dotnet/api/microsoft.entityframeworkcore.entityframeworkqueryableextensions.singleasync#Microsoft_EntityFrameworkCore_EntityFrameworkQueryableExtensions_SingleAsync__1_System_Linq_IQueryable___0__System_Linq_Expressions_Expression_System_Func___0_System_Boolean___System_Threading_CancellationToken_).
 
 But if you want to `Include` other entities, then `FindAsync` is no longer appropriate. This means that you may need to abandon `FindAsync` and move to a query as your app progresses.


### PR DESCRIPTION
Found a typo in the `FindAsync` section where "they" was used instead of "that".

Currently: "Can have perf benefits in some situations, but **they** rarely happens for typical web apps."
