### PR TITLE
Coverage for 64-bit apps on Azure App Service

### DIFF
--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -2,9 +2,10 @@
 title: Deploy ASP.NET Core apps to Azure App Service
 author: guardrex
 description: This article contains links to Azure host and deploy resources.
+monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/24/2018
+ms.date: 12/04/2018
 uid: host-and-deploy/azure-apps/index
 ---
 # Deploy ASP.NET Core apps to Azure App Service
@@ -35,19 +36,21 @@ Set up a CI build for an ASP.NET Core app, then create a continuous deployment r
 [Azure Web App sandbox](https://github.com/projectkudu/kudu/wiki/Azure-Web-App-sandbox)  
 Discover Azure App Service runtime execution limitations enforced by the Azure Apps platform.
 
-::: moniker range=">= aspnetcore-2.0"
-
 ## Application configuration
 
-The following NuGet packages provide automatic logging features for apps deployed to Azure App Service:
+### Platform
+
+Runtimes for 64-bit (x64) and 32-bit (x86) apps are present on the Azure App Service and supported for ASP.NET Core apps. The [.NET Core SDK](/dotnet/core/sdk) available on App Service is 32-bit, but you can deploy 64-bit apps using the [Kudu](https://github.com/projectkudu/kudu/wiki) console or via [MSDeploy with a Visual Studio Azure App Service publish profile or CLI command](xref:host-and-deploy/visual-studio-publish-profiles).
+
+### Packages
+
+Include the following NuGet packages to provide automatic logging features for apps deployed to Azure App Service:
 
 * [Microsoft.AspNetCore.AzureAppServices.HostingStartup](https://www.nuget.org/packages/Microsoft.AspNetCore.AzureAppServices.HostingStartup/) uses [IHostingStartup](xref:fundamentals/configuration/platform-specific-configuration) to provide ASP.NET Core light-up integration with Azure App Service. The added logging features are provided by the `Microsoft.AspNetCore.AzureAppServicesIntegration` package.
 * [Microsoft.AspNetCore.AzureAppServicesIntegration](https://www.nuget.org/packages/Microsoft.AspNetCore.AzureAppServicesIntegration/) executes [AddAzureWebAppDiagnostics](/dotnet/api/microsoft.extensions.logging.azureappservicesloggerfactoryextensions.addazurewebappdiagnostics) to add Azure App Service diagnostics logging providers in the `Microsoft.Extensions.Logging.AzureAppServices` package.
 * [Microsoft.Extensions.Logging.AzureAppServices](https://www.nuget.org/packages/Microsoft.Extensions.Logging.AzureAppServices/) provides logger implementations to support Azure App Service diagnostics logs and log streaming features.
 
-If targeting .NET Core and referencing the [Microsoft.AspNetCore.All metapackage](xref:fundamentals/metapackage), the preceding packages are included. The packages are absent from the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app). If targeting .NET Framework or referencing the `Microsoft.AspNetCore.App` metapackage, reference the individual logging packages.
-
-::: moniker-end
+The preceding packages aren't available from the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app). If targeting .NET Framework or referencing the `Microsoft.AspNetCore.App` metapackage, reference the individual packages in the app's project file.
 
 ## Override app configuration using the Azure Portal
 
@@ -112,7 +115,7 @@ If a problem occurs using the preview site extension, open an issue on [GitHub](
 1. Type "ex" in the search box or scroll down the list of management sections to **DEVELOPMENT TOOLS**.
 1. Select **DEVELOPMENT TOOLS** > **Extensions**.
 1. Select **Add**.
-1. Select the **ASP.NET Core &lt;x.y&gt; (x86) Runtime** extension from the list, where `<x.y>` is the ASP.NET Core preview version (for example, **ASP.NET Core 2.2 (x86) Runtime**). The x86 runtime is appropriate for [framework-dependent deployments](/dotnet/core/deploying/#framework-dependent-deployments-fdd) that rely on out-of-process hosting by the ASP.NET Core Module.
+1. Select the **ASP.NET Core {X.Y} ({x64|x86}) Runtime** extension from the list, where `{X.Y}` is the ASP.NET Core preview version (for example, **ASP.NET Core 2.2 (x86) Runtime**).
 1. Select **OK** to accept the legal terms.
 1. Select **OK** to install the extension.
 
@@ -121,12 +124,12 @@ When the operation completes, the latest .NET Core preview is installed. Verify 
 1. Select **Advanced Tools** under **DEVELOPMENT TOOLS**.
 1. Select **Go** on the **Advanced Tools** blade.
 1. Select the **Debug console** > **PowerShell** menu item.
-1. At the PowerShell prompt, execute the following command. Substitute the ASP.NET Core runtime version for `<x.y>` in the command:
+1. At the PowerShell prompt, execute the following command. Substitute the ASP.NET Core runtime version for `{X.Y}` and the platform for `{PLATFORM}` in the command:
 
    ```powershell
-   Test-Path D:\home\SiteExtensions\AspNetCoreRuntime.<x.y>.x86\
+   Test-Path D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.{PLATFORM}\
    ```
-   If the installed preview runtime is for ASP.NET Core 2.2, the command is:
+   If the installed preview runtime is for ASP.NET Core 2.2 (x86), the command is:
    ```powershell
    Test-Path D:\home\SiteExtensions\AspNetCoreRuntime.2.2.x86\
    ```
@@ -135,12 +138,12 @@ When the operation completes, the latest .NET Core preview is installed. Verify 
 ::: moniker range=">= aspnetcore-2.2"
 
 > [!NOTE]
-> The platform architecture (x86/x64) of an App Services app is set in the **Application Settings** blade under **General Settings** for apps that are hosted on an A-series compute or better hosting tier. If the app is run in in-process mode and the platform architecture is configured for 64-bit (x64), the ASP.NET Core Module uses the 64-bit preview runtime, if present. Install the **ASP.NET Core &lt;x.y&gt; (x64) Runtime** extension (for example, **ASP.NET Core 2.2 (x64) Runtime**).
+> The platform architecture (x86/x64) of an App Services app is set in the **Application Settings** blade under **General Settings** for apps that are hosted on an A-series compute or better hosting tier. If the app is run in in-process mode and the platform architecture is configured for 64-bit (x64), the ASP.NET Core Module uses the 64-bit preview runtime, if present. Install the **ASP.NET Core {X.Y} (x64) Runtime** extension (for example, **ASP.NET Core 2.2 (x64) Runtime**).
 >
-> After installing the x64 preview runtime, run the following command in the Kudu PowerShell command window to verify the installation. Substitute the ASP.NET Core runtime version for `<x.y>` in the command:
+> After installing the x64 preview runtime, run the following command in the Kudu PowerShell command window to verify the installation. Substitute the ASP.NET Core runtime version for `{X.Y}` in the command:
 >
 > ```powershell
-> Test-Path D:\home\SiteExtensions\AspNetCoreRuntime.<x.y>.x64\
+> Test-Path D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.x64\
 > ```
 > If the installed preview runtime is for ASP.NET Core 2.2, the command is:
 > ```powershell


### PR DESCRIPTION
Fixes #9800

* Let's version for 2.1+ while we're at it.
* My updates assume that the preview runtime extension is available, too. I'll revise if that's not the case ... let me know 👂.
