### PR TITLE
Remove an erroneous namespace declaration

### DIFF
--- a/aspnet/web-api/overview/formats-and-model-binding/media-formatters/samples/sample4.cs
+++ b/aspnet/web-api/overview/formats-and-model-binding/media-formatters/samples/sample4.cs
@@ -1,4 +1,3 @@
-namespace ProductStore.Formatters
 using System;
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
namespace ProductStore.Formatters was declared 2 times; 1 time in the first line and 1 time in line 9.