### PR TITLE
fix aspnet/SignalR#3190 by adding docs on cancellation in 2.2

### DIFF
--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -52,6 +52,9 @@ cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(10));
 await connection.InvokeAsync("MyLongRunningHubMethod", parameterValue, cancellationTokenSource.Token);
 ```
 
+> [!NOTE]
+> It's not possible to pass a `CancellationToken` from the JavaScript client.
+
 ## The Context object
 
 The `Hub` class has a `Context` property that contains the following properties with information about the connection:

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -35,6 +35,14 @@ Create a hub by declaring a class that inherits from `Hub`, and add public metho
 
 [!code-csharp[Create and use hubs](hubs/sample/hubs/chathub.cs?range=8-37)]
 
+::: moniker range="= aspnetcore-2.1"
+
+You can specify a return type and parameters, including complex types and arrays, as you would in any C# method. SignalR handles the serialization and deserialization of complex objects and arrays in your parameters and return values.
+
+::: moniker-end
+
+::: moniker range=">= aspnetcore-2.2"
+
 You can specify a return type and parameters, including complex types and arrays, as you would in any C# method. SignalR handles the serialization and deserialization of complex objects and arrays in your parameters and return values. You can also add a `CancellationToken` parameter to your Hub method and SignalR will link it to the client. If the client provides a `CancellationToken` when calling `SendAsync` or `InvokeAsync` and then cancels the `CancellationTokenSource` associated with that token, SignalR will send that cancellation through to the server.
 
 ```csharp
