### PR TITLE
UE edit of Security considerations in ASP.NET Core SignalR

### DIFF
--- a/aspnetcore/signalr/security.md
+++ b/aspnetcore/signalr/security.md
@@ -63,12 +63,12 @@ Exception messages are generally considered sensitive data that shouldn't be rev
 
 ## Buffer management
 
-SignalR uses per-connection buffers to manage incoming and outgoing messages. By default, SignalR limits these buffers to 32 KB. The largest message a client or server can send is 32 KB. The maximum memory consumed by a connection for messages is 32 KB. If your messages are always smaller than 32 K, you can reduce the limit, which:
+SignalR uses per-connection buffers to manage incoming and outgoing messages. By default, SignalR limits these buffers to 32 KB. The largest message a client or server can send is 32 KB. The maximum memory consumed by a connection for messages is 32 KB. If your messages are always smaller than 32 KB, you can reduce the limit, which:
 
 * Prevents a client from being able to send a larger message.
 * The server will never need to allocate large buffers to accept messages.
 
-If your messages are larger than 32 K, you can increase the limit. Increasing this limit means:
+If your messages are larger than 32 KB, you can increase the limit. Increasing this limit means:
 
 * The client can cause the server to allocate large memory buffers.
 * Server allocation of large buffers may reduce the number of concurrent connections.

--- a/aspnetcore/signalr/security.md
+++ b/aspnetcore/signalr/security.md
@@ -44,7 +44,7 @@ The protections provided by CORS don't apply to WebSockets. Browsers do **not**:
 * Perform CORS pre-flight requests.
 * Respect the restrictions specified in `Access-Control` headers when making WebSocket requests.
 
-However, browsers do send the `Origin` header when issuing WebSocket requests. Applications should be configured to validate these headers in order to ensure that only WebSockets coming from the expected origins are allowed.
+However, browsers do send the `Origin` header when issuing WebSocket requests. Applications should be configured to validate these headers to ensure that only WebSockets coming from the expected origins are allowed.
 
 In ASP.NET Core 2.1 and later, header validation can be achieved using a custom middleware placed **before `UseSignalR`, and authentication middleware** in `Configure`:
 
@@ -63,12 +63,12 @@ Exception messages are generally considered sensitive data that shouldn't be rev
 
 ## Buffer management
 
-SignalR uses per-connection buffers to manage incoming and outgoing messages. By default, SignalR limits these buffers to 32KB. The largest message a client or server can send is 32KB. The maximum memory consumed by a connection for messages is 32KB. If your messages are always smaller than than 32K, you can reduce the limit, which:
+SignalR uses per-connection buffers to manage incoming and outgoing messages. By default, SignalR limits these buffers to 32 KB. The largest message a client or server can send is 32 KB. The maximum memory consumed by a connection for messages is 32 KB. If your messages are always smaller than 32 K, you can reduce the limit, which:
 
 * Prevents a client from being able to send a larger message.
 * The server will never need to allocate large buffers to accept messages.
 
-If your messages are larger than 32K, you can increase the limit. Increasing this limit means:
+If your messages are larger than 32 K, you can increase the limit. Increasing this limit means:
 
 * The client can cause the server to allocate large memory buffers.
 * Server allocation of large buffers may reduce the number of concurrent connections.

