### PR TITLE
Add redirect entry for tutorials index page

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -624,6 +624,11 @@
           "source_path": "aspnetcore/web-api/advanced/index.md",
           "redirect_url": "/aspnet/core/web-api/",
           "redirect_document_id": false
+      },
+      {
+        "source_path": "aspnetcore/tutorials/index.md",
+        "redirect_url": "/aspnet/core/tutorials/razor-pages/",
+        "redirect_document_id": false
       }
     ] 
   }


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/9386

The tutorials index page was deleted as part of the ToC reorganization. This PR redirects to the Razor Pages tutorial.