### PR TITLE
Move xref config to docfx.json

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -35,10 +35,7 @@
         "RestApi": "Content"
       },
       "build_entry_point": "docs",
-      "template_folder": "_themes",
-      "xref_query_tags": [
-        "/dotnet"
-      ]
+      "template_folder": "_themes"
     },
     {
       "docset_name": "aspnet-core-conceptual",

--- a/aspnet/docfx.json
+++ b/aspnet/docfx.json
@@ -35,6 +35,9 @@
     ],
     "overwrite": [],
     "externalReference": [],
+    "xrefService": [
+      "https://xref.docs.microsoft.com/query?uid={uid}"
+    ],
     "globalMetadata": {
       "_navPath": "/foo",
       "_navRel": "/foo",


### PR DESCRIPTION
Move xref config for aspnet from openpublishing config file to docfx.json file.