### PR TITLE
C47280: Missing semicolon

### DIFF
--- a/aspnet/single-page-application/overview/introduction/knockoutjs-template.md
+++ b/aspnet/single-page-application/overview/introduction/knockoutjs-template.md
@@ -157,7 +157,7 @@ The MVC controllers are also located in the Controllers folder of the solution. 
 
 [!code-cshtml[Main](knockoutjs-template/samples/sample4.cshtml)]
 
-When users are logged in, they see the main UI. Otherwise, they see the login panel. Note that this conditional rendering happens on the server side. Never try to hide sensitive content on the client side&#8212anything that you send in an HTTP response is visible to someone who is watching the raw HTTP messages.
+When users are logged in, they see the main UI. Otherwise, they see the login panel. Note that this conditional rendering happens on the server side. Never try to hide sensitive content on the client side&#8212;anything that you send in an HTTP response is visible to someone who is watching the raw HTTP messages.
 
 ## Client-Side JavaScript and Knockout.js
 


### PR DESCRIPTION
Hello, @MikeWasson,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description of the source issue: Missing semicolon at the end of the numeric entity is preventing  code to be displayed as a dash  "—"
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.



<!--
When creating a new PR, please do the following:

* Reference the issue number if there is one, e.g.:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->