### PR TITLE
C53605: Escaping mock URL

### DIFF
--- a/aspnet/web-pages/overview/getting-started/introducing-aspnet-web-pages-2/publishing.md
+++ b/aspnet/web-pages/overview/getting-started/introducing-aspnet-web-pages-2/publishing.md
@@ -44,7 +44,7 @@ This tutorial contains four sections:
 <a id="defaultpage"></a>
 ## Setting up the default page
 
-When a user navigates to the base address for your website, the default page for your site is displayed to the user. For example, when Default.htm is set as the default page for the site at www\.contoso.com, then navigating to <strong>www\.contoso.com</strong> is the same as navigating to <strong>www\.contoso.com/Default.htm</strong>.
+When a user navigates to the base address for your web site, the default page for your site is displayed to the user. For example, when Default.htm is set as the default page for the site at www\.contoso.com, then navigating to <strong>www\.contoso.com</strong> is the same as navigating to <strong>www\.contoso.com/Default.htm</strong>.
 
 Currently, your site uses **Default.cshtml** as the default page. This page is fine for your default page, but in this tutorial you have not added any content to that page so it would display a blank page. Open Default.cshtml and replace the content with the following code.
 

--- a/aspnet/web-pages/overview/getting-started/introducing-aspnet-web-pages-2/publishing.md
+++ b/aspnet/web-pages/overview/getting-started/introducing-aspnet-web-pages-2/publishing.md
@@ -44,7 +44,7 @@ This tutorial contains four sections:
 <a id="defaultpage"></a>
 ## Setting up the default page
 
-When a user navigates to the base address for your web site, the default page for your site is displayed to the user. For example, when Default.htm is set as the default page for the site at www.contoso.com, then navigating to <strong>www.contoso.com</strong> is the same as navigating to <strong>www.contoso.com/Default.htm</strong>.
+When a user navigates to the base address for your website, the default page for your site is displayed to the user. For example, when Default.htm is set as the default page for the site at www\.contoso.com, then navigating to <strong>www\.contoso.com</strong> is the same as navigating to <strong>www\.contoso.com/Default.htm</strong>.
 
 Currently, your site uses **Default.cshtml** as the default page. This page is fine for your default page, but in this tutorial you have not added any content to that page so it would display a blank page. Open Default.cshtml and replace the content with the following code.
 

--- a/aspnet/web-pages/overview/getting-started/introducing-aspnet-web-pages-2/publishing.md
+++ b/aspnet/web-pages/overview/getting-started/introducing-aspnet-web-pages-2/publishing.md
@@ -44,7 +44,7 @@ This tutorial contains four sections:
 <a id="defaultpage"></a>
 ## Setting up the default page
 
-When a user navigates to the base address for your web site, the default page for your site is displayed to the user. For example, when Default.htm is set as the default page for the site at www\.contoso.com, then navigating to <strong>www\.contoso.com</strong> is the same as navigating to <strong>www\.contoso.com/Default.htm</strong>.
+When a user navigates to the base address for your web site, the default page for your site is displayed to the user. For example, when *Default.htm* is set as the default page for the site at `www.contoso.com`, then navigating to `www.contoso.com` is the same as navigating to `www.contoso.com/Default.htm`.
 
 Currently, your site uses **Default.cshtml** as the default page. This page is fine for your default page, but in this tutorial you have not added any content to that page so it would display a blank page. Open Default.cshtml and replace the content with the following code.
 


### PR DESCRIPTION
Hello, @Rick-Anderson,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: contoso.com is a mock URL and should not be linked. The proposed fix for this is either write the URL within code box, meaning between grave accents (`) or using backslashes.
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->