### PR TITLE
Fix status code for WebSocket origin validation

### DIFF
--- a/aspnetcore/signalr/security/sample/Startup.cs
+++ b/aspnetcore/signalr/security/sample/Startup.cs
@@ -73,7 +73,7 @@ namespace SignalR_CORS
                     if (!string.IsNullOrEmpty(origin) && !_allowedOrigins.Contains(origin))
                     {
                         // The origin is not allowed, reject the request
-                        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        context.Response.StatusCode = StatusCodes.Status403Forbidden;
                         return Task.CompletedTask;
                     }
                 }


### PR DESCRIPTION
fixes https://github.com/aspnet/Docs/issues/9246

The spec does mention that we should use `403 Forbidden` when validating the Origin. I missed that when writing the original sample :) https://tools.ietf.org/html/rfc6455#section-10.2