### PR TITLE
Remove version tabs from intro to MVC

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc.md
@@ -78,26 +78,7 @@ In the next part of this tutorial, we'll learn about MVC and start writing some 
 
 ::: moniker range="<= aspnetcore-2.0"
 
-# [ASP.NET Core 2.x](#tab/aspnetcore2x/)
-
 [!INCLUDE [](~/includes/net-core-prereqs.md)]
-
-# [ASP.NET Core 1.x](#tab/aspnetcore1x/)
-
-Install Visual Studio Community 2017. Select the Community download. Skip this step if you have Visual Studio 2017 installed.
-
-* [Visual Studio 2017 Home page installer](https://www.visualstudio.com/)
-
-Run the installer and select the following workloads:
-
-* **ASP.NET and web development** (under **Web & Cloud**)
-* **.NET Core cross-platform development** (under **Other Toolsets**)
-
-![**ASP.NET and web development** (under **Web & Cloud**)](start-mvc/_static/web_workload.png)
-
-![**.NET Core cross-cross-platfrom development** (under **Other Toolsets**)](start-mvc/_static/x_plat_wl.png)
-
----
 
 ## Create a web app
 
@@ -114,8 +95,6 @@ Complete the **New Project** dialog:
 
 ![New project dialog, .Net core in left pane, ASP.NET Core web ](start-mvc/_static/new_project2.png)
 
-# [ASP.NET Core 2.x](#tab/aspnetcore2x)
-
 Complete the **New ASP.NET Core Web Application (.NET Core) - MvcMovie** dialog:
 
 * In the version selector drop-down box select **ASP.NET Core 2.-**
@@ -123,19 +102,6 @@ Complete the **New ASP.NET Core Web Application (.NET Core) - MvcMovie** dialog:
 * Tap **OK**.
 
 ![New project dialog, .Net core in left pane, ASP.NET Core web ](start-mvc/_static/new_project22.png)
-
-# [ASP.NET Core 1.x](#tab/aspnetcore1x)
-
-Complete the **New ASP.NET Core Web Application (.NET Core) - MvcMovie** dialog:
-
-* In the version selector drop-down box tap **ASP.NET Core 1.1**
-* Tap **Web Application**
-* Keep the default **No Authentication**
-* Tap **OK**.
-
-![New ASP.NET Core web app](start-mvc/_static/p3.png)
-
----
 
 Visual Studio used a default template for the MVC project you just created. You have a working app right now by entering a project name and selecting a few options. This is a basic starter project, and it's a good place to start,
 

--- a/aspnetcore/tutorials/first-mvc-app/working-with-sql.md
+++ b/aspnetcore/tutorials/first-mvc-app/working-with-sql.md
@@ -80,19 +80,9 @@ Replace the contents of *Program.cs* with the following code:
 
 ::: moniker range="<= aspnetcore-2.0"
 
-# [ASP.NET Core 2.x](#tab/aspnetcore2x/)
-
 Add the seed initializer to the `Main` method in the *Program.cs* file:
 
 [!code-csharp[](start-mvc/sample/MvcMovie/Program.cs?highlight=6,14-32)]
-
-# [ASP.NET Core 1.x](#tab/aspnetcore1x/)
-
-Add the seed initializer to the end of the `Configure` method in the *Startup.cs* file.
-
-[!code-csharp[](start-mvc/sample/MvcMovie/Startup.cs?highlight=9&name=snippet_seed)]
-
----
 
 ::: moniker-end
 


### PR DESCRIPTION
Two of the tutorials still had tabs being used for versions. The only purpose was to include 1.x text in the tutorial, so the tabs and 1.x content were removed.
