### PR TITLE
Implicit versioning of the All package

### DIFF
--- a/aspnetcore/client-side/bundling-and-minification/samples/BuildBundlerMinifierApp/BuildBundlerMinifierApp.csproj
+++ b/aspnetcore/client-side/bundling-and-minification/samples/BuildBundlerMinifierApp/BuildBundlerMinifierApp.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.6.362" />
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.6.362" />

--- a/aspnetcore/client-side/bundling-and-minification/samples/BuildBundlerMinifierApp/BuildBundlerMinifierApp.csproj
+++ b/aspnetcore/client-side/bundling-and-minification/samples/BuildBundlerMinifierApp/BuildBundlerMinifierApp.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.6.362" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.6.362" />

--- a/aspnetcore/client-side/spa/sample/AngularServerSideRendering/AngularServerSideRendering.csproj
+++ b/aspnetcore/client-side/spa/sample/AngularServerSideRendering/AngularServerSideRendering.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="2.0.0" />
   </ItemGroup>
 

--- a/aspnetcore/client-side/spa/sample/AngularServerSideRendering/AngularServerSideRendering.csproj
+++ b/aspnetcore/client-side/spa/sample/AngularServerSideRendering/AngularServerSideRendering.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="2.0.0" />
   </ItemGroup>
 

--- a/aspnetcore/common/samples/WebApplication1DotNetCore2.0App/WebApplication1.csproj
+++ b/aspnetcore/common/samples/WebApplication1DotNetCore2.0App/WebApplication1.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />

--- a/aspnetcore/common/samples/WebApplication1DotNetCore2.0App/WebApplication1.csproj
+++ b/aspnetcore/common/samples/WebApplication1DotNetCore2.0App/WebApplication1.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />

--- a/aspnetcore/data/ef-mvc/intro/samples/cu-final/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-mvc/intro/samples/cu-final/ContosoUniversity.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
 

--- a/aspnetcore/data/ef-mvc/intro/samples/cu-final/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-mvc/intro/samples/cu-final/ContosoUniversity.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
 

--- a/aspnetcore/data/ef-mvc/intro/samples/cu/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-mvc/intro/samples/cu/ContosoUniversity.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
 

--- a/aspnetcore/data/ef-mvc/intro/samples/cu/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-mvc/intro/samples/cu/ContosoUniversity.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
 

--- a/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part3-sorting/CU3.csproj
+++ b/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part3-sorting/CU3.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part3-sorting/CU3.csproj
+++ b/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part3-sorting/CU3.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part4-migrations/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part4-migrations/ContosoUniversity.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part4-migrations/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part4-migrations/ContosoUniversity.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part5-complex/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part5-complex/ContosoUniversity.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part5-complex/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part5-complex/ContosoUniversity.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part6-related/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part6-related/ContosoUniversity.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part6-related/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part6-related/ContosoUniversity.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part7/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part7/ContosoUniversity.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part7/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part7/ContosoUniversity.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part8/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part8/ContosoUniversity.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part8/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part8/ContosoUniversity.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/cu/ContosoUniversity.csproj
+++ b/aspnetcore/data/ef-rp/intro/samples/cu/ContosoUniversity.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.5" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Utils" Version="2.1.5" />
   </ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/cu/ContosoUniversity1_csproj.txt
+++ b/aspnetcore/data/ef-rp/intro/samples/cu/ContosoUniversity1_csproj.txt
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Utils" Version="2.0.0" />
   </ItemGroup>

--- a/aspnetcore/data/ef-rp/intro/samples/cu/ContosoUniversity1_csproj.txt
+++ b/aspnetcore/data/ef-rp/intro/samples/cu/ContosoUniversity1_csproj.txt
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Utils" Version="2.0.0" />
   </ItemGroup>

--- a/aspnetcore/fundamentals/localization/sample/Localization/Localization.csproj
+++ b/aspnetcore/fundamentals/localization/sample/Localization/Localization.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/fundamentals/localization/sample/Localization/Localization.csproj
+++ b/aspnetcore/fundamentals/localization/sample/Localization/Localization.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/fundamentals/localization/sample/POLocalization/POLocalization.csproj
+++ b/aspnetcore/fundamentals/localization/sample/POLocalization/POLocalization.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="OrchardCore.Localization.Core" Version="1.0.0-beta1-3187" />
   </ItemGroup>
 

