### PR TITLE
Surface troubleshooting code from IIS Int repo

### DIFF
--- a/aspnetcore/fundamentals/servers/httpsys.md
+++ b/aspnetcore/fundamentals/servers/httpsys.md
@@ -5,7 +5,7 @@ description: Learn about HTTP.sys, a web server for ASP.NET Core on Windows. Bui
 monikerRange: '>= aspnetcore-2.0'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 09/13/2018
+ms.date: 11/26/2018
 uid: fundamentals/servers/httpsys
 ---
 # HTTP.sys web server implementation in ASP.NET Core
@@ -196,4 +196,5 @@ For apps hosted by HTTP.sys that interact with requests from the Internet or a c
 
 * [HTTP Server API](https://msdn.microsoft.com/library/windows/desktop/aa364510.aspx)
 * [aspnet/HttpSysServer GitHub repository (source code)](https://github.com/aspnet/HttpSysServer/)
-* [Host in ASP.NET Core](xref:fundamentals/host/index)
+* <xref:fundamentals/host/index>
+* <xref:test/troubleshoot>

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn about Kestrel, the cross-platform web server for ASP.NET Core.
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 11/12/2018
+ms.date: 11/26/2018
 uid: fundamentals/servers/kestrel
 ---
 # Kestrel web server implementation in ASP.NET Core
@@ -1021,7 +1021,8 @@ Host Filtering Middleware is disabled by default. To enable the middleware, defi
 
 ## Additional resources
 
-* [Enforce HTTPS](xref:security/enforcing-ssl)
+* <xref:test/troubleshoot>
+* <xref:security/enforcing-ssl>
+* <xref:host-and-deploy/proxy-load-balancer>
 * [Kestrel source code](https://github.com/aspnet/KestrelHttpServer)
 * [RFC 7230: Message Syntax and Routing (Section 5.4: Host)](https://tools.ietf.org/html/rfc7230#section-5.4)
-* [Configure ASP.NET Core to work with proxy servers and load balancers](xref:host-and-deploy/proxy-load-balancer)

--- a/aspnetcore/host-and-deploy/iis/index.md
+++ b/aspnetcore/host-and-deploy/iis/index.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn how to host ASP.NET Core apps on Windows Server Internet Information Services (IIS).
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/10/2018
+ms.date: 11/26/2018
 uid: host-and-deploy/iis/index
 ---
 # Host ASP.NET Core on Windows with IIS
@@ -604,6 +604,7 @@ Distinguish common errors when hosting ASP.NET Core apps on IIS.
 
 ## Additional resources
 
+* <xref:test/troubleshoot>
 * [Introduction to ASP.NET Core](xref:index)
 * [The Official Microsoft IIS Site](https://www.iis.net/)
 * [Windows Server technical content library](/windows-server/windows-server)

--- a/aspnetcore/host-and-deploy/iis/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/iis/troubleshoot.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn how to diagnose problems with Internet Information Services (IIS) deployments of ASP.NET Core apps.
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/24/2018
+ms.date: 11/26/2018
 uid: host-and-deploy/iis/troubleshoot
 ---
 # Troubleshoot ASP.NET Core on IIS
@@ -41,7 +41,8 @@ Learn about the debugging support built into Visual Studio Code.
 
 ## App startup errors
 
-**502.5 Process Failure**  
+### 502.5 Process Failure
+
 The worker process fails. The app doesn't start.
 
 The ASP.NET Core Module attempts to start the backend dotnet process but it fails to start. The cause of a process startup failure can usually be determined from entries in the [Application Event Log](#application-event-log) and the [ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log). 
@@ -54,7 +55,7 @@ The *502.5 Process Failure* error page is returned when a hosting or app misconf
 
 ::: moniker range=">= aspnetcore-2.2"
 
-**500.30 In-Process Startup Failure**
+### 500.30 In-Process Startup Failure
 
 The worker process fails. The app doesn't start.
 
@@ -62,7 +63,7 @@ The ASP.NET Core Module attempts to start the .NET Core CLR in-process, but it f
 
 A common failure condition is the app is misconfigured due to targeting a version of the ASP.NET Core shared framework that isn't present. Check which versions of the ASP.NET Core shared framework are installed on the target machine.
 
-**500.0 In-Process Handler Load Failure**
+### 500.0 In-Process Handler Load Failure
 
 The worker process fails. The app doesn't start.
 
@@ -71,7 +72,7 @@ The ASP.NET Core Module fails to find the .NET Core CLR and find the in-process 
 * The app targets either the [Microsoft.AspNetCore.Server.IIS](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.IIS) NuGet package or the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app).
 * The version of the ASP.NET Core shared framework that the app targets is installed on the target machine.
 
-**500.0 Out-Of-Process Handler Load Failure**
+### 500.0 Out-Of-Process Handler Load Failure
 
 The worker process fails. The app doesn't start.
 
@@ -79,12 +80,13 @@ The ASP.NET Core Module fails to find the out-of-process hosting request handler
 
 ::: moniker-end
 
-**500 Internal Server Error**  
+### 500 Internal Server Error
+
 The app starts, but an error prevents the server from fulfilling the request.
 
 This error occurs within the app's code during startup or while creating a response. The response may contain no content, or the response may appear as a *500 Internal Server Error* in the browser. The Application Event Log usually states that the app started normally. From the server's perspective, that's correct. The app did start, but it can't generate a valid response. [Run the app at a command prompt](#run-the-app-at-a-command-prompt) on the server or [enable the ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log) to troubleshoot the problem.
 
-**Connection reset**
+### Connection reset
 
 If an error occurs after the headers are sent, it's too late for the server to send a **500 Internal Server Error** when an error occurs. This often happens when an error occurs during the serialization of complex objects for a response. This type of error appears as a *connection reset* error on the client. [Application logging](xref:fundamentals/logging/index) can help troubleshoot these types of errors.
 
@@ -107,7 +109,7 @@ Access the Application Event Log:
 
 Many startup errors don't produce useful information in the Application Event Log. You can find the cause of some errors by running the app at a command prompt on the hosting system.
 
-**Framework-dependent deployment**
+#### Framework-dependent deployment
 
 If the app is a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd):
 
@@ -115,7 +117,7 @@ If the app is a [framework-dependent deployment](/dotnet/core/deploying/#framewo
 1. The console output from the app, showing any errors, is written to the console window.
 1. If the errors occur when making a request to the app, make a request to the host and port where Kestrel listens. Using the default host and post, make a request to `http://localhost:5000/`. If the app responds normally at the Kestrel endpoint address, the problem is more likely related to the reverse proxy configuration and less likely within the app.
 
-**Self-contained deployment**
+#### Self-contained deployment
 
 If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd):
 
@@ -136,7 +138,8 @@ To enable and view stdout logs:
 1. Navigate to the *logs* folder. Find and open the most recent stdout log.
 1. Study the log for errors.
 
-**Important!** Disable stdout logging when troubleshooting is complete.
+> [!IMPORTANT]
+> Disable stdout logging when troubleshooting is complete.
 
 1. Edit the *web.config* file.
 1. Set **stdoutLogEnabled** to `false`.
@@ -147,9 +150,27 @@ To enable and view stdout logs:
 >
 > For routine logging in an ASP.NET Core app, use a logging library that limits log file size and rotates logs. For more information, see [third-party logging providers](xref:fundamentals/logging/index#third-party-logging-providers).
 
-## Enabling the Developer Exception Page
+## Enable the Developer Exception Page
 
 The `ASPNETCORE_ENVIRONMENT` [environment variable can be added to web.config](xref:host-and-deploy/aspnet-core-module#setting-environment-variables) to run the app in the Development environment. As long as the environment isn't overridden in app startup by `UseEnvironment` on the host builder, setting the environment variable allows the [Developer Exception Page](xref:fundamentals/error-handling) to appear when the app is run.
+
+::: moniker range=">= aspnetcore-2.2"
+
+```xml
+<aspNetCore processPath="dotnet"
+      arguments=".\MyApp.dll"
+      stdoutLogEnabled="false"
+      stdoutLogFile=".\logs\stdout"
+      hostingModel="inprocess">
+  <environmentVariables>
+    <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
+  </environmentVariables>
+</aspNetCore>
+```
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.2"
 
 ```xml
 <aspNetCore processPath="dotnet"
@@ -162,11 +183,17 @@ The `ASPNETCORE_ENVIRONMENT` [environment variable can be added to web.config](x
 </aspNetCore>
 ```
 
+::: moniker-end
+
 Setting the environment variable for `ASPNETCORE_ENVIRONMENT` is only recommended for use on staging and testing servers that aren't exposed to the Internet. Remove the environment variable from the *web.config* file after troubleshooting. For information on setting environment variables in *web.config*, see [environmentVariables child element of aspNetCore](xref:host-and-deploy/aspnet-core-module#setting-environment-variables).
 
-## Common startup errors 
+## Common startup errors
 
 See <xref:host-and-deploy/azure-iis-errors-reference>. Most of the common problems that prevent app startup are covered in the reference topic.
+
+## Obtain data from an app
+
+If an app is capable of responding to requests, obtain request, connection, and additional data from the app using terminal inline middleware. For more information and sample code, see <xref:test/troubleshoot#obtain-data-from-an-app>.
 
 ## Slow or hanging app
 
@@ -184,7 +211,7 @@ See [Remote Debug ASP.NET Core on a Remote IIS Computer in Visual Studio 2017](/
 
 [Application Insights](/azure/application-insights/) provides telemetry from apps hosted by IIS, including error logging and reporting features. Application Insights can only report on errors that occur after the app starts when the app's logging features become available. For more information, see [Application Insights for ASP.NET Core](/azure/application-insights/app-insights-asp-net-core).
 
-## Additional troubleshooting advice
+## Additional advice
 
 Sometimes a functioning app fails immediately after upgrading either the .NET Core SDK on the development machine or package versions within the app. In some cases, incoherent packages may break an app when performing major upgrades. Most of these issues can be fixed by following these instructions:
 
@@ -195,11 +222,12 @@ Sometimes a functioning app fails immediately after upgrading either the .NET Co
 
 > [!TIP]
 > A convenient way to clear package caches is to execute `dotnet nuget locals all --clear` from a command prompt.
-> 
+>
 > Clearing package caches can also be accomplished by using the [nuget.exe](https://www.nuget.org/downloads) tool and executing the command `nuget locals all -clear`. *nuget.exe* isn't a bundled install with the Windows desktop operating system and must be obtained separately from the [NuGet website](https://www.nuget.org/downloads).
 
 ## Additional resources
 
+* <xref:test/troubleshoot>
 * <xref:fundamentals/error-handling>
 * <xref:host-and-deploy/azure-iis-errors-reference>
 * <xref:host-and-deploy/aspnet-core-module>

--- a/aspnetcore/host-and-deploy/index.md
+++ b/aspnetcore/host-and-deploy/index.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to set up hosting environments and deploy ASP.NET Core apps.
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/07/2017
+ms.date: 11/26/2018
 uid: host-and-deploy/index
 ---
 # Host and deploy ASP.NET Core
@@ -25,7 +25,7 @@ The *publish* folder contains *.exe* and *.dll* files for the app, its dependenc
 
 A .NET Core app can be published as *self-contained* or *framework-dependent* app. If the app is self-contained, the *.dll* files that contain the .NET runtime are included in the *publish* folder. If the app is framework-dependent, the .NET runtime files aren't included because the app has a reference to a version of .NET that's installed on the server. The default deployment model is framework-dependent. For more information, see [.NET Core application deployment](/dotnet/articles/core/deploying/index).
 
-In addition to *.exe* and *.dll* files, the *publish* folder for an ASP.NET Core app typically contains configuration files, static assets, and MVC views. For more information, see [Directory structure](xref:host-and-deploy/directory-structure).
+In addition to *.exe* and *.dll* files, the *publish* folder for an ASP.NET Core app typically contains configuration files, static assets, and MVC views. For more information, see <xref:host-and-deploy/directory-structure>.
 
 ## Set up a process manager
 
@@ -40,31 +40,33 @@ An ASP.NET Core app is a console app that must be started when a server boots an
 
 ## Set up a reverse proxy
 
-# [ASP.NET Core 2.x](#tab/aspnetcore2x)
+::: moniker range=">= aspnetcore-2.0"
 
 If the app uses the [Kestrel](xref:fundamentals/servers/kestrel) web server, [Nginx](xref:host-and-deploy/linux-nginx), [Apache](xref:host-and-deploy/linux-apache), or [IIS](xref:host-and-deploy/iis/index) can be used as a reverse proxy server. A reverse proxy server receives HTTP requests from the Internet and forwards them to Kestrel after some preliminary handling.
 
 Either configuration&mdash;with or without a reverse proxy server&mdash;is a valid and supported hosting configuration for ASP.NET Core 2.0 or later apps. For more information, see [When to use Kestrel with a reverse proxy](xref:fundamentals/servers/kestrel#when-to-use-kestrel-with-a-reverse-proxy).
 
-# [ASP.NET Core 1.x](#tab/aspnetcore1x)
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.0"
 
 If the app uses the [Kestrel](xref:fundamentals/servers/kestrel) web server and will be exposed to the Internet, use [Nginx](xref:host-and-deploy/linux-nginx), [Apache](xref:host-and-deploy/linux-apache), or [IIS](xref:host-and-deploy/iis/index) as a reverse proxy server. A reverse proxy server receives HTTP requests from the Internet and forwards them to Kestrel after some preliminary handling. The main reason for using a reverse proxy is security. For more information, see [When to use Kestrel with a reverse proxy](xref:fundamentals/servers/kestrel?tabs=aspnetcore1x#when-to-use-kestrel-with-a-reverse-proxy).
 
----
+::: moniker-end
 
 ## Proxy server and load balancer scenarios
 
 Additional configuration might be required for apps hosted behind proxy servers and load balancers. Without additional configuration, an app might not have access to the scheme (HTTP/HTTPS) and the remote IP address where a request originated. For more information, see [Configure ASP.NET Core to work with proxy servers and load balancers](xref:host-and-deploy/proxy-load-balancer).
 
-## Using Visual Studio and MSBuild to automate deployment
+## Use Visual Studio and MSBuild to automate deployments
 
-Deployment often requires additional tasks besides copying the output from [dotnet publish](/dotnet/core/tools/dotnet-publish) to a server. For example, extra files might be required or excluded from the *publish* folder. Visual Studio uses MSBuild for web deployment, and MSBuild can be customized to do many other tasks during deployment. For more information, see [Publish profiles in Visual Studio](xref:host-and-deploy/visual-studio-publish-profiles) and the [Using MSBuild and Team Foundation Build](http://msbuildbook.com/) book.
+Deployment often requires additional tasks besides copying the output from [dotnet publish](/dotnet/core/tools/dotnet-publish) to a server. For example, extra files might be required or excluded from the *publish* folder. Visual Studio uses MSBuild for web deployment, and MSBuild can be customized to do many other tasks during deployment. For more information, see <xref:host-and-deploy/visual-studio-publish-profiles> and the [Using MSBuild and Team Foundation Build](http://msbuildbook.com/) book.
 
 By using [the Publish Web feature](xref:tutorials/publish-to-azure-webapp-using-vs) or [built-in Git support](xref:host-and-deploy/azure-apps/azure-continuous-deployment), apps can be deployed directly from Visual Studio to the Azure App Service. Azure DevOps Services supports [continuous deployment to Azure App Service](/azure/devops/pipelines/targets/webapp).
 
-## Publishing to Azure
+## Publish to Azure
 
-See [Publish an ASP.NET Core web app to Azure App Service using Visual Studio](xref:tutorials/publish-to-azure-webapp-using-vs) for instructions on how to publish an app to Azure using Visual Studio. The app can also be published to Azure from the [command line](/azure/app-service/app-service-web-get-started-dotnet).
+See <xref:tutorials/publish-to-azure-webapp-using-vs> for instructions on how to publish an app to Azure using Visual Studio. The app can also be published to Azure from the [command line](/azure/app-service/app-service-web-get-started-dotnet).
 
 ## Host in a web farm
 
@@ -72,4 +74,5 @@ For information on configuration for hosting ASP.NET Core apps in a web farm env
 
 ## Additional resources
 
-For information on using Docker as a hosting environment, see [Host ASP.NET Core apps in Docker](xref:host-and-deploy/docker/index).
+* <xref:host-and-deploy/docker/index>
+* <xref:test/troubleshoot>

--- a/aspnetcore/host-and-deploy/linux-apache.md
+++ b/aspnetcore/host-and-deploy/linux-apache.md
@@ -176,7 +176,7 @@ sudo systemctl enable httpd
 
 ## Monitor the app
 
-Apache is now setup to forward requests made to `http://localhost:80` to the ASP.NET Core app running on Kestrel at `http://127.0.0.1:5000`.  However, Apache isn't set up to manage the Kestrel process. Use *systemd* and create a service file to start and monitor the underlying web app. *systemd* is an init system that provides many powerful features for starting, stopping, and managing processes.
+Apache is now setup to forward requests made to `http://localhost:80` to the ASP.NET Core app running on Kestrel at `http://127.0.0.1:5000`. However, Apache isn't set up to manage the Kestrel process. Use *systemd* and create a service file to start and monitor the underlying web app. *systemd* is an init system that provides many powerful features for starting, stopping, and managing processes.
 
 ### Create the service file
 

--- a/aspnetcore/host-and-deploy/linux-apache.md
+++ b/aspnetcore/host-and-deploy/linux-apache.md
@@ -4,7 +4,7 @@ description: Learn how to set up Apache as a reverse proxy server on CentOS to r
 author: spboyer
 ms.author: spboyer
 ms.custom: mvc
-ms.date: 10/23/2018
+ms.date: 11/26/2018
 uid: host-and-deploy/linux-apache
 ---
 # Host ASP.NET Core on Linux with Apache
@@ -174,9 +174,9 @@ sudo systemctl restart httpd
 sudo systemctl enable httpd
 ```
 
-## Monitoring the app
+## Monitor the app
 
-Apache is now setup to forward requests made to `http://localhost:80` to the ASP.NET Core app running on Kestrel at `http://127.0.0.1:5000`.  However, Apache isn't set up to manage the Kestrel process. Use *systemd* and create a service file to start and monitor the underlying web app. *systemd* is an init system that provides many powerful features for starting, stopping, and managing processes. 
+Apache is now setup to forward requests made to `http://localhost:80` to the ASP.NET Core app running on Kestrel at `http://127.0.0.1:5000`.  However, Apache isn't set up to manage the Kestrel process. Use *systemd* and create a service file to start and monitor the underlying web app. *systemd* is an init system that provides many powerful features for starting, stopping, and managing processes.
 
 ### Create the service file
 
@@ -253,7 +253,7 @@ Connection: Keep-Alive
 Transfer-Encoding: chunked
 ```
 
-### Viewing logs
+### View logs
 
 Since the web app using Kestrel is managed using *systemd*, events and processes are logged to a centralized journal. However, this journal includes entries for all of the services and processes managed by *systemd*. To view the `kestrel-helloapp.service`-specific items, use the following command:
 
@@ -282,7 +282,7 @@ To configure data protection to persist and encrypt the key ring, see:
 * <xref:security/data-protection/implementation/key-storage-providers>
 * <xref:security/data-protection/implementation/key-encryption-at-rest>
 
-## Securing the app
+## Secure the app
 
 ### Configure firewall
 
@@ -479,4 +479,5 @@ The example file limits bandwidth as 600 KB/sec under the root location:
 ## Additional resources
 
 * [Prerequisites for .NET Core on Linux](/dotnet/core/linux-prerequisites)
-* [Configure ASP.NET Core to work with proxy servers and load balancers](xref:host-and-deploy/proxy-load-balancer)
+* <xref:test/troubleshoot>
+* <xref:host-and-deploy/proxy-load-balancer>

--- a/aspnetcore/host-and-deploy/linux-nginx.md
+++ b/aspnetcore/host-and-deploy/linux-nginx.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to setup Nginx as a reverse proxy on Ubuntu 16.04 to forward HTTP traffic to an ASP.NET Core web app running on Kestrel.
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/23/2018
+ms.date: 11/26/2018
 uid: host-and-deploy/linux-nginx
 ---
 # Host ASP.NET Core on Linux with Nginx
@@ -180,7 +180,7 @@ If the app runs on the server but fails to respond over the Internet, check the 
 
 When done testing the app, shut the app down with `Ctrl+C` at the command prompt.
 
-## Monitoring the app
+## Monitor the app
 
 The server is setup to forward requests made to `http://<serveraddress>:80` on to the ASP.NET Core app running on Kestrel at `http://127.0.0.1:5000`. However, Nginx isn't set up to manage the Kestrel process. *systemd* can be used to create a service file to start and monitor the underlying web app. *systemd* is an init system that provides many powerful features for starting, stopping, and managing processes. 
 
@@ -262,7 +262,7 @@ Connection: Keep-Alive
 Transfer-Encoding: chunked
 ```
 
-### Viewing logs
+### View logs
 
 Since the web app using Kestrel is managed using `systemd`, all events and processes are logged to a centralized journal. However, this journal includes all entries for all services and processes managed by `systemd`. To view the `kestrel-helloapp.service`-specific items, use the following command:
 
@@ -291,13 +291,13 @@ To configure data protection to persist and encrypt the key ring, see:
 * <xref:security/data-protection/implementation/key-storage-providers>
 * <xref:security/data-protection/implementation/key-encryption-at-rest>
 
-## Securing the app
+## Secure the app
 
 ### Enable AppArmor
 
 Linux Security Modules (LSM) is a framework that's part of the Linux kernel since Linux 2.6. LSM supports different implementations of security modules. [AppArmor](https://wiki.ubuntu.com/AppArmor) is a LSM that implements a Mandatory Access Control system which allows confining the program to a limited set of resources. Ensure AppArmor is enabled and properly configured.
 
-### Configuring the firewall
+### Configure the firewall
 
 Close off all external ports that are not in use. Uncomplicated firewall (ufw) provides a front end for `iptables` by providing a command line interface for configuring the firewall.
 
@@ -316,7 +316,7 @@ sudo ufw allow 443/tcp
 sudo ufw enable
 ```
 
-### Securing Nginx
+### Secure Nginx
 
 #### Change the Nginx response name
 
@@ -381,5 +381,6 @@ Add the line `add_header X-Content-Type-Options "nosniff";` and save the file, t
 
 * [Prerequisites for .NET Core on Linux](/dotnet/core/linux-prerequisites)
 * [Nginx: Binary Releases: Official Debian/Ubuntu packages](https://www.nginx.com/resources/wiki/start/topics/tutorials/install/#official-debian-ubuntu-packages)
-* [Configure ASP.NET Core to work with proxy servers and load balancers](xref:host-and-deploy/proxy-load-balancer)
+* <xref:test/troubleshoot>
+* <xref:host-and-deploy/proxy-load-balancer>
 * [NGINX: Using the Forwarded header](https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/)

--- a/aspnetcore/host-and-deploy/web-farm.md
+++ b/aspnetcore/host-and-deploy/web-farm.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn how to host multiple instances of an ASP.NET Core app with shared resources in a web farm environment.
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/16/2018
+ms.date: 11/26/2018
 uid: host-and-deploy/web-farm
 ---
 # Host ASP.NET Core in a web farm
@@ -61,11 +61,13 @@ The following scenarios don't require additional configuration, but they depend 
 
 ## Troubleshoot
 
-When Data Protection or Caching isn't configured for a web farm environment, intermittent errors occur when requests are processed. This occurs because nodes don't share the same resources and user requests aren't always routed back to the same node.
+### Data Protection and caching
+
+When Data Protection or caching isn't configured for a web farm environment, intermittent errors occur when requests are processed. This occurs because nodes don't share the same resources and user requests aren't always routed back to the same node.
 
 Consider a user who signs into the app using cookie authentication. The user signs into the app on one web farm node. If their next request arrives at the same node where they signed in, the app is able to decrypt the authentication cookie and allows access to the app's resource. If their next request arrives at a different node, the app can't decrypt the authentication cookie from the node where the user signed in, and authorization for the requested resource fails.
 
-When any of the following symptoms occur **intermittently**, the problem is usually traced to improper Data Protection or Caching configuration for a web farm environment:
+When any of the following symptoms occur **intermittently**, the problem is usually traced to improper Data Protection or caching configuration for a web farm environment:
 
 * Authentication breaks &ndash; The authentication cookie is misconfigured or can't be decrypted. OAuth (Facebook, Microsoft, Twitter) or OpenIdConnect logins fail with the error "Correlation failed."
 * Authorization breaks &ndash; Identity is lost.
@@ -74,4 +76,8 @@ When any of the following symptoms occur **intermittently**, the problem is usua
 * TempData fails.
 * POSTs fail &ndash; The anti-forgery check fails.
 
-For more information on Data Protection configuration for web farm deployments, see <xref:security/data-protection/configuration/overview>. For more information on Caching configuration for web farm deployments, see <xref:performance/caching/distributed>.
+For more information on Data Protection configuration for web farm deployments, see <xref:security/data-protection/configuration/overview>. For more information on caching configuration for web farm deployments, see <xref:performance/caching/distributed>.
+
+## Obtain data from apps
+
+If the web farm apps are capable of responding to requests, obtain request, connection, and additional data from the apps using terminal inline middleware. For more information and sample code, see <xref:test/troubleshoot#obtain-data-from-an-app>.

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -5,7 +5,7 @@ description: Learn how to host an ASP.NET Core app in a Windows Service.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 10/30/2018
+ms.date: 11/26/2018
 uid: host-and-deploy/windows-service
 ---
 # Host ASP.NET Core in a Windows Service
@@ -234,3 +234,4 @@ The current working directory returned by calling `Directory.GetCurrentDirectory
 
 * [Kestrel endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration) (includes HTTPS configuration and SNI support)
 * <xref:fundamentals/host/web-host>
+* <xref:test/troubleshoot>

--- a/aspnetcore/test/troubleshoot.md
+++ b/aspnetcore/test/troubleshoot.md
@@ -64,14 +64,15 @@ This warning appears when the environment variable `PATH` doesn't point to any .
 
 ## Obtain data from an app
 
-If an app is capable of responding to requests, you can obtain the following data from the app using terminal inline middleware:
+If an app is capable of responding to requests, you can obtain the following data from the app using middleware:
 
 * Request &ndash; Method, scheme, host, pathbase, path, query string, headers
 * Connection &ndash; Remote IP address, remote port, local IP address, local port, client certificate
 * Identity &ndash; Name, display name
+* Configuration settings
 * Environment variables
 
-Place the following [terminal middleware](xref:fundamentals/middleware/index#create-a-middleware-pipeline-with-iapplicationbuilder) code snippet at the start of the `Startup.Configure` method's request processing pipeline. The environment is checked before the middleware is run to ensure that the code is only executed in the Development environment.
+Place the following [middleware](xref:fundamentals/middleware/index#create-a-middleware-pipeline-with-iapplicationbuilder) code at the beginning of the `Startup.Configure` method's request processing pipeline. The environment is checked before the middleware is run to ensure that the code is only executed in the Development environment.
 
 To obtain the environment use either of the following approaches:
 
@@ -80,7 +81,8 @@ To obtain the environment use either of the following approaches:
 * Assign the environment to a property in the `Startup` class. Check the environment using the property (for example, `if (Environment.IsDevelopment())`).
 
 ```csharp
-public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+public void Configure(IApplicationBuilder app, IHostingEnvironment env, 
+    IConfiguration config)
 {
     if (env.IsDevelopment())
     {
@@ -130,6 +132,13 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
             {
                 sb.Append($"Status: Disabled{nl}{nl}");
             }
+
+            sb.Append($"Configuration{rule}");
+            foreach (var pair in config.GetChildren())
+            {
+                sb.Append($"{pair.Path}: {pair.Value}{nl}");
+            }
+            sb.Append(nl);
 
             sb.Append($"Environment Variables{rule}");
             var vars = System.Environment.GetEnvironmentVariables();

--- a/aspnetcore/test/troubleshoot.md
+++ b/aspnetcore/test/troubleshoot.md
@@ -74,7 +74,7 @@ If an app is capable of responding to requests, you can obtain the following dat
 
 Place the following [middleware](xref:fundamentals/middleware/index#create-a-middleware-pipeline-with-iapplicationbuilder) code at the beginning of the `Startup.Configure` method's request processing pipeline. The environment is checked before the middleware is run to ensure that the code is only executed in the Development environment.
 
-To obtain the environment use either of the following approaches:
+To obtain the environment, use either of the following approaches:
 
 * Inject the `IHostingEnvironment` into the `Startup.Configure` method and check the environment with the local variable. The following sample code demonstrates this approach.
 

--- a/aspnetcore/test/troubleshoot.md
+++ b/aspnetcore/test/troubleshoot.md
@@ -134,7 +134,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env,
             }
 
             sb.Append($"Configuration{rule}");
-            foreach (var pair in config.GetChildren())
+            foreach (var pair in config.AsEnumerable())
             {
                 sb.Append($"{pair.Path}: {pair.Value}{nl}");
             }

--- a/aspnetcore/test/troubleshoot.md
+++ b/aspnetcore/test/troubleshoot.md
@@ -4,7 +4,7 @@ author: Rick-Anderson
 description: Understand and troubleshoot warnings and errors with ASP.NET Core projects.
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/24/2018
+ms.date: 11/26/2018
 uid: test/troubleshoot
 ---
 # Troubleshoot ASP.NET Core projects
@@ -61,3 +61,88 @@ This warning appears when the environment variable `PATH` doesn't point to any .
 
 * Install or verify the .NET Core SDK is installed.
 * Verify that the `PATH` environment variable points to the location in which the SDK is installed. The installer normally sets the `PATH`.
+
+## Obtain data from an app
+
+If an app is capable of responding to requests, you can obtain the following data from the app using terminal inline middleware:
+
+* Request &ndash; Method, scheme, host, pathbase, path, query string, headers
+* Connection &ndash; Remote IP address, remote port, local IP address, local port, client certificate
+* Identity &ndash; Name, display name
+* Environment variables
+
+Place the following [terminal middleware](xref:fundamentals/middleware/index#create-a-middleware-pipeline-with-iapplicationbuilder) code snippet at the start of the `Startup.Configure` method's request processing pipeline. The environment is checked before the middleware is run to ensure that the code is only executed in the Development environment.
+
+To obtain the environment use either of the following approaches:
+
+* Inject the `IHostingEnvironment` into the `Startup.Configure` method and check the environment with the local variable. The following sample code demonstrates this approach.
+
+* Assign the environment to a property in the `Startup` class. Check the environment using the property (for example, `if (Environment.IsDevelopment())`).
+
+```csharp
+public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+{
+    if (env.IsDevelopment())
+    {
+        app.Run(async (context) =>
+        {
+            var sb = new StringBuilder();
+            var nl = System.Environment.NewLine;
+            var rule = string.Concat(nl, new string('-', 40), nl);
+            var authSchemeProvider = app.ApplicationServices
+                .GetRequiredService<IAuthenticationSchemeProvider>();
+
+            sb.Append($"Request{rule}");
+            sb.Append($"{DateTimeOffset.Now}{nl}");
+            sb.Append($"{context.Request.Method} {context.Request.Path}{nl}");
+            sb.Append($"Scheme: {context.Request.Scheme}{nl}");
+            sb.Append($"Host: {context.Request.Headers["Host"]}{nl}");
+            sb.Append($"PathBase: {context.Request.PathBase.Value}{nl}");
+            sb.Append($"Path: {context.Request.Path.Value}{nl}");
+            sb.Append($"Query: {context.Request.QueryString.Value}{nl}{nl}");
+
+            sb.Append($"Connection{rule}");
+            sb.Append($"RemoteIp: {context.Connection.RemoteIpAddress}{nl}");
+            sb.Append($"RemotePort: {context.Connection.RemotePort}{nl}");
+            sb.Append($"LocalIp: {context.Connection.LocalIpAddress}{nl}");
+            sb.Append($"LocalPort: {context.Connection.LocalPort}{nl}");
+            sb.Append($"ClientCert: {context.Connection.ClientCertificate}{nl}{nl}");
+
+            sb.Append($"Identity{rule}");
+            sb.Append($"User: {context.User.Identity.Name}{nl}");
+            var scheme = await authSchemeProvider
+                .GetSchemeAsync(IISDefaults.AuthenticationScheme);
+            sb.Append($"DisplayName: {scheme?.DisplayName}{nl}{nl}");
+
+            sb.Append($"Headers{rule}");
+            foreach (var header in context.Request.Headers)
+            {
+                sb.Append($"{header.Key}: {header.Value}{nl}");
+            }
+            sb.Append(nl);
+
+            sb.Append($"Websockets{rule}");
+            if (context.Features.Get<IHttpUpgradeFeature>() != null)
+            {
+                sb.Append($"Status: Enabled{nl}{nl}");
+            }
+            else
+            {
+                sb.Append($"Status: Disabled{nl}{nl}");
+            }
+
+            sb.Append($"Environment Variables{rule}");
+            var vars = System.Environment.GetEnvironmentVariables();
+            foreach (var key in vars.Keys.Cast<string>().OrderBy(key => key, 
+                StringComparer.OrdinalIgnoreCase))
+            {
+                var value = vars[key];
+                sb.Append($"{key}: {value}{nl}");
+            }
+
+            context.Response.ContentType = "text/plain";
+            await context.Response.WriteAsync(sb.ToString());
+        });
+    }
+}
+```


### PR DESCRIPTION
Fixes #6083 

[Internal Review Topic (Troubleshoot ASP.NET Core projects)](https://review.docs.microsoft.com/en-us/aspnet/core/test/troubleshoot?view=aspnetcore-1.0&branch=pr-en-us-9689)

* The app code from IIS Integration that reports request, connection, env vars is so useful, including outside of IIS scenarios, that imo it should be surfaced to readers. I've used it several times, and the community has enjoyed using it.
* Engineering: The main update to review here is at the bottom of the diff (updates to the last file): *test/troubleshoot.md*.
* In most spots, adding a link to the *test/troublshoot.md* topic is enough. In a few spots, I add a short section.
* UE is not a thrust of this, but I did fix up a few things as I went along.