### PR TITLE
Error NU1605: Detected package downgrade.

### DIFF
--- a/aspnetcore/security/authentication/identity/sample/src/ASPNETCore-IdentityDemoComplete/IdentityDemo/IdentityDemo.csproj
+++ b/aspnetcore/security/authentication/identity/sample/src/ASPNETCore-IdentityDemoComplete/IdentityDemo/IdentityDemo.csproj
@@ -8,11 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" />
     <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.0" />
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />


### PR DESCRIPTION
Demo\IdentityDemo.csproj : error NU1605: Detected package downgrade: Microsoft.EntityFrameworkCore.Tools from 2.0.3 to 2.0.0. Reference the package directly from the project to select a different version.
Demo\IdentityDemo.csproj : error NU1605:  IdentityDemo -> Microsoft.AspNetCore.All 2.0.9 -> Microsoft.EntityFrameworkCore.Tools (>= 2.0.3)
Demo\IdentityDemo.csproj : error NU1605:  IdentityDemo -> Microsoft.EntityFrameworkCore.Tools (>= 2.0.0)

The build failed. Please fix the build errors and run again.



<!--
When creating a new PR, please do the following:

* Reference the issue number if there is one, e.g.:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->