--- a/aspnetcore/fundamentals/localization/sample/POLocalization/POLocalization.csproj
+++ b/aspnetcore/fundamentals/localization/sample/POLocalization/POLocalization.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="OrchardCore.Localization.Core" Version="1.0.0-beta1-3187" />
   </ItemGroup>
 

--- a/aspnetcore/fundamentals/metapackage.md
+++ b/aspnetcore/fundamentals/metapackage.md
@@ -37,7 +37,7 @@ The following *.csproj* file references the `Microsoft.AspNetCore.All` metapacka
 
 ## Implicit versioning
 
-In ASP.NET Core 2.x, you can specify the `Microsoft.AspNetCore.All` package reference without a version. When the version isn't specified, an implicit version is specified by the SDK (`Microsoft.NET.Sdk.Web`). We recommend relying on the implicit version specified by the SDK and not explicitly setting the version number on the package reference. If you have questions about this approach, leave a GitHub comment at the [Discussion for the Microsoft.AspNetCore.App implicit version](https://github.com/aspnet/Docs/issues/6430).
+In ASP.NET Core 2.1 or later, you can specify the `Microsoft.AspNetCore.All` package reference without a version. When the version isn't specified, an implicit version is specified by the SDK (`Microsoft.NET.Sdk.Web`). We recommend relying on the implicit version specified by the SDK and not explicitly setting the version number on the package reference. If you have questions about this approach, leave a GitHub comment at the [Discussion for the Microsoft.AspNetCore.App implicit version](https://github.com/aspnet/Docs/issues/6430).
 
 The implicit version is set to `major.minor.0` for portable apps. The shared framework roll-forward mechanism runs the app on the latest compatible version among the installed shared frameworks. To guarantee the same version is used in development, test, and production, ensure the same version of the shared framework is installed in all environments. For self-contained apps, the implicit version number is set to the `major.minor.patch` of the shared framework bundled in the installed SDK.
 

--- a/aspnetcore/fundamentals/metapackage.md
+++ b/aspnetcore/fundamentals/metapackage.md
@@ -31,13 +31,17 @@ You can use the package trimming process to remove packages that you don't use. 
 
 The following *.csproj* file references the `Microsoft.AspNetCore.All` metapackage for ASP.NET Core:
 
-[!code-xml[](metapackage/samples/Metapackage.All.Example.csproj?highlight=6)]
+[!code-xml[](metapackage/samples/Metapackage.All.Example.csproj?highlight=8)]
 
