### PR TITLE
Update TOC to have the .NET Client API reference.

### DIFF
--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -219,7 +219,7 @@
 ### [Publish to Azure](xref:signalr/publish-to-azure-web-app)
 ## [Clients](xref:signalr/clients)
 ### [.NET client](xref:signalr/dotnet-client)
-### [.NET API reference](/dotnet/api/microsoft.aspnetcore.signalr.client?view=aspnetcore-2.1)
+### [.NET API reference](/dotnet/api/microsoft.aspnetcore.signalr.client)
 ### [Java client](xref:signalr/java-client)
 ### [Java API reference](/java/api/com.microsoft.aspnet.signalr?view=aspnet-signalr-java)
 ### [JavaScript client](xref:signalr/javascript-client)

--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -219,6 +219,7 @@
 ### [Publish to Azure](xref:signalr/publish-to-azure-web-app)
 ## [Clients](xref:signalr/clients)
 ### [.NET client](xref:signalr/dotnet-client)
+### [.NET API reference](/dotnet/api/microsoft.aspnetcore.signalr.client?view=aspnetcore-2.1)
 ### [Java client](xref:signalr/java-client)
 ### [Java API reference](/java/api/com.microsoft.aspnet.signalr?view=aspnet-signalr-java)
 ### [JavaScript client](xref:signalr/javascript-client)


### PR DESCRIPTION
Adding a line to the table of contents. We need a reference to the .NET Client API reference link here. 
