### PR TITLE
Use ConfigureKestrel over UseKestrel

### DIFF
--- a/aspnetcore/migration/21-to-22.md
+++ b/aspnetcore/migration/21-to-22.md
@@ -83,6 +83,16 @@ If your solution relies upon a [global.json](/dotnet/core/tools/global-json) fil
 
 If the app calls <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> in the `CreateWebHostBuilder` method of the `Program` class, call `ConfigureKestrel` instead. For more information, see <xref:fundamentals/servers/kestrel#how-to-use-kestrel-in-aspnet-core-apps>.
 
+```csharp
+public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+    WebHost.CreateDefaultBuilder(args)
+        .UseStartup<Startup>()
+        .ConfigureKestrel((context, options) =>
+        {
+            // Set properties and call methods on options
+        });
+```
+
 ## Update compatibility version
 
 Update the compatibility version in `Startup.ConfigureServices` to `Version_2_2`:

--- a/aspnetcore/migration/21-to-22.md
+++ b/aspnetcore/migration/21-to-22.md
@@ -81,7 +81,7 @@ If your solution relies upon a [global.json](/dotnet/core/tools/global-json) fil
 
 ## Call ConfigureKestrel instead of UseKestrel
 
-If the app calls <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> in the `CreateWebHostBuilder` method of the `Program` class, call `ConfigureKestrel` instead:
+If the app calls <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> in the `CreateWebHostBuilder` method of the `Program` class, call `ConfigureKestrel` instead to avoid conflicts with the [IIS in-process hosting model](xref:fundamentals/servers/aspnet-core-module#in-process-hosting-model):
 
 ```csharp
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>

--- a/aspnetcore/migration/21-to-22.md
+++ b/aspnetcore/migration/21-to-22.md
@@ -81,7 +81,7 @@ If your solution relies upon a [global.json](/dotnet/core/tools/global-json) fil
 
 ## Call ConfigureKestrel instead of UseKestrel
 
-If the app calls <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> in the `CreateWebHostBuilder` method of the `Program` class, call `ConfigureKestrel` instead. For more information, see <xref:fundamentals/servers/kestrel#how-to-use-kestrel-in-aspnet-core-apps>.
+If the app calls <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> in the `CreateWebHostBuilder` method of the `Program` class, call `ConfigureKestrel` instead:
 
 ```csharp
 public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
@@ -92,6 +92,8 @@ public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             // Set properties and call methods on options
         });
 ```
+
+For more information, see <xref:fundamentals/servers/kestrel#how-to-use-kestrel-in-aspnet-core-apps>.
 
 ## Update compatibility version
 

--- a/aspnetcore/migration/21-to-22.md
+++ b/aspnetcore/migration/21-to-22.md
@@ -4,7 +4,7 @@ author: scottaddie
 description: This article outlines the prerequisites and most common steps for migrating an ASP.NET Core 2.1 project to ASP.NET Core 2.2.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 12/04/2018
+ms.date: 12/08/2018
 uid: migration/21-to-22
 ---
 # Migrate from ASP.NET Core 2.1 to 2.2
@@ -39,18 +39,6 @@ To adopt the [in-process hosting model for IIS](xref:fundamentals/servers/aspnet
 
 For more information, see <xref:host-and-deploy/aspnet-core-module#hosting-model>.
 
-## Update .NET Core SDK version in global.json
-
-If your solution relies upon a [global.json](/dotnet/core/tools/global-json) file to target a specific .NET Core SDK version, update its `version` property to the 2.2 version installed on your machine:
-
-```json
-{
-  "sdk": {
-    "version": "2.2.100"
-  }
-}
-```
-
 ## Update package references
 
 If targeting .NET Core, remove the `Version` attribute for the metapackage reference. Inclusion of a `Version` attribute results in the following warning:
@@ -73,11 +61,27 @@ If targeting .NET Framework, update each package reference's `Version` attribute
 <ItemGroup>
   <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
   <PackageReference Include="Microsoft.AspNetCore.CookiePolicy" Version="2.2.0" />
-  <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="2.2.0"/>
+  <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="2.2.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
   <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
 </ItemGroup>
 ```
+
+## Update .NET Core SDK version in global.json
+
+If your solution relies upon a [global.json](/dotnet/core/tools/global-json) file to target a specific .NET Core SDK version, update its `version` property to the 2.2 version installed on your machine:
+
+```json
+{
+  "sdk": {
+    "version": "2.2.100"
+  }
+}
+```
+
+## Call ConfigureKestrel instead of UseKestrel
+
+If the app calls <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel*> in the `CreateWebHostBuilder` method of the `Program` class, call `ConfigureKestrel` instead. For more information, see <xref:fundamentals/servers/kestrel#how-to-use-kestrel-in-aspnet-core-apps>.
 
 ## Update compatibility version
 
@@ -92,10 +96,10 @@ services.AddMvc()
 
 The following table shows the Docker image tag changes:
 
-|2.1                                       |2.2                                       |
-|------------------------------------------|------------------------------------------|
-|`microsoft/dotnet:2.1-aspnetcore-runtime` |`microsoft/dotnet:2.2-aspnetcore-runtime` |
-|`microsoft/dotnet:2.1-sdk`                |`microsoft/dotnet:2.2-sdk`                |
+| 2.1                                       | 2.2                                       |
+| ----------------------------------------- | ----------------------------------------- |
+| `microsoft/dotnet:2.1-aspnetcore-runtime` | `microsoft/dotnet:2.2-aspnetcore-runtime` |
+| `microsoft/dotnet:2.1-sdk`                | `microsoft/dotnet:2.2-sdk`                |
 
 Change the `FROM` lines in your *Dockerfile* to use the new image tags in the preceding table's 2.2 column.
 


### PR DESCRIPTION
Fixes #9901

* I don't say *why* ... is it relevant? It makes the doc shorter to not get into it.
* It also made sense to move *Update .NET Core SDK version in global.json* down because currently it appears in the middle of changes made to the project file.