### PR TITLE
Changed to reflect default json file

### DIFF
--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/appsettings_SQLite.json
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/appsettings_SQLite.json
@@ -1,10 +1,10 @@
-﻿{
+{
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
       "Default": "Warning"
     }
   },
+  "AllowedHosts": "*",
   "ConnectionStrings": {
     "MovieContext": "Data Source=MvcMovie.db"
   }


### PR DESCRIPTION
While going through [this topic](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages-vsc/model?view=aspnetcore-2.1), I noticed that the *appsettings.json* file that is shipped with the template is different now. I updated it. With the change, the highlighted lines do not change - a nice surprise.