@@ -54,6 +62,8 @@ await connection.InvokeAsync("MyLongRunningHubMethod", parameterValue, cancellat
 
 > [!NOTE]
 > It's not possible to pass a `CancellationToken` from the JavaScript client.
+
+::: moniker-end
 
 ## The Context object
 

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -35,7 +35,22 @@ Create a hub by declaring a class that inherits from `Hub`, and add public metho
 
 [!code-csharp[Create and use hubs](hubs/sample/hubs/chathub.cs?range=8-37)]
 
-You can specify a return type and parameters, including complex types and arrays, as you would in any C# method. SignalR handles the serialization and deserialization of complex objects and arrays in your parameters and return values.
+You can specify a return type and parameters, including complex types and arrays, as you would in any C# method. SignalR handles the serialization and deserialization of complex objects and arrays in your parameters and return values. You can also add a `CancellationToken` parameter to your Hub method and SignalR will link it to the client. If the client provides a `CancellationToken` when calling `SendAsync` or `InvokeAsync` and then cancels the `CancellationTokenSource` associated with that token, SignalR will send that cancellation through to the server.
+
+```csharp
+// On the server
+public async Task MyLongRunningHubMethod(string parameter, CancellationToken cancellationToken)
+{
+    await SomeLongRunningTask(cancellationToken)
+}
+
+// On the client, cancel the operation if it hasn't completed after 10 seconds
+var cancellationTokenSource = new CancellationTokenSource();
+cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(10));
+
+// If the token is cancelled, an OperationCancelledException will be thrown here.
+await connection.InvokeAsync("MyLongRunningHubMethod", parameterValue, cancellationTokenSource.Token);
+```
 
 ## The Context object
 

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -35,35 +35,7 @@ Create a hub by declaring a class that inherits from `Hub`, and add public metho
 
 [!code-csharp[Create and use hubs](hubs/sample/hubs/chathub.cs?range=8-37)]
 
-::: moniker range="= aspnetcore-2.1"
-
 You can specify a return type and parameters, including complex types and arrays, as you would in any C# method. SignalR handles the serialization and deserialization of complex objects and arrays in your parameters and return values.
-
-::: moniker-end
-
-::: moniker range=">= aspnetcore-2.2"
-
-You can specify a return type and parameters, including complex types and arrays, as you would in any C# method. SignalR handles the serialization and deserialization of complex objects and arrays in your parameters and return values. You can also add a `CancellationToken` parameter to your Hub method and SignalR will link it to the client. If the client provides a `CancellationToken` when calling `SendAsync` or `InvokeAsync` and then cancels the `CancellationTokenSource` associated with that token, SignalR will send that cancellation through to the server.
-
-```csharp
-// On the server
-public async Task MyLongRunningHubMethod(string parameter, CancellationToken cancellationToken)
-{
-    await SomeLongRunningTask(cancellationToken)
-}
-
-// On the client, cancel the operation if it hasn't completed after 10 seconds
-var cancellationTokenSource = new CancellationTokenSource();
-cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(10));
-
-// If the token is cancelled, an OperationCancelledException will be thrown here.
-await connection.InvokeAsync("MyLongRunningHubMethod", parameterValue, cancellationTokenSource.Token);
-```
-
-> [!NOTE]
-> It's not possible to pass a `CancellationToken` from the JavaScript client.
-
-::: moniker-end
 
 ## The Context object
 

--- a/aspnetcore/signalr/streaming.md
+++ b/aspnetcore/signalr/streaming.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-2.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 06/07/2018
+ms.date: 11/12/2018
 uid: signalr/streaming
 ---
 

--- a/aspnetcore/signalr/streaming.md
+++ b/aspnetcore/signalr/streaming.md
@@ -49,7 +49,8 @@ The `StreamAsChannelAsync` method on `HubConnection` is used to invoke a streami
 // Call "Cancel" on this CancellationTokenSource to send a cancellation message to the server, which will trigger
 // the corresponding token in the Hub method.
 var cancellationTokenSource = new CancellationTokenSource();
-var channel = await hubConnection.StreamAsChannelAsync<int>("Counter", 10, 500, cancellationTokenSource.Token);
+var channel = await hubConnection.StreamAsChannelAsync<int>(
+    "Counter", 10, 500, cancellationTokenSource.Token);
 
 // Wait asynchronously for data to become available
 while (await channel.WaitToReadAsync())

--- a/aspnetcore/signalr/streaming.md
+++ b/aspnetcore/signalr/streaming.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-2.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 11/12/2018
+ms.date: 11/14/2018
 uid: signalr/streaming
 ---
 
@@ -46,8 +46,8 @@ The `StreamAsChannelAsync` method on `HubConnection` is used to invoke a streami
 ::: moniker range=">= aspnetcore-2.2"
 
 ```csharp
-// Call "Cancel" on this CancellationTokenSource to send a cancellation message to the server, which will trigger
-// the corresponding token in the Hub method.
+// Call "Cancel" on this CancellationTokenSource to send a cancellation message to 
+// the server, which will trigger the corresponding token in the Hub method.
 var cancellationTokenSource = new CancellationTokenSource();
 var channel = await hubConnection.StreamAsChannelAsync<int>(
     "Counter", 10, 500, cancellationTokenSource.Token);
@@ -70,7 +70,8 @@ Console.WriteLine("Streaming completed");
 ::: moniker range="= aspnetcore-2.1"
 
 ```csharp
-var channel = await hubConnection.StreamAsChannelAsync<int>("Counter", 10, 500, CancellationToken.None);
+var channel = await hubConnection
+    .StreamAsChannelAsync<int>("Counter", 10, 500, CancellationToken.None);
 
 // Wait asynchronously for data to become available
 while (await channel.WaitToReadAsync())

--- a/aspnetcore/signalr/streaming.md
+++ b/aspnetcore/signalr/streaming.md
@@ -73,7 +73,17 @@ JavaScript clients call streaming methods on hubs by using `connection.stream`. 
 
 [!code-javascript[Streaming javascript](streaming/sample/wwwroot/js/stream.js?range=19-36)]
 
+::: moniker range="= aspnetcore-2.1"
+
+To end the stream from the client, call the `dispose` method on the `ISubscription` that is returned from the `subscribe` method.
+
+::: moniker-end
+
+::: moniker range=">= aspnetcore-2.2"
+
 To end the stream from the client, call the `dispose` method on the `ISubscription` that is returned from the `subscribe` method. Calling this method will cause the `CancellationToken` parameter of the Hub method (if you provided one) to be cancelled.
+
+::: moniker-end
 
 ## Related resources
 

--- a/aspnetcore/signalr/streaming.md
+++ b/aspnetcore/signalr/streaming.md
@@ -43,6 +43,8 @@ A hub method automatically becomes a streaming hub method when it returns a `Cha
 
 The `StreamAsChannelAsync` method on `HubConnection` is used to invoke a streaming method. Pass the hub method name, and arguments defined in the hub method to `StreamAsChannelAsync`. The generic parameter on `StreamAsChannelAsync<T>` specifies the type of objects returned by the streaming method. A `ChannelReader<T>` is returned from the stream invocation, and represents the stream on the client. To read data, a common pattern is to loop over `WaitToReadAsync` and call `TryRead` when data is available. The loop will end when the stream has been closed by the server, or the cancellation token passed to `StreamAsChannelAsync` is canceled.
 
+::: moniker range=">= aspnetcore-2.2"
+
 ```csharp
 // Call "Cancel" on this CancellationTokenSource to send a cancellation message to the server, which will trigger
 // the corresponding token in the Hub method.
@@ -61,6 +63,28 @@ while (await channel.WaitToReadAsync())
 
 Console.WriteLine("Streaming completed");
 ```
+
+::: moniker-end
+
+::: moniker range="= aspnetcore-2.1"
+
+```csharp
+var channel = await hubConnection.StreamAsChannelAsync<int>("Counter", 10, 500, CancellationToken.None);
+
+// Wait asynchronously for data to become available
+while (await channel.WaitToReadAsync())
+{
+    // Read all currently available data synchronously, before waiting for more data
+    while (channel.TryRead(out var count))
+    {
+        Console.WriteLine($"{count}");
+    }
+}
+
+Console.WriteLine("Streaming completed");
+```
+
+::: moniker-end
 
 ## JavaScript client
 

--- a/aspnetcore/signalr/streaming.md
+++ b/aspnetcore/signalr/streaming.md
@@ -35,7 +35,7 @@ A hub method automatically becomes a streaming hub method when it returns a `Cha
 [!code-csharp[Streaming hub method](streaming/sample/Hubs/StreamHub.cs?range=11-35)]
 
 > [!NOTE]
-> In ASP.NET Core 2.2, Hub methods can accept a `CancellationToken` parameter that will be triggered when the client unsubscribes from the stream. Use this token to stop the server operation and release any resources if the client disconnects before the end of the stream.
+> In ASP.NET Core 2.2 or later, streaming Hub methods can accept a `CancellationToken` parameter that will be triggered when the client unsubscribes from the stream. Use this token to stop the server operation and release any resources if the client disconnects before the end of the stream.
 
 ::: moniker-end
 
@@ -81,7 +81,7 @@ To end the stream from the client, call the `dispose` method on the `ISubscripti
 
 ::: moniker range=">= aspnetcore-2.2"
 
-To end the stream from the client, call the `dispose` method on the `ISubscription` that is returned from the `subscribe` method. Calling this method will cause the `CancellationToken` parameter of the Hub method (if you provided one) to be cancelled.
+To end the stream from the client, call the `dispose` method on the `ISubscription` that is returned from the `subscribe` method. Calling this method will cause the `CancellationToken` parameter of the Hub method (if you provided one) to be canceled.
 
 ::: moniker-end
 

--- a/aspnetcore/signalr/streaming/sample/Hubs/StreamHub.aspnetcore21.cs
+++ b/aspnetcore/signalr/streaming/sample/Hubs/StreamHub.aspnetcore21.cs
@@ -15,15 +15,18 @@ namespace SignalRChat.Hubs
         {
             var channel = Channel.CreateUnbounded<int>();
 
-            // We don't want to await WriteItems, otherwise we'd end up waiting 
+            // We don't want to await WriteItemsAsync, otherwise we'd end up waiting 
             // for all the items to be written before returning the channel back to
             // the client.
-            _ = WriteItems(channel.Writer, count, delay);
+            _ = WriteItemsAsync(channel.Writer, count, delay);
 
             return channel.Reader;
         }
 
-        private async Task WriteItems(ChannelWriter<int> writer, int count, int delay)
+        private async Task WriteItemsAsync(
+            ChannelWriter<int> writer,
+            int count,
+            int delay)
         {
             for (var i = 0; i < count; i++)
             {

--- a/aspnetcore/signalr/streaming/sample/Hubs/StreamHub.aspnetcore21.cs
+++ b/aspnetcore/signalr/streaming/sample/Hubs/StreamHub.aspnetcore21.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿// This file contains the ASP.NET Core 2.1 version of this file and is no longer used in the sample.
+#if false
+using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
-using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
@@ -10,30 +11,28 @@ namespace SignalRChat.Hubs
 {
     public class StreamHub : Hub
     {
-        public ChannelReader<int> Counter(int count, int delay, CancellationToken cancellationToken)
+        public ChannelReader<int> Counter(int count, int delay)
         {
             var channel = Channel.CreateUnbounded<int>();
 
             // We don't want to await WriteItems, otherwise we'd end up waiting 
             // for all the items to be written before returning the channel back to
             // the client.
-            _ = WriteItems(channel.Writer, count, delay, cancellationToken);
+            _ = WriteItems(channel.Writer, count, delay);
 
             return channel.Reader;
         }
 
-        private async Task WriteItems(ChannelWriter<int> writer, int count, int delay, CancellationToken cancellationToken)
+        private async Task WriteItems(ChannelWriter<int> writer, int count, int delay)
         {
             for (var i = 0; i < count; i++)
             {
-                // Check the cancellation token regularly so that the server will stop
-                // producing items if the client disconnects.
-                cancellationToken.ThrowIfCancellationRequested();
                 await writer.WriteAsync(i);
-                await Task.Delay(delay, cancellationToken);
+                await Task.Delay(delay);
             }
 
             writer.TryComplete();
         }
     }
 }
+#endif

--- a/aspnetcore/signalr/streaming/sample/Hubs/StreamHub.aspnetcore21.cs
+++ b/aspnetcore/signalr/streaming/sample/Hubs/StreamHub.aspnetcore21.cs
@@ -1,4 +1,4 @@
-﻿// This file contains the ASP.NET Core 2.1 version of this file and is no longer used in the sample.
+﻿// This file contains the ASP.NET Core 2.1 version of this file and is no longer used in the sample, hence we use '#if false' to avoid compiling it.
 #if false
 using System;
 using System.Collections.Generic;

--- a/aspnetcore/signalr/streaming/sample/Hubs/StreamHub.cs
+++ b/aspnetcore/signalr/streaming/sample/Hubs/StreamHub.cs
@@ -10,7 +10,10 @@ namespace SignalRChat.Hubs
 {
     public class StreamHub : Hub
     {
-        public ChannelReader<int> Counter(int count, int delay, CancellationToken cancellationToken)
+        public ChannelReader<int> Counter(
+            int count,
+            int delay,
+            CancellationToken cancellationToken)
         {
             var channel = Channel.CreateUnbounded<int>();
 
@@ -22,7 +25,11 @@ namespace SignalRChat.Hubs
             return channel.Reader;
         }
 
-        private async Task WriteItems(ChannelWriter<int> writer, int count, int delay, CancellationToken cancellationToken)
+        private async Task WriteItems(
+            ChannelWriter<int> writer,
+            int count,
+            int delay,
+            CancellationToken cancellationToken)
         {
             for (var i = 0; i < count; i++)
             {

--- a/aspnetcore/signalr/streaming/sample/Hubs/StreamHub.cs
+++ b/aspnetcore/signalr/streaming/sample/Hubs/StreamHub.cs
@@ -17,15 +17,15 @@ namespace SignalRChat.Hubs
         {
             var channel = Channel.CreateUnbounded<int>();
 
-            // We don't want to await WriteItems, otherwise we'd end up waiting 
+            // We don't want to await WriteItemsAsync, otherwise we'd end up waiting 
             // for all the items to be written before returning the channel back to
             // the client.
-            _ = WriteItems(channel.Writer, count, delay, cancellationToken);
+            _ = WriteItemsAsync(channel.Writer, count, delay, cancellationToken);
 
             return channel.Reader;
         }
 
-        private async Task WriteItems(
+        private async Task WriteItemsAsync(
             ChannelWriter<int> writer,
             int count,
             int delay,
@@ -37,6 +37,9 @@ namespace SignalRChat.Hubs
                 // producing items if the client disconnects.
                 cancellationToken.ThrowIfCancellationRequested();
                 await writer.WriteAsync(i);
+
+                // Use the cancellationToken in other APIs that accept cancellation
+                // tokens so the cancellation can flow down to them.
                 await Task.Delay(delay, cancellationToken);
             }
 


### PR DESCRIPTION
fixes aspnet/SignalR#3190

ASP.NET Core SignalR now has support for a CancellationToken in Hub methods. This updates our docs to show that support in the ASP.NET Core 2.2 version of the docs

My first time using `:::moniker range`, and I think it's appropriate here. We'll see if I did it right :)

| Review Links | 2.1 | 2.2 |
| ------------ | --- | --- |
| ~~Hubs API~~ | ~~[Link](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/hubs?view=aspnetcore-2.1&branch=pr-en-us-9346)~~ | ~~[Link](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/hubs?view=aspnetcore-2.2&branch=pr-en-us-9346)~~ |
| Streaming | [Link](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/streaming?view=aspnetcore-2.1&branch=pr-en-us-9346) | [Link](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/streaming?view=aspnetcore-2.2&branch=pr-en-us-9346) |