### PR TITLE
ANCM: Detect client disconnects and logging

### DIFF
--- a/aspnetcore/host-and-deploy/aspnet-core-module.md
+++ b/aspnetcore/host-and-deploy/aspnet-core-module.md
@@ -324,20 +324,20 @@ The ASP.NET Core Module provides is configurable to provide enhanced diagnostics
 </aspNetCore>
 ```
 
-Debug level (`debugLevel`) values can include both the level and the location. Multiple locations are permitted.
+Debug level (`debugLevel`) values can include both the level and the location.
 
-Levels:
+Levels (in order from least to most verbose):
 
 * ERROR
 * WARNING
 * INFO
 * TRACE
 
-Locations:
+Locations (multiple locations are permitted):
 
 * CONSOLE
-* FILE
 * EVENTLOG
+* FILE
 
 The handler settings can also be provided via environment variables:
 

--- a/aspnetcore/host-and-deploy/aspnet-core-module.md
+++ b/aspnetcore/host-and-deploy/aspnet-core-module.md
@@ -309,7 +309,7 @@ The following sample `aspNetCore` element configures stdout logging for an app h
 
 ## Enhanced diagnostic logs
 
-The ASP.NET Core Module provides is configurable to provide enhanced diagnostics logs. Add the `<handlerSettings>` element to the `<aspNetCore>` element in *web.config*. Setting the `debugLevel` to `TRACE` exposes a higher fidelity of diagnostic information. The example below is configured for an Azure Apps deployment:
+The ASP.NET Core Module provides is configurable to provide enhanced diagnostics logs. Add the `<handlerSettings>` element to the `<aspNetCore>` element in *web.config*. Setting the `debugLevel` to `TRACE` exposes a higher fidelity of diagnostic information:
 
 ```xml
 <aspNetCore processPath="dotnet"
@@ -318,7 +318,7 @@ The ASP.NET Core Module provides is configurable to provide enhanced diagnostics
     stdoutLogFile="\\?\%home%\LogFiles\stdout"
     hostingModel="inprocess">
   <handlerSettings>
-    <handlerSetting name="debugFile" value="%HOME%\LogFiles\Application\amcm.log" />
+    <handlerSetting name="debugFile" value="aspnetcore-debug.log" />
     <handlerSetting name="debugLevel" value="FILE,TRACE" />
   </handlerSettings>
 </aspNetCore>

--- a/aspnetcore/host-and-deploy/aspnet-core-module.md
+++ b/aspnetcore/host-and-deploy/aspnet-core-module.md
@@ -319,26 +319,29 @@ The ASP.NET Core Module provides is configurable to provide enhanced diagnostics
     hostingModel="inprocess">
   <handlerSettings>
     <handlerSetting name="debugFile" value="%HOME%\LogFiles\Application\amcm.log" />
-    <handlerSetting name="debugLevel" value="TRACE" />
+    <handlerSetting name="debugLevel" value="FILE,TRACE" />
   </handlerSettings>
 </aspNetCore>
 ```
 
-Debug level (`debugLevel`) values:
+Debug level (`debugLevel`) values can include both the level and the location. Multiple locations are permitted.
+
+Levels:
 
 * ERROR
 * WARNING
 * INFO
 * TRACE
+
+Locations:
+
 * CONSOLE
 * FILE
 * EVENTLOG
 
 The handler settings can also be provided via environment variables:
 
-* `ASPNETCORE_MODULE_DEBUG_FILE` &ndash; Path to the debug log file.
-  * IIS default: *aspnetcore-debug.log*
-  * Azure Apps default: *%HOME%\\LogFiles\\Application\\amcm.log*
+* `ASPNETCORE_MODULE_DEBUG_FILE` &ndash; Path to the debug log file. (Default: *aspnetcore-debug.log*)
 * `ASPNETCORE_MODULE_DEBUG` &ndash; Debug level setting.
 
 > [!WARNING]

--- a/aspnetcore/host-and-deploy/aspnet-core-module.md
+++ b/aspnetcore/host-and-deploy/aspnet-core-module.md
@@ -314,7 +314,7 @@ The ASP.NET Core Module provides is configurable to provide enhanced diagnostics
 ```xml
 <aspNetCore processPath="dotnet"
     arguments=".\MyApp.dll"
-    stdoutLogEnabled="true"
+    stdoutLogEnabled="false"
     stdoutLogFile="\\?\%home%\LogFiles\stdout"
     hostingModel="inprocess">
   <handlerSettings>

