### PR TITLE
fix error handling if BinderModelName is null

### DIFF
--- a/aspnetcore/mvc/advanced/custom-model-binding/sample/CustomModelBindingSample/Binders/AuthorEntityBinder.cs
+++ b/aspnetcore/mvc/advanced/custom-model-binding/sample/CustomModelBindingSample/Binders/AuthorEntityBinder.cs
@@ -56,7 +56,7 @@ namespace CustomModelBindingSample.Binders
             {
                 // Non-integer arguments result in model state errors
                 bindingContext.ModelState.TryAddModelError(
-                                        bindingContext.ModelName,
+                                        modelName,
                                         "Author Id must be an integer.");
                 return Task.CompletedTask;
             }


### PR DESCRIPTION
this sample code uses a fallback if no name of the model to bind is set

```cs
            var modelName = bindingContext.BinderModelName;
            if (string.IsNullOrEmpty(modelName))
            {
                modelName = "authorId";
            }
```

if no binder name is passed and the parse of int fails too, it results in an ArgumentException because `bindingContext.BinderModelName` is null
