### PR TITLE
Array support with the AKV configuration provider

### DIFF
--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -65,7 +65,7 @@ When reading from a configuration source that allows keys to contain colon (`:`)
 
 Azure Key Vault keys can't use a colon as a separator. The approach described in this topic uses double dashes (`--`) as a separator for hierarchical values (sections). Array keys are stored in Azure Key Vault with double dashes and numeric key segments (`--0--`, `--1--`, … `--{n}--`).
 
-Examine the following [Serilog](https://serilog.net/) logging provider configuration provided by a JSON file. There are two object literals defined in the `WriteTo` array that reflect two Serilog *sinks*, destinations for logging output:
+Examine the following [Serilog](https://serilog.net/) logging provider configuration provided by a JSON file. There are two object literals defined in the `WriteTo` array that reflect two Serilog *sinks*, which describe destinations for logging output:
 
 ```json
 "Serilog": {

--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -57,6 +57,48 @@ When you run the app, a webpage shows the loaded secret values:
 
 ![Browser window showing secret values loaded via the Azure Key Vault Configuration Provider](key-vault-configuration/_static/sample1.png)
 
+## Bind an array to a class
+
+The provider is capable of reading configuration values into an array for binding to a POCO array.
+
+Ordinarily when reading from a configuration source into an array, a numeric key segment is used to distinguish the keys (in colon notation, `:0:`, `:1:`, … `:{n}:`). For more information, see [Configuration: Bind an array to a class](xref:fundamentals/configuration/index#bind-an-array-to-a-class).
+
+In the sample app approach described in this topic, hierarchical values (sections) use `--` (double dashes) as a separator. Array keys that include numeric key segments use the `--` (double dash) notation (`--0--`, `--1--`, … `--{n}--`).
+
+Examine the following [Serilog](https://serilog.net/) JSON file configuration. There are two `WriteTo` sinks specified in a JSON array:
+
+```json
+"Serilog": {
+  "WriteTo": [
+    {
+      "Name": "AzureTableStorage",
+      "Args": {
+        "storageTableName": "logs",
+        "connectionString": "DefaultEnd...ountKey=Eby8...GMGw=="
+      }
+    },
+    {
+      "Name": "AzureDocumentDB",
+      "Args": {
+        "endpointUrl": "https://contoso.documents.azure.com:443",
+        "authorizationKey": "Eby8...GMGw=="
+      }
+    }
+  ]
+}
+```
+
+The configuration shown in the preceding JSON file is stored in Azure Key Vault using `--` (double dash) notation and numeric segments:
+
+| Key | Value |
+| --- | ----- |
+| `Serilog--WriteTo--0--Name` | `AzureTableStorage` |
+| `Serilog--WriteTo--0--Args--storageTableName` | `logs` |
+| `Serilog--WriteTo--0--Args--connectionString` | `DefaultEnd...ountKey=Eby8...GMGw==` |
+| `Serilog--WriteTo--1--Name` | `AzureDocumentDB` |
+| `Serilog--WriteTo--1--Args--endpointUrl` | `https://contoso.documents.azure.com:443` |
+| `Serilog--WriteTo--1--Args--authorizationKey` | `Eby8...GMGw==` |
+
 ## Create prefixed key vault secrets and load configuration values (key-name-prefix-sample)
 
 `AddAzureKeyVault` also provides an overload that accepts an implementation of `IKeyVaultSecretManager`, which allows you to control how key vault secrets are converted into configuration keys. For example, you can implement the interface to load secret values based on a prefix value you provide at app startup. This allows you, for example, to load secrets based on the version of the app.

--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -61,9 +61,9 @@ When you run the app, a webpage shows the loaded secret values:
 
 The provider is capable of reading configuration values into an array for binding to a POCO array.
 
-Ordinarily when reading from a configuration source into an array, a numeric key segment is used to distinguish the keys (in colon notation, `:0:`, `:1:`, … `:{n}:`). For more information, see [Configuration: Bind an array to a class](xref:fundamentals/configuration/index#bind-an-array-to-a-class).
+When reading from a configuration source that allows keys to contain colon (`:`) separators, a numeric key segment is used to distinguish the keys that make up an array (`:0:`, `:1:`, … `:{n}:`). For more information, see [Configuration: Bind an array to a class](xref:fundamentals/configuration/index#bind-an-array-to-a-class).
 
-In the sample app approach described in this topic, hierarchical values (sections) use `--` (double dashes) as a separator. Array keys that include numeric key segments use the `--` (double dash) notation (`--0--`, `--1--`, … `--{n}--`).
+Azure Key Vault keys can't use a colon as a separator. The approach described in this topic uses double dashes (`--`) as a separator for hierarchical values (sections). Array keys are stored in Azure Key Vault with double dashes and numeric key segments (`--0--`, `--1--`, … `--{n}--`).
 
 Examine the following [Serilog](https://serilog.net/) JSON file configuration. There are two `WriteTo` sinks specified in a JSON array:
 
@@ -88,7 +88,7 @@ Examine the following [Serilog](https://serilog.net/) JSON file configuration. T
 }
 ```
 
-The configuration shown in the preceding JSON file is stored in Azure Key Vault using `--` (double dash) notation and numeric segments:
+The configuration shown in the preceding JSON file is stored in Azure Key Vault using double dash (`--`) notation and numeric segments:
 
 | Key | Value |
 | --- | ----- |

--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -5,7 +5,7 @@ description: Learn how to use the Azure Key Vault Configuration Provider to conf
 monikerRange: '>= aspnetcore-1.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/01/2018
+ms.date: 10/17/2018
 uid: security/key-vault-configuration
 ---
 # Azure Key Vault configuration provider in ASP.NET Core
@@ -65,7 +65,7 @@ When reading from a configuration source that allows keys to contain colon (`:`)
 
 Azure Key Vault keys can't use a colon as a separator. The approach described in this topic uses double dashes (`--`) as a separator for hierarchical values (sections). Array keys are stored in Azure Key Vault with double dashes and numeric key segments (`--0--`, `--1--`, … `--{n}--`).
 
-Examine the following [Serilog](https://serilog.net/) JSON file configuration. There are two `WriteTo` sinks specified in a JSON array:
+Examine the following [Serilog](https://serilog.net/) logging provider configuration provided by a JSON file. There are two object literals defined in the `WriteTo` array that reflect two Serilog *sinks*, destinations for logging output:
 
 ```json
 "Serilog": {


### PR DESCRIPTION
Fixes #8750 

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/security/key-vault-configuration?view=aspnetcore-1.1&branch=pr-en-us-9064)

Uses the explain-by-example strategy based on the issue discussion with @Jaffacakes82. JSON is familiar to devs, so a SxS show-and-tell with the AKV keys might make sense.

@Jaffacakes82, would this have worked for you?
