### PR TITLE
Added "Next" to "Search" button

### DIFF
--- a/aspnetcore/tutorials/razor-pages/da1.md
+++ b/aspnetcore/tutorials/razor-pages/da1.md
@@ -45,4 +45,4 @@ Select `using System.ComponentModel.DataAnnotations;`
 
 > [!div class="step-by-step"]
 > [Previous: Working with SQL Server LocalDB](xref:tutorials/razor-pages/sql)
-> [Add search](xref:tutorials/razor-pages/search)
+> [Next: Add search](xref:tutorials/razor-pages/search)


### PR DESCRIPTION
I noticed the "Next" button in this tutorial was not prefaced with `Next:` like the rest of the tutorials. This massive pull request resolves this.