### PR TITLE
List default services for Generic Host

### DIFF
--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -43,10 +43,10 @@ The Generic Host library is available in the [Microsoft.Extensions.Hosting names
 
 The following services are registered during host initialization:
 
-* [Environment](xref:fundamentals/environments) (<xref:Microsoft.AspNetCore.Hosting.IHostingEnvironment>)
+* [Environment](xref:fundamentals/environments) (<xref:Microsoft.Extensions.Hosting.IHostingEnvironment>)
 * <xref:Microsoft.Extensions.Hosting.HostBuilderContext>
 * [Configuration](xref:fundamentals/configuration/index) (<xref:Microsoft.Extensions.Configuration.IConfiguration>)
-* <xref:Microsoft.AspNetCore.Hosting.IApplicationLifetime> (<xref:Microsoft.AspNetCore.Hosting.Internal.ApplicationLifetime>)
+* <xref:Microsoft.Extensions.Hosting.IApplicationLifetime> (<xref:Microsoft.Extensions.Hosting.Internal.ApplicationLifetime>)
 * <xref:Microsoft.Extensions.Hosting.IHostLifetime> (<xref:Microsoft.Extensions.Hosting.Internal.ConsoleLifetime>)
 * <xref:Microsoft.Extensions.Hosting.IHost>
 * [Options](xref:fundamentals/configuration/options) (<xref:Microsoft.Extensions.DependencyInjection.OptionsServiceCollectionExtensions.AddOptions*>)

--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -39,6 +39,19 @@ The Generic Host library is available in the [Microsoft.Extensions.Hosting names
 
 [!code-csharp[](generic-host/samples-snapshot/2.x/GenericHostSample/Program.cs?name=snippet_HostBuilder)]
 
+## Default services
+
+The following services are registered during host initialization:
+
+* [Environment](xref:fundamentals/environments) (<xref:Microsoft.AspNetCore.Hosting.IHostingEnvironment>)
+* <xref:Microsoft.Extensions.Hosting.HostBuilderContext>
+* [Configuration](xref:fundamentals/configuration/index) (<xref:Microsoft.Extensions.Configuration.IConfiguration>)
+* <xref:Microsoft.AspNetCore.Hosting.IApplicationLifetime> (<xref:Microsoft.AspNetCore.Hosting.Internal.ApplicationLifetime>)
+* <xref:Microsoft.Extensions.Hosting.IHostLifetime> (<xref:Microsoft.Extensions.Hosting.Internal.ConsoleLifetime>)
+* <xref:Microsoft.Extensions.Hosting.IHost>
+* [Options](xref:fundamentals/configuration/options) (<xref:Microsoft.Extensions.DependencyInjection.OptionsServiceCollectionExtensions.AddOptions*>)
+* [Logging](xref:fundamentals/logging/index) (<xref:Microsoft.Extensions.DependencyInjection.LoggingServiceCollectionExtensions.AddLogging*>)
+
 ## Host configuration
 
 [HostBuilder](/dotnet/api/microsoft.extensions.hosting.hostbuilder) relies on the following approaches to set the host configuration values:

--- a/aspnetcore/fundamentals/host/generic-host/samples-snapshot/2.x/GenericHostSample/Program.cs
+++ b/aspnetcore/fundamentals/host/generic-host/samples-snapshot/2.x/GenericHostSample/Program.cs
@@ -61,7 +61,15 @@ namespace GenericHostSample
             var host = new HostBuilder()
                 .ConfigureServices((hostContext, services) =>
                 {
-                    services.AddLogging();
+                    if (hostContext.HostingEnvironment.IsDevelopment())
+                    {
+                        // Development service configuration
+                    }
+                    else
+                    {
+                        // Non-development service configuration
+                    }
+
                     services.AddHostedService<LifetimeEventsHostedService>();
                     services.AddHostedService<TimedHostedService>();
                 })

--- a/aspnetcore/fundamentals/host/generic-host/samples/2.x/GenericHostSample/Program.cs
+++ b/aspnetcore/fundamentals/host/generic-host/samples/2.x/GenericHostSample/Program.cs
@@ -30,7 +30,6 @@ namespace GenericHostSample
                 })
                 .ConfigureServices((hostContext, services) =>
                 {
-                    services.AddLogging();
                     services.AddHostedService<LifetimeEventsHostedService>();
                     services.AddHostedService<TimedHostedService>();
                 })


### PR DESCRIPTION
Fixes #8893 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-2.1&branch=pr-en-us-9061)

* Remove Logging from service config (given it's a default service).
* List the default services (too literal here? ... trimming needed??? :hocho:)