### PR TITLE
Updated help reference

### DIFF
--- a/aspnetcore/tutorials/web-api-vsc.md
+++ b/aspnetcore/tutorials/web-api-vsc.md
@@ -27,6 +27,8 @@ There are three versions of this tutorial:
 
 [!INCLUDE[prerequisites](~/includes/net-core-prereqs-vscode.md)]
 
+See [Visual Studio Code help](#visual-studio-code-help) for tips on using VS Code.
+
 ## Create the project
 
 From a console, run the following commands:
@@ -51,7 +53,7 @@ Press **Debug** (F5) to build and run the program. In a browser, navigate to htt
 ["value1","value2"]
 ```
 
-See [Visual Studio Code help](#visual-studio-code-help) for tips on using VS Code.
+
 
 ## Add support for Entity Framework Core
 


### PR DESCRIPTION
I was reviewing an issue - to me, it looks like the VS Code help reference was a bit out of place. Having it up front right under the prerequisites might be a better spot.
