### PR TITLE
Update xml code snippet

### DIFF
--- a/aspnetcore/signalr/java-client/sample/pom.xml
+++ b/aspnetcore/signalr/java-client/sample/pom.xml
@@ -27,6 +27,7 @@
             <artifactId>signalr</artifactId>
             <version>1.0.0</version>
         </dependency>
+        <!-- </snippet_dependencyElement> -->
     </dependencies>
 
 </project>


### PR DESCRIPTION
The closing dependency element was missing which caused this error in the docs. It should now show the xml depedency section example for adding the SignalR Java client. 

![xmlsnippet](https://user-images.githubusercontent.com/4809660/49551925-2099a580-f8a6-11e8-8298-40947dc80ef4.png)
