### PR TITLE
VS Code `dotnet run -p` command update

### DIFF
--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -224,7 +224,7 @@ The SignalR server must be configured to pass SignalR requests to SignalR.
 * In the integrated terminal, run the following command:
 
   ```console
-  dotnet run -p SignalRChat
+  dotnet run -p SignalRChat.csproj
   ```
   
 # [Visual Studio for Mac](#tab/visual-studio-mac)


### PR DESCRIPTION
When I run through the tutorial after executing `code -r SignalRChat`, a new VSCode window opens that is in the signalRChat directory.  (Ex. C:\SignalRChat).  When I execute `dotnet run -p SignalRChat` from there I get an error
"MSBUILD : error MSB1009: Project file does not exist.
Switch: SignalRChat

The build failed. Please fix the build errors and run again."

However, if I change the command to `dotnet run -p SignalRChat.csproj` it works.



<!--
When creating a new PR, please do the following:

* Reference the issue number if there is one, e.g.:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->