--- a/aspnetcore/signalr/security.md
+++ b/aspnetcore/signalr/security.md
@@ -32,6 +32,8 @@ For more information on configuring CORS, see [Enable Cross-Origin Requests (COR
 
 For example, the following CORS policy allows a SignalR browser client hosted on `http://example.com` to access your SignalR app:
 
+[!code-csharp[Main](security/sample/Startup.cs?name=snippet1)]
+
 ```csharp
 public void Configure(IApplicationBuilder app)
 {
@@ -66,6 +68,8 @@ The protections provided by CORS don't apply to WebSockets. Browsers do **not**:
 However, browsers do send the `Origin` header when issuing WebSocket requests.  Applications should be configured to validate these headers in order to ensure that only WebSockets coming from the origins you expect are allowed.
 
 In ASP.NET Core 2.1, header validation can be achieved using a custom middleware placed **above `UseSignalR`, and any authentication middleware** in `Configure`:
+
+[!code-csharp[Main](security/sample/Startup.cs?name=snippet2)]
 
 ```csharp
 // In Startup, add a static field listing the allowed Origin values:

--- a/aspnetcore/signalr/security.md
+++ b/aspnetcore/signalr/security.md
@@ -24,7 +24,7 @@ This article provides information on securing SignalR.
 
 CORS should be configured in the SignalR app to only allow the origin `www.example.com`.
 
-For more information on configuring CORS, see [Enable Cross-Origin Requests (CORS)](xref:security/cors). SignalR requires the following CORS policies:
+For more information on configuring CORS, see [Enable Cross-Origin Requests (CORS)](xref:security/cors). SignalR **requires** the following CORS policies:
 
 * Allow the specific expected origins. Allowing any origin is possible but is **not** secure or recommended.
 * HTTP methods `GET` and `POST` must be allowed.
@@ -78,5 +78,4 @@ There are limits for incoming and outgoing messages, both can be configured on t
 * `ApplicationMaxBufferSize` represents the maximum number of bytes from the client that the server buffers. If the client attempts to send a message larger than this limit, the connection may be closed.
 * `TransportMaxBufferSize` represents the maximum number of bytes the server can send. If the server attempts to send a message (including return values from hub methods) larger than this limit, an exception will be thrown.
 
-Setting the limit to `0` disables the limit. However, disabling the limit exposes the app malicious large message creation. Removing the limit allows a client to send a message of any size. Malicious clients sending large  
-messages can cause excess memory to be allocated. Excess memory usage can significantly reduce the number of concurrent connections.
+Setting the limit to `0` disables the limit. Removing the limit allows a client to send a message of any size. Malicious clients sending large messages can cause excess memory to be allocated. Excess memory usage can significantly reduce the number of concurrent connections.

--- a/aspnetcore/signalr/security/sample/Startup.cs
+++ b/aspnetcore/signalr/security/sample/Startup.cs
@@ -59,8 +59,8 @@ namespace SignalR_CORS
         {
             // ... other middleware ...
 
-            // Validate Origin header on WebSocket requests to prevent unexpected cross-site WebSocket 
-            // requests
+            // Validate Origin header on WebSocket requests to prevent unexpected cross-site 
+            // WebSocket requests.
             app.Use((context, next) =>
             {
                 // Check for a WebSocket request.
@@ -68,7 +68,8 @@ namespace SignalR_CORS
                 {
                     var origin = context.Request.Headers["Origin"];
 
-                    // If there is no origin header, or if the origin header doesn't match an allowed value:
+                    // If there is no origin header, or if the origin header doesn't match 
+                    // an allowed value:
                     if (string.IsNullOrEmpty(origin) && !_allowedOrigins.Contains(origin))
                     {
                         // The origin is not allowed, reject the request

--- a/aspnetcore/signalr/security/sample/Startup.cs
+++ b/aspnetcore/signalr/security/sample/Startup.cs
@@ -70,7 +70,7 @@ namespace SignalR_CORS
 
                     // If there is no origin header, or if the origin header doesn't match 
                     // an allowed value:
-                    if (string.IsNullOrEmpty(origin) && !_allowedOrigins.Contains(origin))
+                    if (!string.IsNullOrEmpty(origin) && !_allowedOrigins.Contains(origin))
                     {
                         // The origin is not allowed, reject the request
                         context.Response.StatusCode = StatusCodes.Status400BadRequest;

--- a/aspnetcore/signalr/security/sample/Startup.cs
+++ b/aspnetcore/signalr/security/sample/Startup.cs
@@ -1,0 +1,107 @@
+﻿#define snippet2 // snippet1
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SignalR_CORS
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+#if snippet1
+        #region snippet1
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            // ... other middleware ...
+
+            // Make sure the CORS middleware is ahead of SignalR.
+            app.UseCors(builder =>
+            {
+                builder.WithOrigins("http://example.com")
+                    .AllowAnyHeader()
+                    .WithMethods("GET", "POST")
+                    .AllowCredentials();
+            });
+
+            // ... other middleware ...
+
+            app.UseSignalR(routes =>
+            {
+                routes.MapHub<ChatHub>("/chatHub");
+            });
+
+            // ... other middleware ...
+        }
+
+        #endregion
+#endif
+#if snippet2
+        #region snippet2
+
+        // In Startup, add a static field listing the allowed Origin values:
+        private static readonly HashSet<string> _allowedOrigins = new HashSet<string>()
+        {
+            // Add allowed origins here. For example:
+            "http://www.mysite.com",
+            "http://mysite.com",
+        };
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            // ... other middleware ...
+
+            // Validate Origin header on WebSocket requests to prevent unexpected cross-site WebSocket 
+            // requests
+            app.Use((context, next) =>
+            {
+                // Check for a WebSocket request.
+                if (string.Equals(context.Request.Headers["Upgrade"], "websocket"))
+                {
+                    var origin = context.Request.Headers["Origin"];
+
+                    // If there is no origin header, or if the origin header doesn't match an allowed value:
+                    if (string.IsNullOrEmpty(origin) && !_allowedOrigins.Contains(origin))
+                    {
+                        // The origin is not allowed, reject the request
+                        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        return Task.CompletedTask;
+                    }
+                }
+
+                // The request is a valid Origin or not a WebSocket request, so continue.
+                return next();
+            });
+
+            // ... other middleware ...
+
+            app.UseSignalR(routes =>
+            {
+                routes.MapHub<ChatHub>("/chatHub");
+            });
+
+            // ... other middleware ...
+        }
+
+        #endregion
+#endif
+    }
+
+    public class ChatHub : Hub
+    {
+        public async Task SendMessage(string user, string message)
+        {
+            await Clients.All.SendAsync("ReceiveMessage", user, message);
+        }
+    }
+}
+
+

--- a/aspnetcore/signalr/security/sample/Startup.cs
+++ b/aspnetcore/signalr/security/sample/Startup.cs
@@ -68,7 +68,7 @@ namespace SignalR_CORS
                 {
                     var origin = context.Request.Headers["Origin"];
 
-                    // If there is no origin header, or if the origin header doesn't match 
+                    // If there is an origin header, and the origin header doesn't match 
                     // an allowed value:
                     if (!string.IsNullOrEmpty(origin) && !_allowedOrigins.Contains(origin))
                     {


### PR DESCRIPTION
[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/security?view=aspnetcore-2.1&branch=pr-en-us-9088)

- Kill long sentences. Long sentences are difficult for native speakers and impossible for MT (machine translation)
- Format code to prevent horizontal scroll bar on tablets 85 characters wide. You can simulate tablets by viewing in a browser of the maximum width that doesn't have left or right panes (TOC's).
- Prune dead wood. Avoid unnecessary words that don't add meaning to the text.
- Avoid "you" except when it make the statement more clear. 

  - For example, the following CORS policy allows a SignalR browser client hosted on `http://example.com` to access **your** SignalR app:
  -For example, the following CORS policy allows a SignalR browser client hosted on `http://example.com` to access the SignalR app hosted on `http://signalr.example.com`:
- Avoid Wikipedia links
- Code snippets

Explicit sign-off required on my security rewording below:
- [ ]  Allow cross-origin requests only from domains you trust or control. 

The following are slightly too long but I couldn't find an elegant way to shorten them (not that my other trimming was elegant):

- Applications should be configured to validate these headers to ensure that only WebSockets coming from the expected origins are allowed.