### PR TITLE
C47281: Missing semicolon

### DIFF
--- a/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v3/working-with-entity-relations.md
+++ b/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v3/working-with-entity-relations.md
@@ -59,7 +59,7 @@ To support this request, add the following method to the `ProductsController` cl
 
 [!code-csharp[Main](working-with-entity-relations/samples/sample6.cs)]
 
-The *key* parameter is the key of the product. The method returns the related entity&#8212in this case, a `Supplier` instance. The method name and parameter name are both important. In general, if the navigation property is named "X", you need to add a method named "GetX". The method must take a parameter named "*key*" that matches the data type of the parent's key.
+The *key* parameter is the key of the product. The method returns the related entity&#8212;in this case, a `Supplier` instance. The method name and parameter name are both important. In general, if the navigation property is named "X", you need to add a method named "GetX". The method must take a parameter named "*key*" that matches the data type of the parent's key.
 
 It is also important to include the **[FromOdataUri]** attribute in the *key* parameter. This attribute tells Web API to use OData syntax rules when it parses the key from the request URI.
 


### PR DESCRIPTION
Hello, @MikeWasson,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description of the source issue: Missing semicolon at the end of the numeric entity is preventing  code to be displayed as a dash  "—"
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.



<!--
When creating a new PR, please do the following:

* Reference the issue number if there is one, e.g.:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->