-The preceding markup represents a typical ASP.NET Core 2.0 template. It doesn't specify a version number for the `Microsoft.AspNetCore.All` package reference. When the version isn't specified, an [implicit](https://github.com/dotnet/core/blob/master/release-notes/1.0/sdk/1.0-rc3-implicit-package-refs.md) version is specified by the SDK (`Microsoft.NET.Sdk.Web`). We recommend relying on the implicit version specified by the SDK and not explicitly setting the version number on the package reference. If you have questions about this approach, leave a GitHub comment at the [Discussion for the Microsoft.AspNetCore.App implicit version](https://github.com/aspnet/Docs/issues/6430).
+::: moniker range=">= aspnetcore-2.1"
+
+## Implicit versioning
+
+In ASP.NET Core 2.x, you can specify the `Microsoft.AspNetCore.All` package reference without a version. When the version isn't specified, an implicit version is specified by the SDK (`Microsoft.NET.Sdk.Web`). We recommend relying on the implicit version specified by the SDK and not explicitly setting the version number on the package reference. If you have questions about this approach, leave a GitHub comment at the [Discussion for the Microsoft.AspNetCore.App implicit version](https://github.com/aspnet/Docs/issues/6430).
 
 The implicit version is set to `major.minor.0` for portable apps. The shared framework roll-forward mechanism runs the app on the latest compatible version among the installed shared frameworks. To guarantee the same version is used in development, test, and production, ensure the same version of the shared framework is installed in all environments. For self-contained apps, the implicit version number is set to the `major.minor.patch` of the shared framework bundled in the installed SDK.
 
-Specifying a version number on the `Microsoft.AspNetCore.All` package reference does **not** guarantee that version of the shared framework is chosen. For example, suppose version "2.0.0" is specified, but "2.0.1" is installed. In that case, the app will use "2.0.1". Although not recommended, you can disable roll forward (patch and/or minor). For more information regarding dotnet host roll-forward and how to configure its behavior, see [dotnet host roll forward](https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/roll-forward-on-no-candidate-fx.md).
+Specifying a version number on the `Microsoft.AspNetCore.All` package reference does **not** guarantee that version of the shared framework is chosen. For example, suppose version "2.1.1" is specified, but "2.1.3" is installed. In that case, the app will use "2.1.3". Although not recommended, you can disable roll forward (patch and/or minor). For more information regarding dotnet host roll-forward and how to configure its behavior, see [dotnet host roll forward](https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/roll-forward-on-no-candidate-fx.md).
 
 The project's SDK must be set to `Microsoft.NET.Sdk.Web` in the project file to use the implicit version of `Microsoft.AspNetCore.All`. When the `Microsoft.NET.Sdk` SDK is specified (`<Project Sdk="Microsoft.NET.Sdk">` at the top of the project file), the following warning is generated:
 
@@ -45,11 +49,13 @@ The project's SDK must be set to `Microsoft.NET.Sdk.Web` in the project file to 
 
 This is a known issue with the .NET Core 2.1 SDK and will be fixed in the .NET Core 2.2 SDK.
 
+::: moniker-end
+
 <a name="migrate"></a>
 
 ## Migrating from Microsoft.AspNetCore.All to Microsoft.AspNetCore.App
 
-The following packages are included in `Microsoft.AspNetCore.All` but not the `Microsoft.AspNetCore.App` package. 
+The following packages are included in `Microsoft.AspNetCore.All` but not the `Microsoft.AspNetCore.App` package.
 
 * `Microsoft.AspNetCore.ApplicationInsights.HostingStartup`
 * `Microsoft.AspNetCore.AzureAppServices.HostingStartup`

--- a/aspnetcore/fundamentals/metapackage.md
+++ b/aspnetcore/fundamentals/metapackage.md
@@ -5,10 +5,9 @@ description: The Microsoft.AspNetCore.All metapackage is not recommended for ASP
 monikerRange: '>= aspnetcore-2.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/24/2018
+ms.date: 10/25/2018
 uid: fundamentals/metapackage
 ---
-
 # Microsoft.AspNetCore.All metapackage for ASP.NET Core 2.0
 
 > [!NOTE]
@@ -33,6 +32,18 @@ You can use the package trimming process to remove packages that you don't use. 
 The following *.csproj* file references the `Microsoft.AspNetCore.All` metapackage for ASP.NET Core:
 
 [!code-xml[](metapackage/samples/Metapackage.All.Example.csproj?highlight=6)]
+
+The preceding markup represents a typical ASP.NET Core 2.0 template. It doesn't specify a version number for the `Microsoft.AspNetCore.All` package reference. When the version isn't specified, an [implicit](https://github.com/dotnet/core/blob/master/release-notes/1.0/sdk/1.0-rc3-implicit-package-refs.md) version is specified by the SDK (`Microsoft.NET.Sdk.Web`). We recommend relying on the implicit version specified by the SDK and not explicitly setting the version number on the package reference. If you have questions about this approach, leave a GitHub comment at the [Discussion for the Microsoft.AspNetCore.App implicit version](https://github.com/aspnet/Docs/issues/6430).
+
+The implicit version is set to `major.minor.0` for portable apps. The shared framework roll-forward mechanism runs the app on the latest compatible version among the installed shared frameworks. To guarantee the same version is used in development, test, and production, ensure the same version of the shared framework is installed in all environments. For self-contained apps, the implicit version number is set to the `major.minor.patch` of the shared framework bundled in the installed SDK.
+
+Specifying a version number on the `Microsoft.AspNetCore.All` package reference does **not** guarantee that version of the shared framework is chosen. For example, suppose version "2.0.0" is specified, but "2.0.1" is installed. In that case, the app will use "2.0.1". Although not recommended, you can disable roll forward (patch and/or minor). For more information regarding dotnet host roll-forward and how to configure its behavior, see [dotnet host roll forward](https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/roll-forward-on-no-candidate-fx.md).
+
+The project's SDK must be set to `Microsoft.NET.Sdk.Web` in the project file to use the implicit version of `Microsoft.AspNetCore.All`. When the `Microsoft.NET.Sdk` SDK is specified (`<Project Sdk="Microsoft.NET.Sdk">` at the top of the project file), the following warning is generated:
+
+*Warning NU1604: Project dependency Microsoft.AspNetCore.All does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.*
+
+This is a known issue with the .NET Core 2.1 SDK and will be fixed in the .NET Core 2.2 SDK.
 
 <a name="migrate"></a>
 

--- a/aspnetcore/fundamentals/metapackage/samples/Metapackage.All.Example.csproj
+++ b/aspnetcore/fundamentals/metapackage/samples/Metapackage.All.Example.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 </Project>

--- a/aspnetcore/fundamentals/metapackage/samples/Metapackage.All.Example.csproj
+++ b/aspnetcore/fundamentals/metapackage/samples/Metapackage.All.Example.csproj
@@ -1,8 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
+
 </Project>

--- a/aspnetcore/fundamentals/startup/sample/StartupFilterSample.csproj
+++ b/aspnetcore/fundamentals/startup/sample/StartupFilterSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
   
 </Project>

--- a/aspnetcore/fundamentals/startup/sample/StartupFilterSample.csproj
+++ b/aspnetcore/fundamentals/startup/sample/StartupFilterSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
   
 </Project>

--- a/aspnetcore/host-and-deploy/docker/visual-studio-tools-for-docker/samples/2.0/HelloDockerTools/HelloDockerTools.csproj
+++ b/aspnetcore/host-and-deploy/docker/visual-studio-tools-for-docker/samples/2.0/HelloDockerTools/HelloDockerTools.csproj
@@ -5,7 +5,7 @@
     <ProjectUISubcaption>.NET Core 2.0</ProjectUISubcaption>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4" />

--- a/aspnetcore/host-and-deploy/docker/visual-studio-tools-for-docker/samples/2.0/HelloDockerTools/HelloDockerTools.csproj
+++ b/aspnetcore/host-and-deploy/docker/visual-studio-tools-for-docker/samples/2.0/HelloDockerTools/HelloDockerTools.csproj
@@ -5,7 +5,7 @@
     <ProjectUISubcaption>.NET Core 2.0</ProjectUISubcaption>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4" />

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -43,7 +43,7 @@ The following project file was created with the command `dotnet new mvc`:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -43,7 +43,7 @@ The following project file was created with the command `dotnet new mvc`:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/includes/RP/code/RazorPagesMovie.csproj
+++ b/aspnetcore/includes/RP/code/RazorPagesMovie.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.1" />

--- a/aspnetcore/includes/RP/code/RazorPagesMovie.csproj
+++ b/aspnetcore/includes/RP/code/RazorPagesMovie.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.1" />

--- a/aspnetcore/migration/1x-to-2x/samples/AspNetCoreDotNetCore2App/AspNetCoreDotNetCore2App/AspNetCoreDotNetCore2App.csproj
+++ b/aspnetcore/migration/1x-to-2x/samples/AspNetCoreDotNetCore2App/AspNetCoreDotNetCore2App/AspNetCoreDotNetCore2App.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/aspnetcore/migration/1x-to-2x/samples/AspNetCoreDotNetCore2App/AspNetCoreDotNetCore2App/AspNetCoreDotNetCore2App.csproj
+++ b/aspnetcore/migration/1x-to-2x/samples/AspNetCoreDotNetCore2App/AspNetCoreDotNetCore2App/AspNetCoreDotNetCore2App.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/aspnetcore/migration/20_21/sample/WebApp20.csproj
+++ b/aspnetcore/migration/20_21/sample/WebApp20.csproj
@@ -4,7 +4,7 @@
     <UserSecretsId>aspnet-{Project Name}-{GUID}</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.4" PrivateAssets="All" />
   </ItemGroup>

--- a/aspnetcore/migration/20_21/sample/WebApp20.csproj
+++ b/aspnetcore/migration/20_21/sample/WebApp20.csproj
@@ -4,7 +4,7 @@
     <UserSecretsId>aspnet-{Project Name}-{GUID}</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.4" PrivateAssets="All" />
   </ItemGroup>

--- a/aspnetcore/migration/configuration/samples/WebApp1/src/WebApp1/WebApp1.csproj
+++ b/aspnetcore/migration/configuration/samples/WebApp1/src/WebApp1/WebApp1.csproj
@@ -8,6 +8,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 </Project>

--- a/aspnetcore/migration/configuration/samples/WebApp1/src/WebApp1/WebApp1.csproj
+++ b/aspnetcore/migration/configuration/samples/WebApp1/src/WebApp1/WebApp1.csproj
@@ -8,6 +8,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 </Project>

--- a/aspnetcore/migration/http-modules/sample/Asp.Net.Core/Asp.Net.Core.csproj
+++ b/aspnetcore/migration/http-modules/sample/Asp.Net.Core/Asp.Net.Core.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 </Project>

--- a/aspnetcore/migration/http-modules/sample/Asp.Net.Core/Asp.Net.Core.csproj
+++ b/aspnetcore/migration/http-modules/sample/Asp.Net.Core/Asp.Net.Core.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 </Project>

--- a/aspnetcore/migration/mvc/sample/WebApp1.csproj
+++ b/aspnetcore/migration/mvc/sample/WebApp1.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
- <PackageReference Include="Microsoft.AspNetCore.All" />
+ <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 </Project>

--- a/aspnetcore/migration/mvc/sample/WebApp1.csproj
+++ b/aspnetcore/migration/mvc/sample/WebApp1.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
- <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+ <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 </Project>

--- a/aspnetcore/migration/proper-to-2x/index.md
+++ b/aspnetcore/migration/proper-to-2x/index.md
@@ -26,7 +26,7 @@ Targeting .NET Core allows you to eliminate numerous explicit package references
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.All" />
+  <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
 </ItemGroup>
 ```
 

--- a/aspnetcore/migration/proper-to-2x/index.md
+++ b/aspnetcore/migration/proper-to-2x/index.md
@@ -26,7 +26,7 @@ Targeting .NET Core allows you to eliminate numerous explicit package references
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+  <PackageReference Include="Microsoft.AspNetCore.All" />
 </ItemGroup>
 ```
 

--- a/aspnetcore/migration/proper-to-2x/mvc2.md
+++ b/aspnetcore/migration/proper-to-2x/mvc2.md
@@ -32,7 +32,7 @@ Targeting .NET Core allows you to eliminate numerous explicit package references
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.All" />
+  <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
 </ItemGroup>
 ```
 

--- a/aspnetcore/migration/proper-to-2x/mvc2.md
+++ b/aspnetcore/migration/proper-to-2x/mvc2.md
@@ -32,7 +32,7 @@ Targeting .NET Core allows you to eliminate numerous explicit package references
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+  <PackageReference Include="Microsoft.AspNetCore.All" />
 </ItemGroup>
 ```
 

--- a/aspnetcore/mvc/advanced/app-parts/sample/AppPartsSample/AppPartsSample.csproj
+++ b/aspnetcore/mvc/advanced/app-parts/sample/AppPartsSample/AppPartsSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/aspnetcore/mvc/advanced/app-parts/sample/AppPartsSample/AppPartsSample.csproj
+++ b/aspnetcore/mvc/advanced/app-parts/sample/AppPartsSample/AppPartsSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/aspnetcore/mvc/controllers/routing/sample/main/WebMvcRouting.csproj
+++ b/aspnetcore/mvc/controllers/routing/sample/main/WebMvcRouting.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/mvc/controllers/routing/sample/main/WebMvcRouting.csproj
+++ b/aspnetcore/mvc/controllers/routing/sample/main/WebMvcRouting.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/mvc/controllers/testing/sample/TestingControllersSample/src/TestingControllersSample/TestingControllersSample.csproj
+++ b/aspnetcore/mvc/controllers/testing/sample/TestingControllersSample/src/TestingControllersSample/TestingControllersSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/mvc/controllers/testing/sample/TestingControllersSample/src/TestingControllersSample/TestingControllersSample.csproj
+++ b/aspnetcore/mvc/controllers/testing/sample/TestingControllersSample/src/TestingControllersSample/TestingControllersSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/mvc/models/validation/sample/ValidationSample.csproj
+++ b/aspnetcore/mvc/models/validation/sample/ValidationSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/mvc/models/validation/sample/ValidationSample.csproj
+++ b/aspnetcore/mvc/models/validation/sample/ValidationSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/mvc/views/razor/sample/RazorSample.csproj
+++ b/aspnetcore/mvc/views/razor/sample/RazorSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/mvc/views/razor/sample/RazorSample.csproj
+++ b/aspnetcore/mvc/views/razor/sample/RazorSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/mvc/views/view-components/sample/StarterViewComp/StarterViewComp.csproj
+++ b/aspnetcore/mvc/views/view-components/sample/StarterViewComp/StarterViewComp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/mvc/views/view-components/sample/StarterViewComp/StarterViewComp.csproj
+++ b/aspnetcore/mvc/views/view-components/sample/StarterViewComp/StarterViewComp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/mvc/views/view-components/sample/ViewCompFinal/ViewCompFinal.csproj
+++ b/aspnetcore/mvc/views/view-components/sample/ViewCompFinal/ViewCompFinal.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/mvc/views/view-components/sample/ViewCompFinal/ViewCompFinal.csproj
+++ b/aspnetcore/mvc/views/view-components/sample/ViewCompFinal/ViewCompFinal.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/razor-pages/index/sample/RazorPagesContacts/RazorPagesContacts.csproj
+++ b/aspnetcore/razor-pages/index/sample/RazorPagesContacts/RazorPagesContacts.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/razor-pages/index/sample/RazorPagesContacts/RazorPagesContacts.csproj
+++ b/aspnetcore/razor-pages/index/sample/RazorPagesContacts/RazorPagesContacts.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/razor-pages/index/sample/RazorPagesContacts2/RazorPagesContacts2.csproj
+++ b/aspnetcore/razor-pages/index/sample/RazorPagesContacts2/RazorPagesContacts2.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/razor-pages/index/sample/RazorPagesContacts2/RazorPagesContacts2.csproj
+++ b/aspnetcore/razor-pages/index/sample/RazorPagesContacts2/RazorPagesContacts2.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/razor-pages/index/sample/RazorPagesIntro/RazorPagesIntro.csproj
+++ b/aspnetcore/razor-pages/index/sample/RazorPagesIntro/RazorPagesIntro.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/razor-pages/index/sample/RazorPagesIntro/RazorPagesIntro.csproj
+++ b/aspnetcore/razor-pages/index/sample/RazorPagesIntro/RazorPagesIntro.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/razor-pages/upload-files/samples/1.x/RazorPagesMovie/RazorPagesMovie.csproj
+++ b/aspnetcore/razor-pages/upload-files/samples/1.x/RazorPagesMovie/RazorPagesMovie.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
     <PackageReference Include="BuildBundlerMinifier" Version="2.5.357" />
   </ItemGroup>

--- a/aspnetcore/razor-pages/upload-files/samples/1.x/RazorPagesMovie/RazorPagesMovie.csproj
+++ b/aspnetcore/razor-pages/upload-files/samples/1.x/RazorPagesMovie/RazorPagesMovie.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
     <PackageReference Include="BuildBundlerMinifier" Version="2.5.357" />
   </ItemGroup>

--- a/aspnetcore/security/anti-request-forgery/sample/MvcSample/MvcSample.csproj
+++ b/aspnetcore/security/anti-request-forgery/sample/MvcSample/MvcSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/security/anti-request-forgery/sample/MvcSample/MvcSample.csproj
+++ b/aspnetcore/security/anti-request-forgery/sample/MvcSample/MvcSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/security/authentication/identity/sample/src/ASPNETCore-IdentityDemoComplete/IdentityDemo/IdentityDemo.csproj
+++ b/aspnetcore/security/authentication/identity/sample/src/ASPNETCore-IdentityDemoComplete/IdentityDemo/IdentityDemo.csproj
@@ -7,7 +7,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/aspnetcore/security/authentication/identity/sample/src/ASPNETCore-IdentityDemoComplete/IdentityDemo/IdentityDemo.csproj
+++ b/aspnetcore/security/authentication/identity/sample/src/ASPNETCore-IdentityDemoComplete/IdentityDemo/IdentityDemo.csproj
@@ -7,7 +7,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/aspnetcore/security/authorization/resourcebased/samples/ResourceBasedAuthApp2/ResourceBasedAuthApp2.csproj
+++ b/aspnetcore/security/authorization/resourcebased/samples/ResourceBasedAuthApp2/ResourceBasedAuthApp2.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/aspnetcore/security/authorization/resourcebased/samples/ResourceBasedAuthApp2/ResourceBasedAuthApp2.csproj
+++ b/aspnetcore/security/authorization/resourcebased/samples/ResourceBasedAuthApp2/ResourceBasedAuthApp2.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/aspnetcore/security/authorization/secure-data/samples/final2/ContactManager.csproj
+++ b/aspnetcore/security/authorization/secure-data/samples/final2/ContactManager.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Utils" Version="2.0.1" />

--- a/aspnetcore/security/authorization/secure-data/samples/final2/ContactManager.csproj
+++ b/aspnetcore/security/authorization/secure-data/samples/final2/ContactManager.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Utils" Version="2.0.1" />

--- a/aspnetcore/security/authorization/secure-data/samples/starter2/ContactManager.csproj
+++ b/aspnetcore/security/authorization/secure-data/samples/starter2/ContactManager.csproj
@@ -4,7 +4,7 @@
     <UserSecretsId>aspnet-ContactManager-0DAD76F8-C053-4971-A8DF-4C55A4FF198B</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Utils" Version="2.0.1" />

--- a/aspnetcore/security/authorization/secure-data/samples/starter2/ContactManager.csproj
+++ b/aspnetcore/security/authorization/secure-data/samples/starter2/ContactManager.csproj
@@ -4,7 +4,7 @@
     <UserSecretsId>aspnet-ContactManager-0DAD76F8-C053-4971-A8DF-4C55A4FF198B</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Utils" Version="2.0.1" />

--- a/aspnetcore/tutorials/dotnet-watch/sample/WebApp/WebApp.csproj
+++ b/aspnetcore/tutorials/dotnet-watch/sample/WebApp/WebApp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/tutorials/dotnet-watch/sample/WebApp/WebApp.csproj
+++ b/aspnetcore/tutorials/dotnet-watch/sample/WebApp/WebApp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/tutorials/first-mvc-app-xplat/start-mvc/sample/MvcMovie/MvcMovie.csproj
+++ b/aspnetcore/tutorials/first-mvc-app-xplat/start-mvc/sample/MvcMovie/MvcMovie.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/tutorials/first-mvc-app-xplat/start-mvc/sample/MvcMovie/MvcMovie.csproj
+++ b/aspnetcore/tutorials/first-mvc-app-xplat/start-mvc/sample/MvcMovie/MvcMovie.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie/MvcMovie.csproj
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie/MvcMovie.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie/MvcMovie.csproj
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie/MvcMovie.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>

--- a/aspnetcore/tutorials/first-web-api/samples/2.0/TodoApi/TodoApi.csproj
+++ b/aspnetcore/tutorials/first-web-api/samples/2.0/TodoApi/TodoApi.csproj
@@ -7,7 +7,7 @@
 
   <!-- <snippet_Metapackage> -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
   <!-- </snippet_Metapackage> -->
 

--- a/aspnetcore/tutorials/first-web-api/samples/2.0/TodoApi/TodoApi.csproj
+++ b/aspnetcore/tutorials/first-web-api/samples/2.0/TodoApi/TodoApi.csproj
@@ -7,7 +7,7 @@
 
   <!-- <snippet_Metapackage> -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
   <!-- </snippet_Metapackage> -->
 

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/RazorPagesMovie.csproj
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/RazorPagesMovie.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
     <PackageReference Include="BuildBundlerMinifier" Version="2.5.357" />
   </ItemGroup>

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/RazorPagesMovie.csproj
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie/RazorPagesMovie.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
     <PackageReference Include="BuildBundlerMinifier" Version="2.5.357" />
   </ItemGroup>

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/snapshot_cli_sample/RazorPagesMovie/RazorPagesMovie.cli.csproj
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/snapshot_cli_sample/RazorPagesMovie/RazorPagesMovie.cli.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/snapshot_cli_sample/RazorPagesMovie/RazorPagesMovie.cli.csproj
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/snapshot_cli_sample/RazorPagesMovie/RazorPagesMovie.cli.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/TodoApi.csproj
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/TodoApi.csproj
@@ -13,7 +13,7 @@
   <!-- </snippet_DocumentationFileElement> -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="NSwag.AspNetCore" Version="11.19.2" />
   </ItemGroup>
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/TodoApi.csproj
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.NSwag/TodoApi.csproj
@@ -13,7 +13,7 @@
   <!-- </snippet_DocumentationFileElement> -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="NSwag.AspNetCore" Version="11.19.2" />
   </ItemGroup>
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/TodoApi.csproj
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/TodoApi.csproj
@@ -13,7 +13,7 @@
   <!-- </snippet_SuppressWarnings> -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="2.3.0" />
   </ItemGroup>
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/TodoApi.csproj
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/2.0/TodoApi.Swashbuckle/TodoApi.csproj
@@ -13,7 +13,7 @@
   <!-- </snippet_SuppressWarnings> -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="2.3.0" />
   </ItemGroup>
 

--- a/aspnetcore/web-api/action-return-types/samples/WebApiSample.Api.Pre21/WebApiSample.Api.Pre21.csproj
+++ b/aspnetcore/web-api/action-return-types/samples/WebApiSample.Api.Pre21/WebApiSample.Api.Pre21.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>  
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="2.3.0" />
   </ItemGroup>
 

--- a/aspnetcore/web-api/action-return-types/samples/WebApiSample.Api.Pre21/WebApiSample.Api.Pre21.csproj
+++ b/aspnetcore/web-api/action-return-types/samples/WebApiSample.Api.Pre21/WebApiSample.Api.Pre21.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>  
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="2.3.0" />
   </ItemGroup>
 

--- a/aspnetcore/web-api/advanced/formatting/sample/ResponseFormattingSample.csproj
+++ b/aspnetcore/web-api/advanced/formatting/sample/ResponseFormattingSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/web-api/advanced/formatting/sample/ResponseFormattingSample.csproj
+++ b/aspnetcore/web-api/advanced/formatting/sample/ResponseFormattingSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.Api.Pre21/WebApiSample.Api.Pre21.csproj
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.Api.Pre21/WebApiSample.Api.Pre21.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
   </ItemGroup>

--- a/aspnetcore/web-api/define-controller/samples/WebApiSample.Api.Pre21/WebApiSample.Api.Pre21.csproj
+++ b/aspnetcore/web-api/define-controller/samples/WebApiSample.Api.Pre21/WebApiSample.Api.Pre21.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #9219 

@JunTaoLuo Dan calls out the implicit versioning "for 2.1 SDK or later;" however, we don't usually version the doc content by SDK release. We might need to say something for this update in the passage that I'm adding to the All topic (*aspnetcore/fundamentals/metapackage.md*) about which SDK version this applies to. I don't know if that's something that you would like to do or what version to call out.

I also remove the version from the samples. We also assume that devs are using the latest SDK with our samples.