### PR TITLE
fix template option error

### DIFF
--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -47,7 +47,7 @@ Create an ASP.NET Core Web Application project with Individual User Accounts.
 # [.NET Core CLI](#tab/netcore-cli)
 
 ```cli
-dotnet new webapp --auth Individual -o WebApp1
+dotnet new razor --auth Individual -o WebApp1
 ```
 
 ---


### PR DESCRIPTION
There is no such  template option named 'webapp'. we should use 'mvc' or 'razor' instead.