### PR TITLE
added .net client discussion

### DIFF
--- a/aspnetcore/signalr/supported-platforms.md
+++ b/aspnetcore/signalr/supported-platforms.md
@@ -29,7 +29,7 @@ The [JavaScript client](https://www.npmjs.com/package/@aspnet/signalr) runs on N
  
 ## .NET client
 
-The [.NET client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) runs on any server platform supported by ASP.NET Core.
+The [.NET client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) can be used by developers building apps using .NET Core. [Xamarin developers can use SignalR](https://github.com/aspnet/Announcements/issues/305) for building applications for Android using Xamarin.Android 8.4.0.1 and later, and for iOS using Xamarin.Android 11.14.0.4 and later. 
 
 When the server runs IIS, the WebSockets transport requires IIS 8.0 or higher, on Windows Server 2012 or higher. Other transports are supported on all platforms.
 

--- a/aspnetcore/signalr/supported-platforms.md
+++ b/aspnetcore/signalr/supported-platforms.md
@@ -29,7 +29,7 @@ The [JavaScript client](https://www.npmjs.com/package/@aspnet/signalr) runs on N
  
 ## .NET client
 
-The [.NET client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) runs on any platform supported by ASP.NET Core. For example, [Xamarin developers can use SignalR](https://github.com/aspnet/Announcements/issues/305) for building applications for Android using Xamarin.Android 8.4.0.1 and later, and for iOS using Xamarin.Android 11.14.0.4 and later.
+The [.NET client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) runs on any platform supported by ASP.NET Core. For example, [Xamarin developers can use SignalR](https://github.com/aspnet/Announcements/issues/305) for building applications for Android using Xamarin.Android 8.4.0.1 and later, and for iOS using Xamarin.iOS 11.14.0.4 and later.
 
 When the server runs IIS, the WebSockets transport requires IIS 8.0 or higher, on Windows Server 2012 or higher. Other transports are supported on all platforms.
 

--- a/aspnetcore/signalr/supported-platforms.md
+++ b/aspnetcore/signalr/supported-platforms.md
@@ -5,10 +5,9 @@ description: Supported platforms for ASP.NET Core SignalR
 monikerRange: '>= aspnetcore-2.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 09/26/2018
+ms.date: 11/12/2018
 uid: signalr/supported-platforms
 ---
-
 # ASP.NET Core SignalR supported platforms
 
 ## Server system requirements
@@ -29,7 +28,7 @@ The [JavaScript client](https://www.npmjs.com/package/@aspnet/signalr) runs on N
  
 ## .NET client
 
-The [.NET client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) runs on any platform supported by ASP.NET Core. For example, [Xamarin developers can use SignalR](https://github.com/aspnet/Announcements/issues/305) for building applications for Android using Xamarin.Android 8.4.0.1 and later, and for iOS using Xamarin.iOS 11.14.0.4 and later.
+The [.NET client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) runs on any platform supported by ASP.NET Core. For example, [Xamarin developers can use SignalR](https://github.com/aspnet/Announcements/issues/305) for building Android apps using Xamarin.Android 8.4.0.1 and later and iOS apps using Xamarin.iOS 11.14.0.4 and later.
 
 When the server runs IIS, the WebSockets transport requires IIS 8.0 or higher, on Windows Server 2012 or higher. Other transports are supported on all platforms.
 

--- a/aspnetcore/signalr/supported-platforms.md
+++ b/aspnetcore/signalr/supported-platforms.md
@@ -29,7 +29,7 @@ The [JavaScript client](https://www.npmjs.com/package/@aspnet/signalr) runs on N
  
 ## .NET client
 
-The [.NET client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) can be used by developers using .NET Core. [Xamarin developers can use SignalR](https://github.com/aspnet/Announcements/issues/305) for building applications for Android using Xamarin.Android 8.4.0.1 and later, and for iOS using Xamarin.Android 11.14.0.4 and later. 
+The [.NET client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) runs on any platform supported by ASP.NET Core. For example, [Xamarin developers can use SignalR](https://github.com/aspnet/Announcements/issues/305) for building applications for Android using Xamarin.Android 8.4.0.1 and later, and for iOS using Xamarin.Android 11.14.0.4 and later.
 
 When the server runs IIS, the WebSockets transport requires IIS 8.0 or higher, on Windows Server 2012 or higher. Other transports are supported on all platforms.
 

--- a/aspnetcore/signalr/supported-platforms.md
+++ b/aspnetcore/signalr/supported-platforms.md
@@ -29,7 +29,7 @@ The [JavaScript client](https://www.npmjs.com/package/@aspnet/signalr) runs on N
  
 ## .NET client
 
-The [.NET client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) can be used by developers building apps using .NET Core. [Xamarin developers can use SignalR](https://github.com/aspnet/Announcements/issues/305) for building applications for Android using Xamarin.Android 8.4.0.1 and later, and for iOS using Xamarin.Android 11.14.0.4 and later. 
+The [.NET client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) can be used by developers using .NET Core. [Xamarin developers can use SignalR](https://github.com/aspnet/Announcements/issues/305) for building applications for Android using Xamarin.Android 8.4.0.1 and later, and for iOS using Xamarin.Android 11.14.0.4 and later. 
 
 When the server runs IIS, the WebSockets transport requires IIS 8.0 or higher, on Windows Server 2012 or higher. Other transports are supported on all platforms.
 


### PR DESCRIPTION
fixes #9460, by limiting the "server side" language in the .net client segment and by adding a brief discussion on Xamarin, which links off to the issue we created to help Xamarin developers get going. 