### PR TITLE
WebSocket Origin Restriction

### DIFF
--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -148,7 +148,7 @@ The protections provided by CORS don't apply to WebSockets. Browsers do **not**:
 
 However, browsers do send the `Origin` header when issuing WebSocket requests. Applications should be configured to validate these headers to ensure that only WebSockets coming from the expected origins are allowed.
 
-If you are hosting your server on "https://server.com" and hosting your client on "https://client.com", add "https://client.com" to the `AllowedOrigins` list for WebSockets to verify.
+If you're hosting your server on "https://server.com" and hosting your client on "https://client.com", add "https://client.com" to the `AllowedOrigins` list for WebSockets to verify.
 
 ```csharp
 app.UseWebSockets(new WebSocketOptions()

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -81,7 +81,7 @@ The following settings can be configured:
 
 * `KeepAliveInterval` - How frequently to send "ping" frames to the client to ensure proxies keep the connection open. The default is two minutes.
 * `ReceiveBufferSize` - The size of the buffer used to receive data. Advanced users may need to change this for performance tuning based on the size of the data. The default is 4 KB.
-* `AllowedOrigins` - List of the Origin header values allowed for WebSocket requests to prevent cross-site WebSocket hijacking. By default, all origins are allowed.
+* `AllowedOrigins` - A list of allowed Origin header values for WebSocket requests. By default, all origins are allowed. See "WebSocket origin restriction" below for details.
 
 ::: moniker-end
 

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -150,7 +150,7 @@ However, browsers do send the `Origin` header when issuing WebSocket requests. A
 
 If you are hosting your server on "https://server.com" and hosting your client on "https://client.com", add "https://client.com" to the `AllowedOrigins` list for WebSockets to verify.
 
-```c#
+```csharp
 app.UseWebSockets(new WebSocketOptions()
 {
     AllowedOrigins.Add("https://client.com");

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -71,7 +71,7 @@ Add the WebSockets middleware in the `Configure` method of the `Startup` class:
 The following settings can be configured:
 
 * `KeepAliveInterval` - How frequently to send "ping" frames to the client to ensure proxies keep the connection open. The default is two minutes.
-* `ReceiveBufferSize` - The size of the buffer used to receive data. Advanced users may need to change this for performance tuning based on the size of the data. The default is 4kb.
+* `ReceiveBufferSize` - The size of the buffer used to receive data. Advanced users may need to change this for performance tuning based on the size of the data. The default is 4 KB.
 
 ::: moniker-end
 
@@ -80,8 +80,8 @@ The following settings can be configured:
 The following settings can be configured:
 
 * `KeepAliveInterval` - How frequently to send "ping" frames to the client to ensure proxies keep the connection open. The default is two minutes.
-* `ReceiveBufferSize` - The size of the buffer used to receive data. Advanced users may need to change this for performance tuning based on the size of the data. The default is 4kb.
-* `AllowedOrigins`    - List of the Origin header values allowed for WebSocket requests to prevent cross-site WebSocket hijacking. By default, all origins are allowed.
+* `ReceiveBufferSize` - The size of the buffer used to receive data. Advanced users may need to change this for performance tuning based on the size of the data. The default is 4 KB.
+* `AllowedOrigins` - List of the Origin header values allowed for WebSocket requests to prevent cross-site WebSocket hijacking. By default, all origins are allowed.
 
 ::: moniker-end
 

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -70,8 +70,8 @@ Add the WebSockets middleware in the `Configure` method of the `Startup` class:
 
 The following settings can be configured:
 
-* `KeepAliveInterval` - How frequently to send "ping" frames to the client to ensure proxies keep the connection open.
-* `ReceiveBufferSize` - The size of the buffer used to receive data. Advanced users may need to change this for performance tuning based on the size of the data.
+* `KeepAliveInterval` - How frequently to send "ping" frames to the client to ensure proxies keep the connection open. The default is two minutes.
+* `ReceiveBufferSize` - The size of the buffer used to receive data. Advanced users may need to change this for performance tuning based on the size of the data. The default is 4kb.
 
 ::: moniker-end
 
@@ -79,9 +79,9 @@ The following settings can be configured:
 
 The following settings can be configured:
 
-* `KeepAliveInterval` - How frequently to send "ping" frames to the client to ensure proxies keep the connection open.
-* `ReceiveBufferSize` - The size of the buffer used to receive data. Advanced users may need to change this for performance tuning based on the size of the data.
-* `AllowedOrigins`    - List of the Origin header values allowed for WebSocket requests to prevent Cross-Site WebSocket Hijacking. By default all Origins are allowed.
+* `KeepAliveInterval` - How frequently to send "ping" frames to the client to ensure proxies keep the connection open. The default is two minutes.
+* `ReceiveBufferSize` - The size of the buffer used to receive data. Advanced users may need to change this for performance tuning based on the size of the data. The default is 4kb.
+* `AllowedOrigins`    - List of the Origin header values allowed for WebSocket requests to prevent cross-site WebSocket hijacking. By default all Origins are allowed.
 
 ::: moniker-end
 
@@ -139,7 +139,7 @@ When accepting the WebSocket connection before beginning the loop, the middlewar
 
 ::: moniker range=">= aspnetcore-2.2"
 
-### WebSocket Origin Restriction
+### WebSocket origin restriction
 
 The protections provided by CORS don't apply to WebSockets. Browsers do **not**:
 
@@ -157,10 +157,8 @@ app.UseWebSockets(new WebSocketOptions()
 });
 ```
 
