### PR TITLE
Replace missing JS file in sample app

### DIFF
--- a/aspnetcore/client-side/bundling-and-minification/samples/BuildBundlerMinifierApp/wwwroot/js/site.min.js
+++ b/aspnetcore/client-side/bundling-and-minification/samples/BuildBundlerMinifierApp/wwwroot/js/site.min.js
@@ -1,0 +1,1 @@
+AddAltToImg=function(t,a){var r=$(t,a);r.attr("alt",r.attr("id").replace(/ID/,""))};


### PR DESCRIPTION
To resolve a recent build warning showing up on PRs:

> Cannot  resolve  '../client-side/bundling-and-minification/samples/BuildBundlerMinifierApp/wwwroot/js/site.min.js'  relative to 'client-side/bundling-and-minification.md'.