### PR TITLE
ASP.NET Core MVC: Updating validation sample to 2.2

### DIFF
--- a/aspnetcore/mvc/models/validation/sample/Program.cs
+++ b/aspnetcore/mvc/models/validation/sample/Program.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace MVCMovie
 {
@@ -15,7 +14,6 @@ namespace MVCMovie
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole().AddDebug())
                 .Build();
     }
 }

--- a/aspnetcore/mvc/models/validation/sample/Program.cs
+++ b/aspnetcore/mvc/models/validation/sample/Program.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace MVCMovie
 {
@@ -14,6 +15,7 @@ namespace MVCMovie
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole().AddDebug())
                 .Build();
     }
 }

--- a/aspnetcore/mvc/models/validation/sample/Startup.cs
+++ b/aspnetcore/mvc/models/validation/sample/Startup.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using MVCMovie.Controllers;
 
@@ -10,7 +11,8 @@ namespace MVCMovie
         {
             services.AddSingleton(new MVCMovieContext());
             services.AddSingleton<IUserRepository>(new UserRepository());
-            services.AddMvc(options => options.MaxModelValidationErrors = 50);
+            services.AddMvc(options => options.MaxModelValidationErrors = 50)
+                    .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
         }
 
         public void Configure(IApplicationBuilder app)

--- a/aspnetcore/mvc/models/validation/sample/Startup.cs
+++ b/aspnetcore/mvc/models/validation/sample/Startup.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using MVCMovie.Controllers;
 
@@ -8,17 +6,6 @@ namespace MVCMovie
 {
     public class Startup
     {
-        public Startup(IHostingEnvironment env)
-        {
-            var builder = new ConfigurationBuilder()
-                .SetBasePath(env.ContentRootPath)
-                .AddEnvironmentVariables();
-
-            Configuration = builder.Build();
-        }
-
-        public IConfigurationRoot Configuration { get; }
-
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton(new MVCMovieContext());

--- a/aspnetcore/mvc/models/validation/sample/Startup.cs
+++ b/aspnetcore/mvc/models/validation/sample/Startup.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using MVCMovie.Controllers;
 
 namespace MVCMovie
@@ -27,12 +26,8 @@ namespace MVCMovie
             services.AddMvc(options => options.MaxModelValidationErrors = 50);
         }
 
-        public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app)
         {
-            loggerFactory
-                .AddConsole(Configuration.GetSection("Logging"))
-                .AddDebug();
-
             app.UseStaticFiles();
             app.UseMvc(routes => routes.MapRoute(
                 name: "default",

--- a/aspnetcore/mvc/models/validation/sample/ValidationSample.csproj
+++ b/aspnetcore/mvc/models/validation/sample/ValidationSample.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aspnetcore/mvc/models/validation/sample/ValidationSample.csproj
+++ b/aspnetcore/mvc/models/validation/sample/ValidationSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/mvc/models/validation/sample/ValidationSample.csproj
+++ b/aspnetcore/mvc/models/validation/sample/ValidationSample.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Addresses #8622

- Target 2.2
- Switching from using deprecated logging setup
