### PR TITLE
Use comment in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,11 @@
-When creating a new PR, please do the following and delete this template text:
+<!--
+When creating a new PR, please do the following:
 
-* Reference the issue number if there is one:
+* Reference the issue number if there is one, e.g.:
 
-  Fixes #Issue_Number
+Fixes #Issue_Number
 
-  > The "Fixes #nnn" syntax in the PR description causes
-  > GitHub to automatically close the issue when this PR is merged.
+The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.
+
+NOTE: This is a comment; please type your descriptions above or below it.
+-->


### PR DESCRIPTION
Since GitHub supports comments in pull request templates, I thought this might be a nice way to provide the text without causing anyone to have to delete it afterward. We used it on another project of mine with success, so contributing the idea back.