### PR TITLE
Uncommented EnsureCreated() in DbInitializer.cs

### DIFF
--- a/aspnetcore/data/ef-rp/intro/samples/cu21/Data/DbInitializer.cs
+++ b/aspnetcore/data/ef-rp/intro/samples/cu21/Data/DbInitializer.cs
@@ -12,7 +12,7 @@ namespace ContosoUniversity.Data
     {
         public static void Initialize(SchoolContext context)
         {
-            // context.Database.EnsureCreated();
+            context.Database.EnsureCreated();
 
             // Look for any students.
             if (context.Student.Any())


### PR DESCRIPTION
In [DbInitializer.cs](https://github.com/aspnet/Docs/blob/master/aspnetcore/data/ef-rp/intro/samples/cu21/Data/DbInitializer.cs) the line of code for `context.Database.EnsureCreated();` is currently commented out. 

This doesn't seem to be an issue if simply copy-pasting the code samples throughout the tutorial, but the reader could potentially run into an error if the database is ever dropped as there would not be a check for an existing database. 

Also, further in the tutorial (see [here](https://docs.microsoft.com/en-us/aspnet/core/data/ef-rp/migrations?view=aspnetcore-2.1&tabs=visual-studio#create-an-initial-migration-and-update-the-db)), the reader is then asked to remove this line as they would have setup the use of migrations. This is a bit confusing as the line would have been commented out thus far anyway, so deleting the comment seems trivial.
