### PR TITLE
Address casing of MacOS

### DIFF
--- a/aspnetcore/tutorials/razor-pages-vsc/model.md
+++ b/aspnetcore/tutorials/razor-pages-vsc/model.md
@@ -60,7 +60,7 @@ Build the project to verify you don't have any errors.
   dotnet aspnet-codegenerator razorpage -m Movie -dc MovieContext -udl -outDir Pages\Movies --referenceScriptLibraries
   ```
 
-* **For MacOS and Linux**: Run the following command:
+* **For macOS and Linux**: Run the following command:
 
   ```console
   dotnet aspnet-codegenerator razorpage -m Movie -dc MovieContext -udl -outDir Pages/Movies --referenceScriptLibraries

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start.md
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start.md
@@ -23,7 +23,7 @@ This tutorial teaches the basics of building an ASP.NET Core Razor Pages web app
 There are three versions of this tutorial:
 
 * Windows: This tutorial
-* MacOS: [Get started with Razor Pages with Visual Studio for Mac](xref:tutorials/razor-pages-mac/razor-pages-start)
+* macOS: [Get started with Razor Pages with Visual Studio for Mac](xref:tutorials/razor-pages-mac/razor-pages-start)
 * macOS, Linux, and Windows: [Get started with ASP.NET Core Razor Pages in Visual Studio Code](xref:tutorials/razor-pages-vsc/razor-pages-start)
 
 [View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/tutorials/razor-pages/razor-pages-start/sample) ([how to download](xref:index#how-to-download-a-sample))


### PR DESCRIPTION
Change "MacOS" to the official casing of "macOS".