--- a/aspnetcore/host-and-deploy/aspnet-core-module.md
+++ b/aspnetcore/host-and-deploy/aspnet-core-module.md
@@ -43,6 +43,8 @@ The following characteristics apply when hosting in-process:
 
 * If setting up the app's host manually with `WebHostBuilder` (not using [CreateDefaultBuilder](xref:fundamentals/host/web-host#set-up-a-host)) and the app is ever run directly on the Kestrel server (self-hosted), call `UseKestrel` before calling `UseIISIntegration`. If the order is reversed, the host fails to start.
 
+* Client disconnects are detected. The [HttpContext.RequestAborted](xref:Microsoft.AspNetCore.Http.HttpContext.RequestAborted*) cancellation token is cancelled when the client disconnects.
+
 ### Hosting model changes
 
 If the `hostingModel` setting is changed in the *web.config* file (explained in the [Configuration with web.config](#configuration-with-webconfig) section), the module recycles the worker process for IIS.
@@ -149,7 +151,7 @@ See [Sub-application configuration](xref:host-and-deploy/iis/index#sub-applicati
 
 | Attribute | Description | Default |
 | --------- | ----------- | :-----: |
-| `arguments` | <p>Optional string attribute.</p><p>Arguments to the executable specified in **processPath**.</p>| |
+| `arguments` | <p>Optional string attribute.</p><p>Arguments to the executable specified in **processPath**.</p> | |
 | `disableStartUpErrorPage` | <p>Optional Boolean attribute.</p><p>If true, the **502.5 - Process Failure** page is suppressed, and the 502 status code page configured in the *web.config* takes precedence.</p> | `false` |
 | `forwardWindowsAuthToken` | <p>Optional Boolean attribute.</p><p>If true, the token is forwarded to the child process listening on %ASPNETCORE_PORT% as a header 'MS-ASPNETCORE-WINAUTHTOKEN' per request. It's the responsibility of that process to call CloseHandle on this token per request.</p> | `true` |
 | `hostingModel` | <p>Optional string attribute.</p><p>Specifies the hosting model as in-process (`inprocess`) or out-of-process (`outofprocess`).</p> | `outofprocess` |
@@ -300,6 +302,47 @@ The following sample `aspNetCore` element configures stdout logging for an app h
     stdoutLogFile="\\?\%home%\LogFiles\stdout">
 </aspNetCore>
 ```
+
+::: moniker-end
+
+::: moniker range=">= aspnetcore-2.2"
+
+## Enhanced diagnostic logs
+
+The ASP.NET Core Module provides is configurable to provide enhanced diagnostics logs. Add the `<handlerSettings>` element to the `<aspNetCore>` element in *web.config*. Setting the `debugLevel` to `TRACE` exposes a higher fidelity of diagnostic information. The example below is configured for an Azure Apps deployment:
+
+```xml
+<aspNetCore processPath="dotnet"
+    arguments=".\MyApp.dll"
+    stdoutLogEnabled="true"
+    stdoutLogFile="\\?\%home%\LogFiles\stdout"
+    hostingModel="inprocess">
+  <handlerSettings>
+    <handlerSetting name="debugFile" value="%HOME%\LogFiles\Application\amcm.log" />
+    <handlerSetting name="debugLevel" value="TRACE" />
+  </handlerSettings>
+</aspNetCore>
+```
+
+Debug level (`debugLevel`) values:
+
+* ERROR
+* WARNING
+* INFO
+* TRACE
+* CONSOLE
+* FILE
+* EVENTLOG
+
+The handler settings can also be provided via environment variables:
+
+* `ASPNETCORE_MODULE_DEBUG_FILE` &ndash; Path to the debug log file.
+  * IIS default: *aspnetcore-debug.log*
+  * Azure Apps default: *%HOME%\\LogFiles\\Application\\amcm.log*
+* `ASPNETCORE_MODULE_DEBUG` &ndash; Debug level setting.
+
+> [!WARNING]
+> Do **not** leave debug logging enabled in the deployment for longer than required to troubleshoot an issue. The size of the log isn't limited. Leaving the debug log enabled can exhaust the available disk space and crash the server or app service.
 
 ::: moniker-end
 


### PR DESCRIPTION
Fixes #9141 

Carrying over the question on ...

> Debug level (`debugLevel`) values:
>
> \* ERROR
> \* WARNING
> \* INFO
> \* TRACE
> \* CONSOLE
> \* FILE
> \* EVENTLOG

The first four look like logging levels, and the last three look like locations. How do I fix the coverage?