-This helps ensure that browser users are using a trusted client and not a malicious one from a different site.
-
 > [!NOTE]
-> The `Origin` header is controlled by the client and, like the `Referer` header, can be faked. These headers should **not** be used as an authentication mechanism.
+> The `Origin` header is controlled by the client and, like the `Referer` header, can be faked. Do **not** use these headers as an authentication mechanism.
 
 ::: moniker-end
 

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -66,10 +66,24 @@ Add the WebSockets middleware in the `Configure` method of the `Startup` class:
 
 ::: moniker-end
 
+::: moniker range="< aspnetcore-2.2"
+
 The following settings can be configured:
 
 * `KeepAliveInterval` - How frequently to send "ping" frames to the client to ensure proxies keep the connection open.
 * `ReceiveBufferSize` - The size of the buffer used to receive data. Advanced users may need to change this for performance tuning based on the size of the data.
+
+::: moniker-end
+
+::: moniker range=">= aspnetcore-2.2"
+
+The following settings can be configured:
+
+* `KeepAliveInterval` - How frequently to send "ping" frames to the client to ensure proxies keep the connection open.
+* `ReceiveBufferSize` - The size of the buffer used to receive data. Advanced users may need to change this for performance tuning based on the size of the data.
+* `AllowedOrigins`    - List of the Origin header values allowed for WebSocket requests to prevent Cross-Site WebSocket Hijacking. By default all Origins are allowed.
+
+::: moniker-end
 
 ::: moniker range=">= aspnetcore-2.0"
 
@@ -122,6 +136,29 @@ The code shown earlier that accepts the WebSocket request passes the `WebSocket`
 ::: moniker-end
 
 When accepting the WebSocket connection before beginning the loop, the middleware pipeline ends. Upon closing the socket, the pipeline unwinds. That is, the request stops moving forward in the pipeline when the WebSocket is accepted. When the loop is finished and the socket is closed, the request proceeds back up the pipeline.
+
+### WebSocket Origin Restriction
+
+The protections provided by CORS don't apply to WebSockets. Browsers do **not**:
+
+* Perform CORS pre-flight requests.
+* Respect the restrictions specified in `Access-Control` headers when making WebSocket requests.
+
+However, browsers do send the `Origin` header when issuing WebSocket requests. Applications should be configured to validate these headers to ensure that only WebSockets coming from the expected origins are allowed.
+
+If you are hosting your server on "https://server.com" and hosting your client on "https://client.com", add "https://client.com" to the `AllowedOrigins` list for WebSockets to verify.
+
+```c#
+app.UseWebSockets(new WebSocketOptions()
+{
+    AllowedOrigins.Add("https://client.com");
+});
+```
+
+This helps ensure that browser users are using a trusted client and not a malicious one from a different site.
+
+> [!NOTE]
+> The `Origin` header is controlled by the client and, like the `Referer` header, can be faked. These headers should **not** be used as an authentication mechanism.
 
 ## IIS/IIS Express support
 

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -137,6 +137,8 @@ The code shown earlier that accepts the WebSocket request passes the `WebSocket`
 
 When accepting the WebSocket connection before beginning the loop, the middleware pipeline ends. Upon closing the socket, the pipeline unwinds. That is, the request stops moving forward in the pipeline when the WebSocket is accepted. When the loop is finished and the socket is closed, the request proceeds back up the pipeline.
 
+::: moniker range=">= aspnetcore-2.2"
+
 ### WebSocket Origin Restriction
 
 The protections provided by CORS don't apply to WebSockets. Browsers do **not**:
@@ -159,6 +161,8 @@ This helps ensure that browser users are using a trusted client and not a malici
 
 > [!NOTE]
 > The `Origin` header is controlled by the client and, like the `Referer` header, can be faked. These headers should **not** be used as an authentication mechanism.
+
+::: moniker-end
 
 ## IIS/IIS Express support
 

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -5,7 +5,7 @@ description: Learn how to get started with WebSockets in ASP.NET Core.
 monikerRange: '>= aspnetcore-1.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 06/28/2018
