### PR TITLE
Enhance hosting startup library language

### DIFF
--- a/aspnetcore/fundamentals/host/platform-specific-configuration.md
+++ b/aspnetcore/fundamentals/host/platform-specific-configuration.md
@@ -118,10 +118,10 @@ In the creation of a dynamic hosting startup:
 
 * A hosting startup assembly is created from the console app without an entry point that:
   * Includes a class that contains the `IHostingStartup` implementation.
-  * Includes a [HostingStartup](/dotnet/api/microsoft.aspnetcore.hosting.hostingstartupattribute) attribute to identify the class as an implementation of `IHostingStartup`.
+  * Includes a [HostingStartup](/dotnet/api/microsoft.aspnetcore.hosting.hostingstartupattribute) attribute to identify the `IHostingStartup` implementation class.
 * The console app is published to obtain the hosting startup's dependencies. A consequence of publishing the console app is that unused dependencies are trimmed from the dependencies file.
-* The hosting startup assembly is referenced in the pulished app's dependencies file. 
-* The hosting startup assembly and its dependencies file is placed into the runtime package store. To discover the hosting startup assembly and its dependencies file, they're referenced in a pair of environment variables.
+* The dependencies file is modified to set the runtime location of the hosting startup assembly.
+* The hosting startup assembly and its dependencies file is placed into the runtime package store. To discover the hosting startup assembly and its dependencies file, they're listed in a pair of environment variables.
 
 The console app references the [Microsoft.AspNetCore.Hosting.Abstractions](https://www.nuget.org/packages/Microsoft.AspNetCore.Hosting.Abstractions/) package:
 

--- a/aspnetcore/fundamentals/host/platform-specific-configuration.md
+++ b/aspnetcore/fundamentals/host/platform-specific-configuration.md
@@ -107,19 +107,21 @@ The app's Index page reads and renders the configuration values for the two keys
 
 *This approach is only available for .NET Core apps, not .NET Framework.*
 
-A dynamic hosting startup enhancement that doesn't require a compile-time reference for activation can be provided in a console app without an entry point that contains a `HostingStartup` attribute. Publishing the console app produces an *implementation library* that can be consumed from the runtime store.
+A dynamic hosting startup enhancement that doesn't require a compile-time reference for activation can be provided in a console app without an entry point that contains a `HostingStartup` attribute. Publishing the console app produces a hosting startup assembly that can be consumed from the runtime store.
 
 A console app without an entry point is used in this process because:
 
-* A dependencies file is required to consume the hosting startup. A dependencies file is a runnable app asset that's produced by publishing an app, not a library.
+* A dependencies file is required to consume the hosting startup in the hosting startup assembly. A dependencies file is a runnable app asset that's produced by publishing an app, not a library.
 * A library can't be added directly to the [runtime package store](/dotnet/core/deploying/runtime-store), which requires a runnable project that targets the shared runtime.
 
 In the creation of a dynamic hosting startup:
 
-* An *implementation library* is created from the class that contains the `IHostingStartup`. The implementation library is treated as a normal package.
-* The implementation library is referenced in the console app's dependencies file. 
+* A hosting startup assembly is created from the console app without an entry point that:
+  * Includes a class that contains the `IHostingStartup` implementation.
+  * Includes a [HostingStartup](/dotnet/api/microsoft.aspnetcore.hosting.hostingstartupattribute) attribute to identify the class as an implementation of `IHostingStartup`.
 * The console app is published to obtain the hosting startup's dependencies. A consequence of publishing the console app is that unused dependencies are trimmed from the dependencies file.
-* The app and its dependencies file is placed into the runtime package store. To discover the hosting startup assembly and its dependencies file, they're referenced in a pair of environment variables.
+* The hosting startup assembly is referenced in the pulished app's dependencies file. 
+* The hosting startup assembly and its dependencies file is placed into the runtime package store. To discover the hosting startup assembly and its dependencies file, they're referenced in a pair of environment variables.
 
 The console app references the [Microsoft.AspNetCore.Hosting.Abstractions](https://www.nuget.org/packages/Microsoft.AspNetCore.Hosting.Abstractions/) package:
 

--- a/aspnetcore/fundamentals/host/platform-specific-configuration.md
+++ b/aspnetcore/fundamentals/host/platform-specific-configuration.md
@@ -5,7 +5,7 @@ description: Discover how to enhance an ASP.NET Core app from an external assemb
 monikerRange: '>= aspnetcore-2.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/13/2018
+ms.date: 11/02/2018
 uid: fundamentals/configuration/platform-specific-configuration
 ---
 # Enhance an app from an external assembly in ASP.NET Core with IHostingStartup
@@ -107,14 +107,19 @@ The app's Index page reads and renders the configuration values for the two keys
 
 *This approach is only available for .NET Core apps, not .NET Framework.*
 
-A dynamic hosting startup enhancement that doesn't require a compile-time reference for activation can be provided in a console app without an entry point. The app contains a `HostingStartup` attribute. To create a dynamic hosting startup:
+A dynamic hosting startup enhancement that doesn't require a compile-time reference for activation can be provided in a console app without an entry point that contains a `HostingStartup` attribute. Publishing the console app produces an *implementation library* that can be consumed from the runtime store.
 
-1. An implementation library is created from the class that contains the `IHostingStartup` implementation. The implementation library is treated as a normal package.
-1. A console app without an entry point references the implementation library package. A console app is used because:
-   * A dependencies file is a runnable app asset, so a library can't furnish a dependencies file.
-   * A library can't be added directly to the [runtime package store](/dotnet/core/deploying/runtime-store), which requires a runnable project that targets the shared runtime.
-1. The console app is published to obtain the hosting startup's dependencies. A consequence of publishing the console app is that unused dependencies are trimmed from the dependencies file.
-1. The app and its dependencies file is placed into the runtime package store. To discover the hosting startup assembly and its dependencies file, they're referenced in a pair of environment variables.
+A console app without an entry point is used in this process because:
+
+* A dependencies file is required to consume the hosting startup. A dependencies file is a runnable app asset that's produced by publishing an app, not a library.
+* A library can't be added directly to the [runtime package store](/dotnet/core/deploying/runtime-store), which requires a runnable project that targets the shared runtime.
+
+In the creation of a dynamic hosting startup:
+
+* An *implementation library* is created from the class that contains the `IHostingStartup`. The implementation library is treated as a normal package.
+* The implementation library is referenced in the console app's dependencies file. 
+* The console app is published to obtain the hosting startup's dependencies. A consequence of publishing the console app is that unused dependencies are trimmed from the dependencies file.
+* The app and its dependencies file is placed into the runtime package store. To discover the hosting startup assembly and its dependencies file, they're referenced in a pair of environment variables.
 
 The console app references the [Microsoft.AspNetCore.Hosting.Abstractions](https://www.nuget.org/packages/Microsoft.AspNetCore.Hosting.Abstractions/) package:
 


### PR DESCRIPTION
Fixes #9402 

[Internal Review Topic (Console app without an entry point section)](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/host/platform-specific-configuration?view=aspnetcore-2.0&branch=pr-en-us-9404#console-app-without-an-entry-point)
* Reorganize the content for the hosting startup lib.
* Attempt to remove *implementation library* language and refer to publishing the console app and the hosting startup assembly instead.

@toryb, this might be (probably is) a bit rough on first redraft of the original language. See if this clarifies it ... is it still confusing? If so, where is it going wrong?