### PR TITLE
Clarify Redis package vs SignalR version

### DIFF
--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -27,7 +27,7 @@ This article explains SignalR-specific aspects of setting up a [Redis](https://r
 
 ::: moniker range="= aspnetcore-2.1"
 
-* In the SignalR app, install the `Microsoft.AspNetCore.SignalR.Redis` NuGet package.
+* In the SignalR app, install the `Microsoft.AspNetCore.SignalR.Redis` NuGet package. (This package is for ASP.NET Core 2.1; there is also a `Microsoft.AspNetCore.SignalR.StackExchanggeRedis` package, which is for ASP.NET Core 2.2 and later.)
 
 * In the `Startup.ConfigureServices` method, call `AddRedis` after `AddSignalR`:
 
@@ -54,7 +54,7 @@ This article explains SignalR-specific aspects of setting up a [Redis](https://r
 
 ::: moniker range="> aspnetcore-2.1"
 
-* In the SignalR app, install the `Microsoft.AspNetCore.SignalR.StackExchangeRedis` NuGet package.
+* In the SignalR app, install the `Microsoft.AspNetCore.SignalR.StackExchangeRedis` NuGet package. (This package is for ASP.NET Core 2.2 and later; there is also a `Microsoft.AspNetCore.SignalR.Redis` package, which is for ASP.NET Core 2.1.)
 
 * In the `Startup.ConfigureServices` method, call `AddStackExchangeRedis` after `AddSignalR`:
 

--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -27,7 +27,7 @@ This article explains SignalR-specific aspects of setting up a [Redis](https://r
 
 ::: moniker range="= aspnetcore-2.1"
 
-* In the SignalR app, install the `Microsoft.AspNetCore.SignalR.Redis` NuGet package. (This package is for ASP.NET Core 2.1; there is also a `Microsoft.AspNetCore.SignalR.StackExchanggeRedis` package, which is for ASP.NET Core 2.2 and later.)
+* In the SignalR app, install the `Microsoft.AspNetCore.SignalR.Redis` NuGet package. (This package is for ASP.NET Core 2.1. It can also be used with 2.2, but it will not be supported in 3.0. The `Microsoft.AspNetCore.SignalR.StackExchangeRedis` package is for ASP.NET Core 2.2 and later.)
 
 * In the `Startup.ConfigureServices` method, call `AddRedis` after `AddSignalR`:
 
@@ -54,7 +54,7 @@ This article explains SignalR-specific aspects of setting up a [Redis](https://r
 
 ::: moniker range="> aspnetcore-2.1"
 
-* In the SignalR app, install the `Microsoft.AspNetCore.SignalR.StackExchangeRedis` NuGet package. (This package is for ASP.NET Core 2.2 and later; there is also a `Microsoft.AspNetCore.SignalR.Redis` package, which is for ASP.NET Core 2.1.)
+* In the SignalR app, install the `Microsoft.AspNetCore.SignalR.StackExchangeRedis` NuGet package. (This package is for ASP.NET Core 2.2 and later; there is also a `Microsoft.AspNetCore.SignalR.Redis` package, which is available for ASP.NET Core 2.1 and 2.2 but will not be supported in 3.0.)
 
 * In the `Startup.ConfigureServices` method, call `AddStackExchangeRedis` after `AddSignalR`:
 

--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -56,8 +56,8 @@ This article explains SignalR-specific aspects of setting up a [Redis](https://r
 
 * In the SignalR app, install one of the following NuGet packages:
 
-  * `Microsoft.AspNetCore.SignalR.StackExchangeRedis` - depends on StackExchange.Redis 2.X.X.
-  * `Microsoft.AspNetCore.SignalR.Redis` - depends on StackExchange.Redis 1.X.X. This package will not be shipping in ASP.NET Core 3.0.
+  * `Microsoft.AspNetCore.SignalR.StackExchangeRedis` - Depends on StackExchange.Redis 2.X.X. This is the recommended package for ASP.NET Core 2.2 and later.
+  * `Microsoft.AspNetCore.SignalR.Redis` - Depends on StackExchange.Redis 1.X.X. This package will not be shipping in ASP.NET Core 3.0.
 
 * In the `Startup.ConfigureServices` method, call `AddStackExchangeRedis` after `AddSignalR`:
 

--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -27,7 +27,7 @@ This article explains SignalR-specific aspects of setting up a [Redis](https://r
 
 ::: moniker range="= aspnetcore-2.1"
 
-* In the SignalR app, install the `Microsoft.AspNetCore.SignalR.Redis` NuGet package. (This package is for ASP.NET Core 2.1. It can also be used with 2.2, but it will not be supported in 3.0. The `Microsoft.AspNetCore.SignalR.StackExchangeRedis` package is for ASP.NET Core 2.2 and later.)
+* In the SignalR app, install the `Microsoft.AspNetCore.SignalR.Redis` NuGet package. (There is also a `Microsoft.AspNetCore.SignalR.StackExchangeRedis` package, but that one is for ASP.NET Core 2.2 and later.)
 
 * In the `Startup.ConfigureServices` method, call `AddRedis` after `AddSignalR`:
 
@@ -54,7 +54,10 @@ This article explains SignalR-specific aspects of setting up a [Redis](https://r
 
 ::: moniker range="> aspnetcore-2.1"
 
-* In the SignalR app, install the `Microsoft.AspNetCore.SignalR.StackExchangeRedis` NuGet package. (This package is for ASP.NET Core 2.2 and later; there is also a `Microsoft.AspNetCore.SignalR.Redis` package, which is available for ASP.NET Core 2.1 and 2.2 but will not be supported in 3.0.)
+* In the SignalR app, install one of the following NuGet packages:
+
+  * `Microsoft.AspNetCore.SignalR.StackExchangeRedis` - depends on StackExchange.Redis 2.X.X.
+  * `Microsoft.AspNetCore.SignalR.Redis` - depends on StackExchange.Redis 1.X.X. This package will not be shipping in ASP.NET Core 3.0.
 
 * In the `Startup.ConfigureServices` method, call `AddStackExchangeRedis` after `AddSignalR`:
 


### PR DESCRIPTION
Add text to clarify that StackExchangeRedis is for 2.2, non-SO Redis is for 2.1.
Fixes #9919
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->