+ms.date: 11/06/2018
 uid: fundamentals/websockets
 ---
 # WebSockets support in ASP.NET Core

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -154,6 +154,7 @@ If you are hosting your server on "https://server.com" and hosting your client o
 app.UseWebSockets(new WebSocketOptions()
 {
     AllowedOrigins.Add("https://client.com");
+    AllowedOrigins.Add("https://www.client.com");
 });
 ```
 

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -81,7 +81,7 @@ The following settings can be configured:
 
 * `KeepAliveInterval` - How frequently to send "ping" frames to the client to ensure proxies keep the connection open. The default is two minutes.
 * `ReceiveBufferSize` - The size of the buffer used to receive data. Advanced users may need to change this for performance tuning based on the size of the data. The default is 4kb.
-* `AllowedOrigins`    - List of the Origin header values allowed for WebSocket requests to prevent cross-site WebSocket hijacking. By default all Origins are allowed.
+* `AllowedOrigins`    - List of the Origin header values allowed for WebSocket requests to prevent cross-site WebSocket hijacking. By default, all origins are allowed.
 
 ::: moniker-end
 

--- a/aspnetcore/signalr/security.md
+++ b/aspnetcore/signalr/security.md
@@ -39,13 +39,13 @@ For example, the following CORS policy allows a SignalR browser client hosted on
 
 ## WebSocket Origin Restriction
 
-::: moniker range="< aspnetcore-2.2"
+::: moniker range=">= aspnetcore-2.2"
 
 The protections provided by CORS don't apply to WebSockets. For origin restriction on WebSockets read [WebSockets Origin Restriction](xref:fundamentals/websockets#webSocket-origin-restriction).
 
 ::: moniker-end
 
-::: moniker range=">= aspnetcore-2.2"
+::: moniker range="< aspnetcore-2.2"
 
 The protections provided by CORS don't apply to WebSockets. Browsers do **not**:
 

--- a/aspnetcore/signalr/security.md
+++ b/aspnetcore/signalr/security.md
@@ -41,7 +41,7 @@ For example, the following CORS policy allows a SignalR browser client hosted on
 
 ::: moniker range=">= aspnetcore-2.2"
 
-The protections provided by CORS don't apply to WebSockets. For origin restriction on WebSockets read [WebSockets Origin Restriction](xref:fundamentals/websockets#webSocket-origin-restriction).
+The protections provided by CORS don't apply to WebSockets. For origin restriction on WebSockets read [WebSockets Origin Restriction](xref:fundamentals/websockets#websocket-origin-restriction).
 
 ::: moniker-end
 

--- a/aspnetcore/signalr/security.md
+++ b/aspnetcore/signalr/security.md
@@ -39,6 +39,14 @@ For example, the following CORS policy allows a SignalR browser client hosted on
 
 ## WebSocket Origin Restriction
 
+::: moniker range="< aspnetcore-2.2"
+
+The protections provided by CORS don't apply to WebSockets. For origin restriction on WebSockets read [WebSockets Origin Restriction](xref:fundamentals/websockets#webSocket-origin-restriction).
+
+::: moniker-end
+
+::: moniker range=">= aspnetcore-2.2"
+
 The protections provided by CORS don't apply to WebSockets. Browsers do **not**:
 
 * Perform CORS pre-flight requests.
@@ -52,6 +60,8 @@ In ASP.NET Core 2.1 and later, header validation can be achieved using a custom 
 
 > [!NOTE]
 > The `Origin` header is controlled by the client and, like the `Referer` header, can be faked. These headers should **not** be used as an authentication mechanism.
+
+::: moniker-end
 
 ## Access token logging
 

--- a/aspnetcore/signalr/security.md
+++ b/aspnetcore/signalr/security.md
@@ -41,7 +41,7 @@ For example, the following CORS policy allows a SignalR browser client hosted on
 
 ::: moniker range=">= aspnetcore-2.2"
 
-The protections provided by CORS don't apply to WebSockets. For origin restriction on WebSockets read [WebSockets origin restriction](xref:fundamentals/websockets#websocket-origin-restriction).
+The protections provided by CORS don't apply to WebSockets. For origin restriction on WebSockets, read [WebSockets origin restriction](xref:fundamentals/websockets#websocket-origin-restriction).
 
 ::: moniker-end
 

--- a/aspnetcore/signalr/security.md
+++ b/aspnetcore/signalr/security.md
@@ -41,7 +41,7 @@ For example, the following CORS policy allows a SignalR browser client hosted on
 
 ::: moniker range=">= aspnetcore-2.2"
 
-The protections provided by CORS don't apply to WebSockets. For origin restriction on WebSockets read [WebSockets Origin Restriction](xref:fundamentals/websockets#websocket-origin-restriction).
+The protections provided by CORS don't apply to WebSockets. For origin restriction on WebSockets read [WebSockets origin restriction](xref:fundamentals/websockets#websocket-origin-restriction).
 
 ::: moniker-end
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/Docs/issues/9363

[Internal Review Link](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/security?view=aspnetcore-2.2&branch=pr-en-us-9447)
There are some moniker ranges, so switch the versions to verify they're working