### PR TITLE
use "SetClickTracking" method to disable clicktracking

### DIFF
--- a/aspnetcore/security/authentication/accconfirm/sample/WebPWrecover21/Services/EmailSender.cs
+++ b/aspnetcore/security/authentication/accconfirm/sample/WebPWrecover21/Services/EmailSender.cs
@@ -34,10 +34,7 @@ namespace WebPWrecover.Services
 
             // Disable click tracking.
             // See https://sendgrid.com/docs/User_Guide/Settings/tracking.html
-            msg.TrackingSettings = new TrackingSettings
-            {
-                ClickTracking = new ClickTracking { Enable = false }
-            };
+            msg.SetClickTracking(false, false);
 
             return client.SendEmailAsync(msg);
         }


### PR DESCRIPTION
use `SetClickTracking` method instead of directly accessing the public property `TrackingSettings`.

Reference #9235 
Related to #6268
