### PR TITLE
Create net-core-prereqs-all-2.1.md

### DIFF
--- a/aspnetcore/includes/net-core-prereqs-all-2.1.md
+++ b/aspnetcore/includes/net-core-prereqs-all-2.1.md
@@ -1,0 +1,17 @@
+# [Visual Studio](#tab/visual-studio)
+
+* [Visual Studio 2017 version 15.7.3 or later](https://visualstudio.microsoft.com/downloads/) with the **ASP.NET and web development** workload
+* [.NET Core 2.1 SDK or later](https://www.microsoft.com/net/download/windows)
+
+# [Visual Studio Code](#tab/visual-studio-code)
+
+* [Visual Studio Code](https://code.visualstudio.com/download)
+* [.NET Core SDK 2.1 or later](https://www.microsoft.com/net/download/all)
+* [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+* [Visual Studio for Mac version 7.6.10 or later](https://www.visualstudio.com/downloads/)
+* [.NET Core SDK 2.1 or later](https://www.microsoft.com/net/download/all)
+
+---


### PR DESCRIPTION
We should use this for all 2.2 tutorials - as appropriate. We can flesh this out. Nice consistency.

We could even add `## Prerequisites` to the top.