### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 ASP.NET Docs
 ============
 
-This project provides the source for [docs.microsoft.com/aspnet](https://docs.microsoft.com/aspnet). You can learn more about ASP.NET Core at the [Home](https://github.com/aspnet/home) repo. See the [Contributing Guide](CONTRIBUTING.md) and the [issues list](\https://github.com/aspnet/Docs/issues) if you would like to help out.
+This repository provides the ASP.NET Core and ASP.NET 4.x docs hosted at [docs.microsoft.com/aspnet](https://docs.microsoft.com/aspnet). You can learn more about ASP.NET Core at the [AspNetCore](https://github.com/aspnet/AspNetCore) repository. See the [Contributing Guide](CONTRIBUTING.md) and the [issues list](https://github.com/aspnet/Docs/issues) if you would like to help out.
 
-API PR's ( *api/autoapi/...* ) should not be made here. Changes to API documentation should be made in the source repository against the triple slash `///` comments. 
+API PR's ( *api/autoapi/...* ) should not be made here. Changes to API documentation should be made in the source repository against the triple slash `///` comments.
 
 This project has adopted the [Microsoft Open Source Code of
 Conduct](https://opensource.microsoft.com/codeofconduct/).

--- a/README.md
+++ b/README.md
@@ -1,18 +1,10 @@
+# ASP.NET Docs
+
+This repository contains the conceptual ASP.NET Core and ASP.NET 4.x documentation hosted at [docs.microsoft.com/aspnet](https://docs.microsoft.com/aspnet). Learn more about ASP.NET Core at the [AspNetCore](https://github.com/aspnet/AspNetCore) repository. See the [Contributing Guide](CONTRIBUTING.md) and the [issues list](https://github.com/aspnet/Docs/issues) if you would like to help out.
+
+API PRs (*api/autoapi/...*) shouldn't be made here. Changes to API documentation should be made in the source repository against the triple slash `///` comments.
+
 ## Microsoft Open Source Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
-ASP.NET Docs
-============
-
-This repository provides the ASP.NET Core and ASP.NET 4.x docs hosted at [docs.microsoft.com/aspnet](https://docs.microsoft.com/aspnet). You can learn more about ASP.NET Core at the [AspNetCore](https://github.com/aspnet/AspNetCore) repository. See the [Contributing Guide](CONTRIBUTING.md) and the [issues list](https://github.com/aspnet/Docs/issues) if you would like to help out.
-
-API PR's ( *api/autoapi/...* ) should not be made here. Changes to API documentation should be made in the source repository against the triple slash `///` comments.
-
-This project has adopted the [Microsoft Open Source Code of
-Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct
-FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com)
-with any additional questions or comments.
+For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ASP.NET Docs
 
-This repository contains the conceptual ASP.NET Core and ASP.NET 4.x documentation hosted at [docs.microsoft.com/aspnet](https://docs.microsoft.com/aspnet). Learn more about ASP.NET Core at the [AspNetCore](https://github.com/aspnet/AspNetCore) repository. See the [Contributing Guide](CONTRIBUTING.md) and the [issues list](https://github.com/aspnet/Docs/issues) if you would like to help out.
+This repository contains the conceptual ASP.NET Core and ASP.NET 4.x documentation hosted at [docs.microsoft.com/aspnet](https://docs.microsoft.com/aspnet). See the [Contributing Guide](CONTRIBUTING.md) and the [issues list](https://github.com/aspnet/Docs/issues) if you would like to help out.
 
-API PRs (*api/autoapi/...*) shouldn't be made here. Changes to API documentation should be made in the source repository against the triple slash `///` comments.
+API documentation changes should be made in the [ApiDocs repository](https://github.com/aspnet/ApiDocs) against the triple slash `///` comments.
 
 ## Microsoft Open Source Code of Conduct
 


### PR DESCRIPTION
**Summary of changes**
* The aspnet/Home repo was consolidated into the aspnet/AspNetCore repo (see https://github.com/aspnet/Announcements/issues/320). Updating the README file accordingly.
* Clarifying that the repo contains both ASP.NET Core and ASP.NET 4.x docs.
* Removing duplicated Code of Conduct content.