### PR TITLE
Update aspnetcore/security/authorization/razor-pages-authorization/sa…

### DIFF
--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/2.x/AuthorizationSample/Pages/Account/Login.cshtml.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/2.x/AuthorizationSample/Pages/Account/Login.cshtml.cs
@@ -87,7 +87,7 @@ namespace AuthorizationSample.Pages.Account
 
             await Task.Delay(500);
 
-            if (Input.Email == "maria.rodriguez@contoso.com")
+            if (email == "maria.rodriguez@contoso.com")
             {
                 return new ApplicationUser()
                 {


### PR DESCRIPTION
`AuthenticateUser()` now uses the passed in email parameter, instead of the Input class property.

When checking the user entered email address, the `AuthenticateUser()` method was using the bound property `Input`, which is incorrect, the method must use the `email` parameter that is passed into the method.

PS: This is my first pull request, so is the above enough information?