### PR TITLE
Docs: Mentioned that the Controller name replacement is by convention

### DIFF
--- a/aspnetcore/includes/webApi/getTodoItems.md
+++ b/aspnetcore/includes/webApi/getTodoItems.md
@@ -74,7 +74,7 @@ The `[HttpGet]` attribute denotes a method that responds to an HTTP GET request.
 
 ::: moniker-end
 
-* Replace `[controller]` with the name of the controller, which is the controller class name minus the "Controller" suffix. For this sample, the controller class name is **Todo**Controller and the root name is "todo". ASP.NET Core [routing](xref:mvc/controllers/routing) is case insensitive.
+* Replace `[controller]` with the name of the controller, which by convention is the controller class name minus the "Controller" suffix. For this sample, the controller class name is **Todo**Controller and the root name is "todo". ASP.NET Core [routing](xref:mvc/controllers/routing) is case insensitive.
 * If the `[HttpGet]` attribute has a route template (such as `[HttpGet("/products")]`, append that to the path. This sample doesn't use a template. For more information, see [Attribute routing with Http[Verb] attributes](xref:mvc/controllers/routing#attribute-routing-with-httpverb-attributes).
 
 In the following `GetById` method, `"{id}"` is a placeholder variable for the unique identifier of the to-do item. When `GetById` is invoked, it assigns the value of `"{id}"` in the URL to the method's `id` parameter.


### PR DESCRIPTION
Making it a bit clearer that the [controller] name replacement of MyNameController is by naming convention.



<!--
When creating a new PR, please do the following:

* Reference the issue number if there is one, e.g.:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->