### PR TITLE
Surface Forward Headers in ext auth provider topics

### DIFF
--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -69,7 +69,7 @@ The [IHostingEnvironment.ApplicationName](xref:Microsoft.Extensions.Hosting.IHos
 **Type**: *string*  
 **Default**: The name of the assembly containing the app's entry point.  
 **Set using**: `HostBuilderContext.HostingEnvironment.ApplicationName`  
-**Environment variable**: `<PREFIX_>APPLICATIONNAME` (`<PREFIX_>` is [optional and user-defined](#configuration-builder))
+**Environment variable**: `<PREFIX_>APPLICATIONNAME` (`<PREFIX_>` is [optional and user-defined](#configurehostconfiguration))
 
 ### Content root
 
@@ -79,7 +79,7 @@ This setting determines where the host begins searching for content files.
 **Type**: *string*  
 **Default**: Defaults to the folder where the app assembly resides.  
 **Set using**: `UseContentRoot`  
-**Environment variable**: `<PREFIX_>CONTENTROOT` (`<PREFIX_>` is [optional and user-defined](#configuration-builder))
+**Environment variable**: `<PREFIX_>CONTENTROOT` (`<PREFIX_>` is [optional and user-defined](#configurehostconfiguration))
 
 If the path doesn't exist, the host fails to start.
 
@@ -93,7 +93,7 @@ Sets the app's [environment](xref:fundamentals/environments).
 **Type**: *string*  
 **Default**: Production  
 **Set using**: `UseEnvironment`  
-**Environment variable**: `<PREFIX_>ENVIRONMENT` (`<PREFIX_>` is [optional and user-defined](#configuration-builder))
+**Environment variable**: `<PREFIX_>ENVIRONMENT` (`<PREFIX_>` is [optional and user-defined](#configurehostconfiguration))
 
 The environment can be set to any value. Framework-defined values include `Development`, `Staging`, and `Production`. Values aren't case sensitive.
 

--- a/aspnetcore/security/authentication/social/additional-claims.md
+++ b/aspnetcore/security/authentication/social/additional-claims.md
@@ -5,7 +5,7 @@ description: Learn how to establish additional claims and tokens from external p
 monikerRange: '>= aspnetcore-2.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/28/2018
+ms.date: 11/11/2018
 uid: security/authentication/social/additional-claims
 ---
 # Persist additional claims and tokens from external providers in ASP.NET Core
@@ -16,13 +16,11 @@ An ASP.NET Core app can establish additional claims and tokens from external aut
 
 [View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/security/authentication/social/additional-claims/samples) ([how to download](xref:index#how-to-download-a-sample))
 
-## Prerequisite
+## Prerequisites
 
 Decide which external authentication providers to support in the app. For each provider, register the app and obtain a client ID and client secret. For more information, see <xref:security/authentication/social/index>. The [sample app](#sample-app-instructions) uses the [Google authentication provider](xref:security/authentication/google-logins).
 
-## Authentication provider configuration
-
-### Set the client ID and client secret
+## Set the client ID and client secret
 
 The OAuth authentication provider establishes a trust relationship with an app using a client ID and client secret. Client ID and client secret values are created for the app by the external authentication provider when the app is registered with the provider. Each external provider that the app uses must be configured independently with the provider's client ID and client secret. For more information, see the external authentication provider topics that apply to your scenario:
 
@@ -37,7 +35,7 @@ The sample app configures the Google authentication provider with a client ID an
 
 [!code-csharp[](additional-claims/samples/2.x/AdditionalClaimsSample/Startup.cs?name=snippet_AddGoogle&highlight=4,6)]
 
-### Establish the authentication scope
+## Establish the authentication scope
 
 Specify the list of permissions to retrieve from the provider by specifying the <xref:Microsoft.AspNetCore.Authentication.OAuth.OAuthOptions.Scope*>. Authentication scopes for common external providers appear in the following table.
 
@@ -52,7 +50,7 @@ The sample app adds the Google `plus.login` scope to request Google+ sign in per
 
 [!code-csharp[](additional-claims/samples/2.x/AdditionalClaimsSample/Startup.cs?name=snippet_AddGoogle&highlight=7)]
 
-### Map user data keys and create claims
+## Map user data keys and create claims
 
 In the provider's options, specify a <xref:Microsoft.AspNetCore.Authentication.ClaimActionCollectionMapExtensions.MapJsonKey*> for each key in the external provider's JSON user data for the app identity to read on sign in. For more information on claim types, see <xref:System.Security.Claims.ClaimTypes>.
 
@@ -66,7 +64,7 @@ In the sample app, `OnPostConfirmationAsync` (*Account/ExternalLogin.cshtml.cs*)
 
 [!code-csharp[](additional-claims/samples/2.x/AdditionalClaimsSample/Pages/Account/ExternalLogin.cshtml.cs?name=snippet_OnPostConfirmationAsync&highlight=30-31)]
 
-### Save the access token
+## Save the access token
 
 <xref:Microsoft.AspNetCore.Authentication.RemoteAuthenticationOptions.SaveTokens*> defines whether access and refresh tokens should be stored in the <xref:Microsoft.AspNetCore.Http.Authentication.AuthenticationProperties> after a successful authorization. `SaveTokens` is set to `false` by default to reduce the size of the final authentication cookie.
 
@@ -87,7 +85,7 @@ The sample app saves the access token in:
 
 [!code-csharp[](additional-claims/samples/2.x/AdditionalClaimsSample/Pages/Account/ExternalLogin.cshtml.cs?name=snippet_OnGetCallbackAsync&highlight=31-32)]
 
-### How to add additional custom tokens
+## How to add additional custom tokens
 
 To demonstrate how to add a custom token, which is stored as part of `SaveTokens`, the sample app adds an <xref:Microsoft.AspNetCore.Authentication.AuthenticationToken> with the current <xref:System.DateTime> for an [AuthenticationToken.Name](xref:Microsoft.AspNetCore.Authentication.AuthenticationToken.Name*) of `TicketCreated`:
 
@@ -137,3 +135,5 @@ Authentication Properties
 .expires
     Mon, 10 Sep 2018 18:08:05 GMT
 ```
+
+[!INCLUDE[Forward request information when behind a proxy or load balancer section](includes/forwarded-headers-middleware.md)]

--- a/aspnetcore/security/authentication/social/facebook-logins.md
+++ b/aspnetcore/security/authentication/social/facebook-logins.md
@@ -3,7 +3,8 @@ title: Facebook external login setup in ASP.NET Core
 author: rick-anderson
 description: This tutorial demonstrates the integration of Facebook account user authentication into an existing ASP.NET Core app.
 ms.author: riande
-ms.date: 08/01/2017
+ms.custom: mvc
+ms.date: 11/11/2018
 uid: security/authentication/facebook-logins
 ---
 # Facebook external login setup in ASP.NET Core
@@ -22,19 +23,19 @@ This tutorial shows you how to enable your users to sign in with their Facebook 
 
 * Fill out the form and tap the **Create App ID** button.
 
-   ![Create a New App ID form](index/_static/FBNewAppId.png)
+  ![Create a New App ID form](index/_static/FBNewAppId.png)
 
 * On the **Select a product** page, click **Set Up** on the **Facebook Login** card.
 
-   ![Product Setup page](index/_static/FBProductSetup.png)
+  ![Product Setup page](index/_static/FBProductSetup.png)
 
 * The **Quickstart** wizard will launch with **Choose a Platform** as the first page. Bypass the wizard for now by clicking the **Settings** link in the menu on the left:
 
-   ![Skip Quick Start](index/_static/FBSkipQuickStart.png)
+  ![Skip Quick Start](index/_static/FBSkipQuickStart.png)
 
 * You are presented with the **Client OAuth Settings** page:
 
-![Client OAuth Settings page](index/_static/FBOAuthSetup.png)
+  ![Client OAuth Settings page](index/_static/FBOAuthSetup.png)
 
 * Enter your development URI with */signin-facebook* appended into the **Valid OAuth Redirect URIs** field (for example: `https://localhost:44320/signin-facebook`). The Facebook authentication configured later in this tutorial will automatically handle requests at */signin-facebook* route to implement the OAuth flow.
 
@@ -43,10 +44,9 @@ This tutorial shows you how to enable your users to sign in with their Facebook 
 
 * Click **Save Changes**.
 
-* Click **Settings > Basic** link in the left navigation. 
+* Click **Settings** > **Basic** link in the left navigation.
 
-    On this page, make a note of your `App ID` and your `App Secret`. You will add both into your ASP.NET Core application in the next section:
-
+  On this page, make a note of your `App ID` and your `App Secret`. You will add both into your ASP.NET Core application in the next section:
 
 * When deploying the site you need to revisit the **Facebook Login** setup page and register a new public URI.
 
@@ -63,7 +63,7 @@ dotnet user-secrets set Authentication:Facebook:AppSecret <app-secret>
 
 ## Configure Facebook Authentication
 
-# [ASP.NET Core 2.x](#tab/aspnetcore2x/)
+::: moniker range=">= aspnetcore-2.0"
 
 Add the Facebook service in the `ConfigureServices` method in the *Startup.cs* file:
 
@@ -81,9 +81,11 @@ services.AddAuthentication().AddFacebook(facebookOptions =>
 
 [!INCLUDE [default settings configuration](includes/default-settings.md)]
 
-[!INCLUDE[](~/includes/chain-auth-providers.md)]
+[!INCLUDE[](includes/chain-auth-providers.md)]
 
-# [ASP.NET Core 1.x](#tab/aspnetcore1x/)
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.0"
 
 Install the [Microsoft.AspNetCore.Authentication.Facebook](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Facebook) package.
 
@@ -102,7 +104,7 @@ app.UseFacebookAuthentication(new FacebookOptions()
 });
 ```
 
----
+::: moniker-end
 
 See the [FacebookOptions](/dotnet/api/microsoft.aspnetcore.builder.facebookoptions) API reference for more information on configuration options supported by Facebook authentication. Configuration options can be used to:
 
@@ -128,6 +130,8 @@ Once you enter your Facebook credentials you are redirected back to your site wh
 You are now logged in using your Facebook credentials:
 
 ![Web application: User authenticated](index/_static/Done.png)
+
+[!INCLUDE[Forward request information when behind a proxy or load balancer section](includes/forwarded-headers-middleware.md)]
 
 ## Troubleshooting
 

--- a/aspnetcore/security/authentication/social/google-logins.md
+++ b/aspnetcore/security/authentication/social/google-logins.md
@@ -3,7 +3,8 @@ title: Google external login setup in ASP.NET Core
 author: rick-anderson
 description: This tutorial demonstrates the integration of Google account user authentication into an existing ASP.NET Core app.
 ms.author: riande
-ms.date: 08/02/2017
+ms.custom: mvc
+ms.date: 11/11/2018
 uid: security/authentication/google-logins
 ---
 # Google external login setup in ASP.NET Core
@@ -39,9 +40,9 @@ This tutorial shows you how to enable your users to sign in with their Google+ a
 ![API Manager Google+API page](index/_static/GoogleConsoleGoCredentials.png)
 
 * Choose:
-   * **Google+ API**
-   * **Web server (e.g. node.js, Tomcat)**, and
-   * **User data**:
+  * **Google+ API**
+  * **Web server (e.g. node.js, Tomcat)**, and
+  * **User data**:
 
 ![API Manager Credentials page: Find out what kind of credentials you need panel](index/_static/GoogleConsoleChooseCred.png)
 
@@ -80,7 +81,7 @@ The values for these tokens can be found in the JSON file downloaded in the prev
 
 ## Configure Google Authentication
 
-# [ASP.NET Core 2.x](#tab/aspnetcore2x/)
+::: moniker range=">= aspnetcore-2.0"
 
 Add the Google service in the `ConfigureServices` method in *Startup.cs* file:
 
@@ -98,9 +99,11 @@ services.AddAuthentication().AddGoogle(googleOptions =>
 
 [!INCLUDE [default settings configuration](includes/default-settings.md)]
 
-[!INCLUDE[](~/includes/chain-auth-providers.md)]
+[!INCLUDE[](includes/chain-auth-providers.md)]
 
-# [ASP.NET Core 1.x](#tab/aspnetcore1x/)
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.0"
 
 The project template used in this tutorial ensures that [Microsoft.AspNetCore.Authentication.Google](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Google) package is installed.
 
@@ -119,7 +122,7 @@ app.UseGoogleAuthentication(new GoogleOptions()
 });
 ```
 
----
+::: moniker-end
 
 See the [GoogleOptions](/dotnet/api/microsoft.aspnetcore.builder.googleoptions) API reference for more information on configuration options supported by Google authentication. This can be used to request different information about the user.
 
@@ -138,6 +141,8 @@ After entering your Google credentials, then you are redirected back to the web 
 You are now logged in using your Google credentials:
 
 ![Web application running in Microsoft Edge: User authenticated](index/_static/Done.png)
+
+[!INCLUDE[Forward request information when behind a proxy or load balancer section](includes/forwarded-headers-middleware.md)]
 
 ## Troubleshooting
 

--- a/aspnetcore/security/authentication/social/includes/chain-auth-providers.md
+++ b/aspnetcore/security/authentication/social/includes/chain-auth-providers.md
@@ -1,3 +1,5 @@
+## Multiple authentication providers
+
 When the app requires multiple providers, chain the provider extension methods behind [AddAuthentication](/dotnet/api/microsoft.extensions.dependencyinjection.authenticationservicecollectionextensions.addauthentication):
 
 ```csharp

--- a/aspnetcore/security/authentication/social/includes/forwarded-headers-middleware.md
+++ b/aspnetcore/security/authentication/social/includes/forwarded-headers-middleware.md
@@ -1,0 +1,9 @@
+## Forward request information with a proxy or load balancer
+
+If the app is deployed behind a proxy server or load balancer, some of the original request information might be forwarded to the app in request headers. This information usually includes the secure request scheme (`https`), host, and client IP address. Apps don't automatically read these request headers to discover and use the original request information.
+
+The scheme is used in link generation that affects the authentication flow with external providers. Losing the secure scheme (`https`) results in the app generating incorrect insecure redirect URLs.
+
+Use Forwarded Headers Middleware to make the original request information available to the app for request processing.
+
+For more information, see <xref:host-and-deploy/proxy-load-balancer>.

--- a/aspnetcore/security/authentication/social/index.md
+++ b/aspnetcore/security/authentication/social/index.md
@@ -3,7 +3,8 @@ title: Facebook, Google, and external provider authentication in ASP.NET Core
 author: rick-anderson
 description: This tutorial demonstrates how to build an ASP.NET Core 2.x app using OAuth 2.0 with external authentication providers.
 ms.author: riande
-ms.date: 11/01/2016
+ms.custom: mvc
+ms.date: 11/11/2018
 uid: security/authentication/social/index
 ---
 # Facebook, Google, and external provider authentication in ASP.NET Core
@@ -22,9 +23,9 @@ Note: Packages presented here abstract a great deal of complexity of the OAuth a
 
 ## Create a New ASP.NET Core Project
 
-* In Visual Studio 2017, create a new project from the Start Page, or via **File > New > Project**.
+* In Visual Studio 2017, create a new project from the Start Page, or via **File** > **New** > **Project**.
 
-* Select the **ASP.NET Core Web Application** template available in **Visual C# > .NET Core** category:
+* Select the **ASP.NET Core Web Application** template available in **Visual C#** > **.NET Core** category:
 
 ![New Project dialog](index/_static/new-project.png)
 
@@ -45,9 +46,11 @@ Note: This tutorial applies to ASP.NET Core 2.0 SDK version which can be selecte
 
 OAuth 2.0 requires the use of SSL for authentication over the HTTPS protocol.
 
-Note: Projects created using **Web Application** or **Web API** project templates for ASP.NET Core 2.x are automatically configured to enable SSL and launch with https URL if the **Individual User Accounts** option was selected on **Change Authentication dialog** in the project wizard as shown above.
+Projects created using the **Web Application** or **Web API** project templates with ASP.NET Core 2.1 or later are automatically configured to enable SSL. The app launches with a secure default endpoint if the **Individual User Accounts** option is selected in the **Change Authentication dialog** of the project wizard.
 
-* Require SSL on your site by following the steps in [Enforce SSL in an ASP.NET Core app](xref:security/enforcing-ssl) topic.
+For more information, see <xref:security/enforcing-ssl>.
+
+[!INCLUDE[Forward request information when behind a proxy or load balancer section](includes/forwarded-headers-middleware.md)]
 
 ## Use SecretManager to store tokens assigned by login providers
 
@@ -68,7 +71,7 @@ Use the following topics to configure your application to use the respective pro
 * [Microsoft](xref:security/authentication/microsoft-logins) instructions
 * [Other provider](xref:security/authentication/otherlogins) instructions
 
-[!INCLUDE[](~/includes/chain-auth-providers.md)]
+[!INCLUDE[](includes/chain-auth-providers.md)]
 
 ## Optionally set password
 

--- a/aspnetcore/security/authentication/social/index.md
+++ b/aspnetcore/security/authentication/social/index.md
@@ -25,7 +25,7 @@ Note: Packages presented here abstract a great deal of complexity of the OAuth a
 
 * In Visual Studio 2017, create a new project from the Start Page, or via **File** > **New** > **Project**.
 
-* Select the **ASP.NET Core Web Application** template available in **Visual C#** > **.NET Core** category:
+* Select the **ASP.NET Core Web Application** template available in the **Visual C#** > **.NET Core** category:
 
 ![New Project dialog](index/_static/new-project.png)
 

--- a/aspnetcore/security/authentication/social/microsoft-logins.md
+++ b/aspnetcore/security/authentication/social/microsoft-logins.md
@@ -3,7 +3,8 @@ title: Microsoft Account external login setup with ASP.NET Core
 author: rick-anderson
 description: This tutorial demonstrates the integration of Microsoft account user authentication into an existing ASP.NET Core app.
 ms.author: riande
-ms.date: 08/24/2017
+ms.custom: mvc
+ms.date: 11/11/2018
 uid: security/authentication/microsoft-logins
 ---
 # Microsoft Account external login setup with ASP.NET Core
@@ -68,7 +69,7 @@ The project template used in this tutorial ensures that [Microsoft.AspNetCore.Au
 
    `dotnet add package Microsoft.AspNetCore.Authentication.MicrosoftAccount`
 
-# [ASP.NET Core 2.x](#tab/aspnetcore2x/)
+::: moniker range=">= aspnetcore-2.0"
 
 Add the Microsoft Account service in the `ConfigureServices` method in *Startup.cs* file:
 
@@ -86,9 +87,11 @@ services.AddAuthentication().AddMicrosoftAccount(microsoftOptions =>
 
 [!INCLUDE [default settings configuration](includes/default-settings.md)]
 
-[!INCLUDE[](~/includes/chain-auth-providers.md)]
+[!INCLUDE[](includes/chain-auth-providers.md)]
 
-# [ASP.NET Core 1.x](#tab/aspnetcore1x/)
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.0"
 
 Add the Microsoft Account middleware in the `Configure` method in *Startup.cs* file:
 
@@ -100,7 +103,7 @@ app.UseMicrosoftAccountAuthentication(new MicrosoftAccountOptions()
 });
 ```
 
----
+::: moniker-end
 
 Although the terminology used on Microsoft Developer Portal names these tokens `ApplicationId` and `Password`, they're exposed as `ClientId` and `ClientSecret` to the configuration API.
 
@@ -121,6 +124,8 @@ Tap **Yes** and you will be redirected back to the web site where you can set yo
 You are now logged in using your Microsoft credentials:
 
 ![Web application: User authenticated](index/_static/Done.png)
+
+[!INCLUDE[Forward request information when behind a proxy or load balancer section](includes/forwarded-headers-middleware.md)]
 
 ## Troubleshooting
 

--- a/aspnetcore/security/authentication/social/other-logins.md
+++ b/aspnetcore/security/authentication/social/other-logins.md
@@ -1,44 +1,44 @@
 ---
-title: Short survey of other authentication providers
+title: External OAuth authentication providers
 author: rick-anderson
+description: Discover External OAuth authentication providers that work with ASP.NET Core apps.
 ms.author: riande
-ms.date: 11/03/2016
+ms.custom: mvc
+ms.date: 11/11/2018
 uid: security/authentication/otherlogins
 ---
-# Short survey of other authentication providers
-
-<a name="security-authentication-other-logins"></a>
+# External OAuth authentication providers
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT), [Pranav Rastogi](https://github.com/rustd), and [Valeriy Novytskyy](https://github.com/01binary)
 
-Here are set up instructions for some other common OAuth providers. Third-party NuGet packages such as the ones maintained by [aspnet-contrib](https://www.nuget.org/packages?q=owners%3Aaspnet-contrib+title%3AOAuth) can be used to complement authentication providers implemented by the ASP.NET Core team.
+The following list includes common external OAuth authentication providers that work with ASP.NET Core apps. Third-party NuGet packages, such as the ones maintained by [aspnet-contrib](https://www.nuget.org/packages?q=owners%3Aaspnet-contrib+title%3AOAuth), can be used to complement the authentication providers implemented by the ASP.NET Core team.
 
-* Set up **LinkedIn** sign in: [https://www.linkedin.com/developer/apps](https://www.linkedin.com/developer/apps). See [official steps](https://developer.linkedin.com/docs/oauth2).
+* [LinkedIn](https://www.linkedin.com/developer/apps) ([Instructions](https://developer.linkedin.com/docs/oauth2))
 
-* Set up **Instagram** sign in: [https://www.instagram.com/developer/register/](https://www.instagram.com/developer/register/). See [official steps](https://www.instagram.com/developer/authentication/).
+* [Instagram](https://www.instagram.com/developer/register/) ([Instructions](https://www.instagram.com/developer/authentication/))
 
-* Set up **Reddit** sign in: [https://www.reddit.com/login?dest=https%3A%2F%2Fwww.reddit.com%2Fprefs%2Fapps](https://www.reddit.com/login?dest=https%3A%2F%2Fwww.reddit.com%2Fprefs%2Fapps). See [official steps](https://github.com/reddit/reddit/wiki/OAuth2-Quick-Start-Example).
+* [Reddit](https://www.reddit.com/login?dest=https%3A%2F%2Fwww.reddit.com%2Fprefs%2Fapps) ([Instructions](https://github.com/reddit/reddit/wiki/OAuth2-Quick-Start-Example))
 
-* Set up **Github** sign in: [https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fsettings%2Fapplications%2Fnew](https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fsettings%2Fapplications%2Fnew). See [official steps](https://developer.github.com/v3/oauth/).
+* [Github](https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fsettings%2Fapplications%2Fnew) ([Instructions](https://developer.github.com/v3/oauth/))
 
-* Set up **Yahoo** sign in: [https://login.yahoo.com/config/login?src=devnet&.done=http%3A%2F%2Fdeveloper.yahoo.com%2Fapps%2Fcreate%2F](https://login.yahoo.com/config/login?src=devnet&.done=http%3A%2F%2Fdeveloper.yahoo.com%2Fapps%2Fcreate%2F). See [official steps](https://developer.yahoo.com/bbauth/user.html).
+* [Yahoo](https://login.yahoo.com/config/login?src=devnet&.done=http%3A%2F%2Fdeveloper.yahoo.com%2Fapps%2Fcreate%2F) ([Instructions](https://developer.yahoo.com/bbauth/user.html))
 
-* Set up **Tumblr** sign in: [https://www.tumblr.com/oauth/apps](https://www.tumblr.com/oauth/apps). See [official steps](https://www.tumblr.com/docs/api/v2#auth).
+* [Tumblr](https://www.tumblr.com/oauth/apps) ([Instructions](https://www.tumblr.com/docs/api/v2#auth))
 
-* Set up **Pinterest** sign in: [https://www.pinterest.com/login/?next=http%3A%2F%2Fdevsite%2Fapps%2F](https://www.pinterest.com/login/?next=http%3A%2F%2Fdevsite%2Fapps%2F). See [official steps](https://developers.pinterest.com/docs/api/overview/?).
+* [Pinterest](https://www.pinterest.com/login/?next=http%3A%2F%2Fdevsite%2Fapps%2F) ([Instructions](https://developers.pinterest.com/docs/api/overview/?))
 
-* Set up **Pocket** sign in: [https://getpocket.com/developer/apps/new](https://getpocket.com/developer/apps/new). See [official steps](https://getpocket.com/developer/docs/authentication).
+* [Pocket](https://getpocket.com/developer/apps/new) ([Instructions](https://getpocket.com/developer/docs/authentication))
 
-* Set up **Flickr** sign in: [https://www.flickr.com/services/apps/create](https://www.flickr.com/services/apps/create). See [official steps](https://www.flickr.com/services/api/auth.oauth.html).
+* [Flickr](https://www.flickr.com/services/apps/create) ([Instructions](https://www.flickr.com/services/api/auth.oauth.html))
 
-* Set up **Dribble** sign in: [https://dribbble.com/signup](https://dribbble.com/signup). See [official steps](http://developer.dribbble.com/v1/oauth/).
+* [Dribble](https://dribbble.com/signup) ([Instructions](http://developer.dribbble.com/v1/oauth/))
 
-* Set up **Vimeo** sign in: [https://vimeo.com/join](https://vimeo.com/join). See [official steps](https://developer.vimeo.com/api/authentication).
+* [Vimeo](https://vimeo.com/join) ([Instructions](https://developer.vimeo.com/api/authentication))
 
-* Set up **SoundCloud** sign in: [https://soundcloud.com/you/apps/new](https://soundcloud.com/you/apps/new). See [official steps](https://developers.soundcloud.com/blog/we-love-oauth-2).
+* [SoundCloud](https://soundcloud.com/you/apps/new) ([Instructions](https://developers.soundcloud.com/blog/we-love-oauth-2))
 
-* Set up **VK** sign in: [https://vk.com/apps?act=manage](https://vk.com/apps?act=manage). See [official steps](https://vk.com/pages?oid=-17680044&p=Authorizing_Sites).
+* [VK](https://vk.com/apps?act=manage) ([Instructions](https://vk.com/pages?oid=-17680044&p=Authorizing_Sites))
 
-## Multiple authentication providers
+[!INCLUDE[Multiple authentication providers](includes/chain-auth-providers.md)]
 
-[!INCLUDE[](~/includes/chain-auth-providers.md)]
+[!INCLUDE[Forward request information when behind a proxy or load balancer section](includes/forwarded-headers-middleware.md)]

--- a/aspnetcore/security/authentication/social/twitter-logins.md
+++ b/aspnetcore/security/authentication/social/twitter-logins.md
@@ -3,7 +3,8 @@ title: Twitter external login setup with ASP.NET Core
 author: rick-anderson
 description: This tutorial demonstrates the integration of Twitter account user authentication into an existing ASP.NET Core app.
 ms.author: riande
-ms.date: 11/01/2016
+ms.custom: mvc
+ms.date: 11/11/2018
 uid: security/authentication/twitter-logins
 ---
 # Twitter external login setup with ASP.NET Core
@@ -16,20 +17,20 @@ This tutorial shows you how to enable your users to [sign in with their Twitter 
 
 * Navigate to [https://apps.twitter.com/](https://apps.twitter.com/) and sign in. If you don't already have a Twitter account, use the **[Sign up now](https://twitter.com/signup)** link to create one. After signing in, the **Application Management** page is shown:
 
-![Twitter Application Management open in Microsoft Edge](index/_static/TwitterAppManage.png)
+  ![Twitter Application Management open in Microsoft Edge](index/_static/TwitterAppManage.png)
 
 * Tap **Create New App** and fill out the application **Name**, **Description** and public **Website** URI (this can be temporary until you register the domain name):
 
-![Create an application page](index/_static/TwitterCreate.png)
+  ![Create an application page](index/_static/TwitterCreate.png)
 
 * Enter your development URI with `/signin-twitter` appended into the **Valid OAuth Redirect URIs** field (for example: `https://localhost:44320/signin-twitter`). The Twitter authentication scheme configured later in this tutorial will automatically handle requests at `/signin-twitter` route to implement the OAuth flow.
 
-> [!NOTE]
-> The URI segment `/signin-twitter` is set as the default callback of the Twitter authentication provider. You can change the default callback URI while configuring the Twitter authentication middleware via the inherited [RemoteAuthenticationOptions.CallbackPath](/dotnet/api/microsoft.aspnetcore.authentication.remoteauthenticationoptions.callbackpath) property of the [TwitterOptions](/dotnet/api/microsoft.aspnetcore.authentication.twitter.twitteroptions) class.
+  > [!NOTE]
+  > The URI segment `/signin-twitter` is set as the default callback of the Twitter authentication provider. You can change the default callback URI while configuring the Twitter authentication middleware via the inherited [RemoteAuthenticationOptions.CallbackPath](/dotnet/api/microsoft.aspnetcore.authentication.remoteauthenticationoptions.callbackpath) property of the [TwitterOptions](/dotnet/api/microsoft.aspnetcore.authentication.twitter.twitteroptions) class.
 
 * Fill out the rest of the form and tap **Create your Twitter application**. New application details are displayed:
 
-![Details tab on Application page](index/_static/TwitterAppDetails.png)
+  ![Details tab on Application page](index/_static/TwitterAppDetails.png)
 
 * When deploying the site you'll need to revisit the **Application Management** page and register a new public URI.
 
@@ -48,9 +49,9 @@ The project template used in this tutorial ensures that [Microsoft.AspNetCore.Au
 * To install this package with Visual Studio 2017, right-click on the project and select **Manage NuGet Packages**.
 * To install with .NET Core CLI, execute the following in your project directory:
 
-   `dotnet add package Microsoft.AspNetCore.Authentication.Twitter`
+  `dotnet add package Microsoft.AspNetCore.Authentication.Twitter`
 
-# [ASP.NET Core 2.x](#tab/aspnetcore2x/)
+::: moniker range=">= aspnetcore-2.0"
 
 Add the Twitter service in the `ConfigureServices` method in *Startup.cs* file:
 
@@ -68,9 +69,11 @@ services.AddAuthentication().AddTwitter(twitterOptions =>
 
 [!INCLUDE [default settings configuration](includes/default-settings.md)]
 
-[!INCLUDE[](~/includes/chain-auth-providers.md)]
+[!INCLUDE[](includes/chain-auth-providers.md)]
 
-# [ASP.NET Core 1.x](#tab/aspnetcore1x/)
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.0"
 
 Add the Twitter middleware in the `Configure` method in *Startup.cs* file:
 
@@ -82,7 +85,7 @@ app.UseTwitterAuthentication(new TwitterOptions()
 });
 ```
 
----
+::: moniker-end
 
 See the [TwitterOptions](/dotnet/api/microsoft.aspnetcore.builder.twitteroptions) API reference for more information on configuration options supported by Twitter authentication. This can be used to request different information about the user.
 
@@ -101,6 +104,8 @@ After entering your Twitter credentials, you are redirected back to the web site
 You are now logged in using your Twitter credentials:
 
 ![Web application: User authenticated](index/_static/Done.png)
+
+[!INCLUDE[Forward request information when behind a proxy or load balancer section](includes/forwarded-headers-middleware.md)]
 
 ## Troubleshooting
 

--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -329,7 +329,7 @@
 #### [Twitter authentication](xref:security/authentication/twitter-logins)
 #### [Google authentication](xref:security/authentication/google-logins)
 #### [Microsoft authentication](xref:security/authentication/microsoft-logins)
-#### [Other authentication providers](xref:security/authentication/otherlogins)
+#### [External authentication providers](xref:security/authentication/otherlogins)
 #### [Additional claims](xref:security/authentication/social/additional-claims)
 ### [WS-Federation authentication](xref:security/authentication/ws-federation)
 ### [Account confirmation and password recovery](xref:security/authentication/accconfirm)


### PR DESCRIPTION
Fixes #9549 

* Not a full UE pass on the group of external provider topics ... don't quite have time for that right now. However, I do hit a number of small UE-type updates.
* Engineering: You only need to look at one thing here: See the *forwarded-headers-middleware.md* file. The content of the file is below. The INCLUDE is linked into the external auth provider topics to surface Forwarded Headers Middleware (proxy/LB topic).

> \#\# Forward request information with a proxy or load balancer
>
> If the app is deployed behind a proxy server or load balancer, some of the original request information might be forwarded to the app in request headers. This information usually includes the secure request scheme (\`https\`), host, and client IP address. Apps don't automatically read these request headers to discover and use the original request information.
>
> The scheme is used in link generation that affects the authentication flow with external providers. Losing the secure scheme (\`https\`) results in the app generating incorrect insecure redirect URLs.
>
> Use Forwarded Headers Middleware to make the original request information available to the app for request processing.
>
> For more information, see \<xref:host-and-deploy/proxy-load-balancer>.

If it's easier to provide feedback in a comment here over hunting down the file on the diff, that works for me.
