### PR TITLE
Change URL of link to Azure deploy with CLI tutorial

### DIFF
--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -283,6 +283,7 @@
 ## Host on Azure App Service
 ### [Overview](xref:host-and-deploy/azure-apps/index)
 ### [Publish with Visual Studio](xref:tutorials/publish-to-azure-webapp-using-vs)
+### [Publish with CLI tools](/azure/app-service/app-service-web-tutorial-dotnetcore-sqldb)
 ### [Publish with Visual Studio and Git](xref:host-and-deploy/azure-apps/azure-continuous-deployment)
 ### [Continuous deployment with Azure Pipelines](/azure/devops/pipelines/get-started-yaml)
 ### [Troubleshoot startup errors](xref:host-and-deploy/azure-apps/troubleshoot)

--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -283,7 +283,6 @@
 ## Host on Azure App Service
 ### [Overview](xref:host-and-deploy/azure-apps/index)
 ### [Publish with Visual Studio](xref:tutorials/publish-to-azure-webapp-using-vs)
-### [Publish with CLI tools](/azure/app-service/app-service-web-get-started-dotnet)
 ### [Publish with Visual Studio and Git](xref:host-and-deploy/azure-apps/azure-continuous-deployment)
 ### [Continuous deployment with Azure Pipelines](/azure/devops/pipelines/get-started-yaml)
 ### [Troubleshoot startup errors](xref:host-and-deploy/azure-apps/troubleshoot)
@@ -313,7 +312,6 @@
 ## [Visual Studio publish profiles](xref:host-and-deploy/visual-studio-publish-profiles)
 ## [Directory structure](xref:host-and-deploy/directory-structure)
 ## [Errors reference for Azure App Service and IIS](xref:host-and-deploy/azure-iis-errors-reference)
-
 
 # Security and Identity
 ## [Overview](xref:security/index)


### PR DESCRIPTION
Fixes #9668 

Tom, do you prefer this approach: Nix the duplicate content by dropping the App Service tutorial link, or how would you like to handle this? The Azure doc set doesn't include a publish-to-Azure tutorial based on the CLI AFAICT. They have [script samples](https://docs.microsoft.com/azure/app-service/app-service-cli-samples?toc=%2Fcli%2Fazure%2Ftoc.json&bc=%2Fcli%2Fazure%2Fbreadcrumb%2Ftoc.json&view=azure-cli-latest) that might do it but not a tutorial.

* Ours: https://docs.microsoft.com/aspnet/core/tutorials/publish-to-azure-webapp-using-vs
* Theirs: https://docs.microsoft.com/azure/app-service/app-service-web-get-started-dotnet

Thanks @henrikrxn for reporting. :rocket:

WRT to the question on publishing with CLI and publish profiles, I think we're ok with the publish profiles topic as it exists. The details are within the file. If we were to attempt cross-linking, we'd probably end up cross-linking that topic everywhere. I think we're relying on the :eye: to scan and catch the topic or the search box at the top of the sidebar TOC to locate the topic for a reader.