### PR TITLE
Add detail about serving partial views named with underscores

### DIFF
--- a/aspnetcore/mvc/views/partial.md
+++ b/aspnetcore/mvc/views/partial.md
@@ -48,7 +48,7 @@ Unlike MVC view or page rendering, a partial view doesn't run *_ViewStart.cshtml
 
 Partial view file names often begin with an underscore (`_`). This naming convention isn't required, but it helps to visually differentiate partial views from views and pages.
 
-Razor Pages doesn't serve as a page a partial view whose file name begins with an underscore. Don't rely on this behavior as a means to secure a partial view.
+Razor Pages doesn't serve as a page a partial view whose file name begins with an underscore. The inclusion of a `@page` directive in the partial view's markup doesn't change this behavior. Don't rely on this behavior as a means to secure a partial view.
 
 ::: moniker-end
 

--- a/aspnetcore/mvc/views/partial.md
+++ b/aspnetcore/mvc/views/partial.md
@@ -38,7 +38,7 @@ Don't use a partial view where complex rendering logic or code execution is requ
 
 ## Declare partial views
 
-::: moniker range=">= aspnetcore-2.1"
+::: moniker range=">= aspnetcore-2.0"
 
 A partial view is a *.cshtml* markup file maintained within the *Views* folder (MVC) or *Pages* folder (Razor Pages).
 
@@ -46,11 +46,23 @@ In ASP.NET Core MVC, a controller's <xref:Microsoft.AspNetCore.Mvc.ViewResult> i
 
 Unlike MVC view or page rendering, a partial view doesn't run *_ViewStart.cshtml*. For more information on *_ViewStart.cshtml*, see <xref:mvc/views/layout>.
 
-Partial view file names often begin with an underscore (`_`). This naming convention isn't required, but it helps to visually differentiate partial views from views and pages. When the file name starts with an underscore, Razor Pages doesn't process the markup file as a Razor Pages page, even when the file's markup includes the `@page` directive.
+Partial view file names often begin with an underscore (`_`). This naming convention isn't required, but it helps to visually differentiate partial views from views and pages.
 
 ::: moniker-end
 
-::: moniker range="< aspnetcore-2.1"
+::: moniker range="= aspnetcore-2.1"
+
+In ASP.NET Core 2.1, Razor Pages serves as a page any partial view whose file name begins with an underscore.
+
+::: moniker-end
+
+::: moniker range="= aspnetcore-2.0 || >= aspnetcore-2.2"
+
+In ASP.NET Core 2.0 and ASP.NET Core 2.2 or later, Razor Pages doesn't serve the partial view as a page. Don't rely on this behavior as a means to secure the partial views.
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.0"
 
 A partial view is a *.cshtml* markup file maintained within the *Views* folder.
 

--- a/aspnetcore/mvc/views/partial.md
+++ b/aspnetcore/mvc/views/partial.md
@@ -52,7 +52,7 @@ Partial view file names often begin with an underscore (`_`). This naming conven
 
 ::: moniker range="= aspnetcore-2.1"
 
-In ASP.NET Core 2.1, Razor Pages serves as a page any partial view whose file name begins with an underscore.
+In ASP.NET Core 2.1 only, Razor Pages serves as a page any partial view whose file name begins with an underscore.
 
 ::: moniker-end
 

--- a/aspnetcore/mvc/views/partial.md
+++ b/aspnetcore/mvc/views/partial.md
@@ -48,17 +48,7 @@ Unlike MVC view or page rendering, a partial view doesn't run *_ViewStart.cshtml
 
 Partial view file names often begin with an underscore (`_`). This naming convention isn't required, but it helps to visually differentiate partial views from views and pages.
 
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.1"
-
-In ASP.NET Core 2.1 only, Razor Pages serves as a page any partial view whose file name begins with an underscore.
-
-::: moniker-end
-
-::: moniker range="= aspnetcore-2.0 || >= aspnetcore-2.2"
-
-In ASP.NET Core 2.0 and ASP.NET Core 2.2 or later, Razor Pages doesn't serve the partial view as a page. Don't rely on this behavior as a means to secure the partial views.
+Razor Pages doesn't serve as a page a partial view whose file name begins with an underscore. Don't rely on this behavior as a means to secure a partial view.
 
 ::: moniker-end
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/Docs/issues/9073

@pranavkm I tried to make it very clear what behavior to expect in which version of ASP.NET Core.

[Internal Review Page](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/views/partial?view=aspnetcore-2.2&branch=pr-en-us-9087#declare-partial-views)