### PR TITLE
Update snippet names

### DIFF
--- a/aspnetcore/client-side/spa-services.md
+++ b/aspnetcore/client-side/spa-services.md
@@ -152,7 +152,7 @@ Install the following:
 
 Webpack Dev Middleware is registered into the HTTP request pipeline via the following code in the *Startup.cs* file's `Configure` method:
 
-[!code-csharp[](../client-side/spa-services/sample/SpaServicesSampleApp/Startup.cs?name=webpack-middleware-registration&highlight=4)]
+[!code-csharp[](../client-side/spa-services/sample/SpaServicesSampleApp/Startup.cs?name=snippet_WebpackMiddlewareRegistration&highlight=4)]
 
 The `UseWebpackDevMiddleware` extension method must be called before [registering static file hosting](xref:fundamentals/static-files) via the `UseStaticFiles` extension method. For security reasons, register the middleware only when the app runs in development mode.
 
@@ -218,7 +218,7 @@ Install the following:
 
 An extension method named `MapSpaFallbackRoute` is used in the `Configure` method:
 
-[!code-csharp[](../client-side/spa-services/sample/SpaServicesSampleApp/Startup.cs?name=mvc-routing-table&highlight=7-9)]
+[!code-csharp[](../client-side/spa-services/sample/SpaServicesSampleApp/Startup.cs?name=snippet_MvcRoutingTable&highlight=7-9)]
 
 Tip: Routes are evaluated in the order in which they're configured. Consequently, the `default` route in the preceding code example is used first for pattern matching.
 

--- a/aspnetcore/client-side/spa-services/sample/SpaServicesSampleApp/Startup.cs
+++ b/aspnetcore/client-side/spa-services/sample/SpaServicesSampleApp/Startup.cs
@@ -33,7 +33,7 @@ namespace SpaServicesSampleApp
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();
 
-            #region webpack-middleware-registration
+            #region snippet_WebpackMiddlewareRegistration
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
@@ -48,7 +48,7 @@ namespace SpaServicesSampleApp
             app.UseStaticFiles();
             #endregion
 
-            #region mvc-routing-table
+            #region snippet_MvcRoutingTable
             app.UseMvc(routes =>
             {
                 routes.MapRoute(


### PR DESCRIPTION
Fixes #9889

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/client-side/spa-services?view=aspnetcore-1.0&branch=pr-en-us-9891)

mmmm ... Looks like this fixes those `can't find the startTag` build warnings I've been getting locally lately. Looks like underscores are *IN* this year and dashes are *OUT*. :smile:

cc: Thanks @dliabenow! :rocket: