### PR TITLE
Exclude Bin and Obj from CopyToOutputDirectory

### DIFF
--- a/aspnetcore/fundamentals/host/generic-host/samples/2.x/GenericHostSample/GenericHostSample.csproj
+++ b/aspnetcore/fundamentals/host/generic-host/samples/2.x/GenericHostSample/GenericHostSample.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="**\*.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="**\*.json" Exclude="Bin\**\*;Obj\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/fundamentals/host/generic-host/samples/2.x/GenericHostSample/GenericHostSample.csproj
+++ b/aspnetcore/fundamentals/host/generic-host/samples/2.x/GenericHostSample/GenericHostSample.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="**\*.json" Exclude="Bin\**\*;Obj\**\*" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="**\*.json" Exclude="bin\**\*;obj\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The code to move JSON files to the output directory causes build failures after multiple builds - at least in .NetCore 2.1. The reason being that for each build the Include="**\*.json" syntax will pick up JSON files that exist in both the Bin and Obj folders - and maintain their file structure - but appending them to the root bin folders causing a recursive file structure problem. This eventually triggers a path to long exception in MSBuild.

After adding the current code to the project file (without the exclude condition)
`<ItemGroup>
  <Content Include="**\*.json"  CopyToOutputDirectory="PreserveNewest" />
</ItemGroup>`

The following happens to the Bin folder:

Build1:
\bin\Debug\netcoreapp2.1\*.json
\bin\Debug\netcoreapp2.1\obj\*.json
Build2:
\bin\Debug\netcoreapp2.1\*.json
\bin\Debug\netcoreapp2.1\obj\*.json
\bin\Debug\netcoreapp2.1\bin\Debug\netcoreapp2.1\*.json
\bin\Debug\netcoreapp2.1\bin\Debug\netcoreapp2.1\obj\*.json
etc etc until the file path is too deep



<!--
When creating a new PR, please do the following:

* Reference the issue number if there is one, e.g.:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->