### PR TITLE
Add example of asp-area with a Razor Pages area

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
@@ -169,7 +169,9 @@ The [asp-area](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Area*) a
 
 ### Usage in Razor Pages
 
-Razor Pages areas are supported in ASP.NET Core 2.1 or later. Consider the following directory hierarchy:
+Razor Pages areas are supported in ASP.NET Core 2.1 or later.
+
+Consider the following directory hierarchy:
 
 * **{Project name}**
   * **wwwroot**
@@ -241,7 +243,7 @@ The generated HTML:
 <a href="https://localhost/Home/About">About</a>
 ```
 
-The host name in the example is localhost, but the Anchor Tag Helper uses the website's public domain when generating the URL.
+The host name in the example is localhost. The Anchor Tag Helper uses the website's public domain when generating the URL.
 
 ## asp-host
 
@@ -287,7 +289,7 @@ Consider the following page handler:
 
 [!code-csharp[](samples/TagHelpersBuiltIn/Pages/Attendee.cshtml.cs?name=snippet_OnGetProfileHandler)]
 
-The page model's associated markup links to the `OnGetProfile` page handler. Note that the `On<Verb>` prefix of the page handler method name is omitted in the `asp-page-handler` attribute value. If this were an asynchronous method, the `Async` suffix would be omitted too.
+The page model's associated markup links to the `OnGetProfile` page handler. Note the `On<Verb>` prefix of the page handler method name is omitted in the `asp-page-handler` attribute value. If this were an asynchronous method, the `Async` suffix would be omitted too.
 
 [!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspPageHandler)]
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
@@ -197,7 +197,9 @@ The generated HTML:
 > To support areas in a Razor Pages app, do one of the following in `Startup.ConfigureServices`:
 >
 > * Set the [compatibility version](xref:mvc/compatibility-version) to 2.1 or later.
-> * Set the [RazorPagesOptions.AllowAreas](xref:Microsoft.AspNetCore.Mvc.RazorPages.RazorPagesOptions.AllowAreas*) property to `true`.
+> * Set the [RazorPagesOptions.AllowAreas](xref:Microsoft.AspNetCore.Mvc.RazorPages.RazorPagesOptions.AllowAreas*) property to `true`:
+>
+>   [!code-csharp[](samples/TagHelpersBuiltIn/Startup.cs?name=snippet_AllowAreas)]
 
 ### Usage in MVC
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
@@ -291,7 +291,7 @@ Consider the following page handler:
 
 [!code-csharp[](samples/TagHelpersBuiltIn/Pages/Attendee.cshtml.cs?name=snippet_OnGetProfileHandler)]
 
-The page model's associated markup links to the `OnGetProfile` page handler. Note the `On<Verb>` prefix of the page handler method name is omitted in the `asp-page-handler` attribute value. If this were an asynchronous method, the `Async` suffix would be omitted too.
+The page model's associated markup links to the `OnGetProfile` page handler. Note the `On<Verb>` prefix of the page handler method name is omitted in the `asp-page-handler` attribute value. When the method is asynchronous, the `Async` suffix is omitted, too.
 
 [!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspPageHandler)]
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
@@ -4,14 +4,14 @@ author: pkellner
 description: Discover the ASP.NET Core Anchor Tag Helper attributes and the role each attribute plays in extending behavior of the HTML anchor tag.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 10/10/2018
+ms.date: 12/18/2018
 uid: mvc/views/tag-helpers/builtin-th/anchor-tag-helper
 ---
 # Anchor Tag Helper in ASP.NET Core
 
 By [Peter Kellner](http://peterkellner.net) and [Scott Addie](https://github.com/scottaddie)
 
-The [Anchor Tag Helper](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper) enhances the standard HTML anchor (`<a ... ></a>`) tag by adding new attributes. By convention, the attribute names are prefixed with `asp-`. The rendered anchor element's `href` attribute value is determined by the values of the `asp-` attributes.
+The [Anchor Tag Helper](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper) enhances the standard HTML anchor (`<a ... ></a>`) tag by adding new attributes. By convention, the attribute names are prefixed with `asp-`. The rendered anchor element's `href` attribute value is determined by the values of the `asp-` attributes.
 
 For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
 
@@ -25,7 +25,7 @@ An inventory of the `asp-` attributes follows.
 
 ## asp-controller
 
-The [asp-controller](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.controller) attribute assigns the controller used for generating the URL. The following markup lists all speakers:
+The [asp-controller](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Controller*) attribute assigns the controller used for generating the URL. The following markup lists all speakers:
 
 [!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspController)]
 
@@ -43,7 +43,7 @@ If the `asp-controller` attribute is specified and `asp-action` isn't, the defau
 
 ## asp-action
 
-The [asp-action](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.action) attribute value represents the controller action name included in the generated `href` attribute. The following markup sets the generated `href` attribute value to the speaker evaluations page:
+The [asp-action](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Action*) attribute value represents the controller action name included in the generated `href` attribute. The following markup sets the generated `href` attribute value to the speaker evaluations page:
 
 [!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspAction)]
 
@@ -59,7 +59,7 @@ If the `asp-action` attribute value is `Index`, then no action is appended to th
 
 ## asp-route-{value}
 
-The [asp-route-{value}](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.routevalues) attribute enables a wildcard route prefix. Any value occupying the `{value}` placeholder is interpreted as a potential route parameter. If a default route isn't found, this route prefix is appended to the generated `href` attribute as a request parameter and value. Otherwise, it's substituted in the route template.
+The [asp-route-{value}](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.RouteValues*) attribute enables a wildcard route prefix. Any value occupying the `{value}` placeholder is interpreted as a potential route parameter. If a default route isn't found, this route prefix is appended to the generated `href` attribute as a request parameter and value. Otherwise, it's substituted in the route template.
 
 Consider the following controller action:
 
@@ -96,8 +96,8 @@ Assume the route prefix isn't part of the matching routing template, as with the
 <!DOCTYPE html>
 <html>
 <body>
-    <a asp-controller="Speaker" 
-       asp-action="Detail" 
+    <a asp-controller="Speaker"
+       asp-action="Detail"
        asp-route-speakerid="@Model.SpeakerId">SpeakerId: @Model.SpeakerId</a>
 <body>
 </html>
@@ -113,7 +113,7 @@ If either `asp-controller` or `asp-action` aren't specified, then the same defau
 
 ## asp-route
 
-The [asp-route](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.route) attribute is used for creating a URL linking directly to a named route. Using [routing attributes](xref:mvc/controllers/routing#attribute-routing), a route can be named as shown in the `SpeakerController` and used in its `Evaluations` action:
+The [asp-route](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Route*) attribute is used for creating a URL linking directly to a named route. Using [routing attributes](xref:mvc/controllers/routing#attribute-routing), a route can be named as shown in the `SpeakerController` and used in its `Evaluations` action:
 
 [!code-csharp[](samples/TagHelpersBuiltIn/Controllers/SpeakerController.cs?range=22-24)]
 
@@ -131,7 +131,7 @@ If `asp-controller` or `asp-action` is specified in addition to `asp-route`, the
 
 ## asp-all-route-data
 
-The [asp-all-route-data](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.routevalues) attribute supports the creation of a dictionary of key-value pairs. The key is the parameter name, and the value is the parameter value.
+The [asp-all-route-data](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.RouteValues*) attribute supports the creation of a dictionary of key-value pairs. The key is the parameter name, and the value is the parameter value.
 
 In the following example, a dictionary is initialized and passed to a Razor view. Alternatively, the data could be passed in with your model.
 
@@ -151,7 +151,7 @@ If any keys in the dictionary match route parameters, those values are substitut
 
 ## asp-fragment
 
-The [asp-fragment](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.fragment) attribute defines a URL fragment to append to the URL. The Anchor Tag Helper adds the hash character (#). Consider the following markup:
+The [asp-fragment](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Fragment*) attribute defines a URL fragment to append to the URL. The Anchor Tag Helper adds the hash character (#). Consider the following markup:
 
 [!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspFragment)]
 
@@ -165,7 +165,41 @@ Hash tags are useful when building client-side apps. They can be used for easy m
 
 ## asp-area
 
-The [asp-area](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.area) attribute sets the area name used to set the appropriate route. The following example depicts how the area attribute causes a remapping of routes. Setting `asp-area` to "Blogs" prefixes the directory *Areas/Blogs* to the routes of the associated controllers and views for this anchor tag.
+The [asp-area](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Area*) attribute sets the area name used to set the appropriate route. The following examples depict how the `asp-area` attribute causes a remapping of routes.
+
+### Usage in Razor Pages
+
+Razor Pages areas are supported in ASP.NET Core 2.1 or later. Consider the following directory hierarchy:
+
+* **{Project name}**
+  * **wwwroot**
+  * **Areas**
+    * **Sessions**
+      * **Pages**
+        * *\_ViewStart.cshtml*
+        * *Index.cshtml*
+        * *Index.cshtml.cs*
+  * **Pages**
+
+The markup to reference the *Sessions* area *Index* Razor Page is:
+
+[!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?snippet_AspAreaRazorPages)]
+
+The generated HTML:
+
+```html
+<a href="/Sessions">View Sessions</a>
+```
+
+> [!TIP]
+> To support areas in a Razor Pages app, do one of the following in `Startup.ConfigureServices`:
+>
+> * Set the [compatibility version](xref:mvc/compatibility-version) to 2.1 or later.
+> * Set the [RazorPagesOptions.AllowAreas](xref:Microsoft.AspNetCore.Mvc.RazorPages.RazorPagesOptions.AllowAreas*) property to `true`.
+
+### Usage in MVC
+
+Consider the following directory hierarchy:
 
 * **{Project name}**
   * **wwwroot**
@@ -180,7 +214,7 @@ The [asp-area](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.a
         * *\_ViewStart.cshtml*
   * **Controllers**
 
-Given the preceding directory hierarchy, the markup to reference the *AboutBlog.cshtml* file is:
+Setting `asp-area` to "Blogs" prefixes the directory *Areas/Blogs* to the routes of the associated controllers and views for this anchor tag. The markup to reference the *AboutBlog* view is:
 
 [!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspArea)]
 
@@ -191,13 +225,13 @@ The generated HTML:
 ```
 
 > [!TIP]
-> For areas to work in an MVC app, the route template must include a reference to the area, if it exists. That template is represented by the second parameter of the `routes.MapRoute` method call in *Startup.Configure*:
+> To support areas in an MVC app, the route template must include a reference to the area, if it exists. That template is represented by the second parameter of the `routes.MapRoute` method call in *Startup.Configure*:
 >
 > [!code-csharp[](samples/TagHelpersBuiltIn/Startup.cs?name=snippet_UseMvc&highlight=5)]
 
 ## asp-protocol
 
-The [asp-protocol](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.protocol) attribute is for specifying a protocol (such as `https`) in your URL. For example:
+The [asp-protocol](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Protocol*) attribute is for specifying a protocol (such as `https`) in your URL. For example:
 
 [!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspProtocol)]
 
@@ -211,7 +245,7 @@ The host name in the example is localhost, but the Anchor Tag Helper uses the we
 
 ## asp-host
 
-The [asp-host](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.host) attribute is for specifying a host name in your URL. For example:
+The [asp-host](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Host*) attribute is for specifying a host name in your URL. For example:
 
 [!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspHost)]
 
@@ -223,7 +257,7 @@ The generated HTML:
 
 ## asp-page
 
-The [asp-page](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.page) attribute is used with Razor Pages. Use it to set an anchor tag's `href` attribute value to a specific page. Prefixing the page name with a forward slash ("/") creates the URL.
+The [asp-page](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Page*) attribute is used with Razor Pages. Use it to set an anchor tag's `href` attribute value to a specific page. Prefixing the page name with a forward slash ("/") creates the URL.
 
 The following sample points to the attendee Razor Page:
 
@@ -247,7 +281,7 @@ The generated HTML:
 
 ## asp-page-handler
 
-The [asp-page-handler](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.pagehandler) attribute is used with Razor Pages. It's intended for linking to specific page handlers.
+The [asp-page-handler](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.PageHandler*) attribute is used with Razor Pages. It's intended for linking to specific page handlers.
 
 Consider the following page handler:
 
@@ -267,3 +301,4 @@ The generated HTML:
 
 * <xref:mvc/controllers/areas>
 * <xref:razor-pages/index>
+* <xref:mvc/compatibility-version>

--- a/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
@@ -185,7 +185,7 @@ Consider the following directory hierarchy:
 
 The markup to reference the *Sessions* area *Index* Razor Page is:
 
-[!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?snippet_AspAreaRazorPages)]
+[!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspAreaRazorPages)]
 
 The generated HTML:
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Areas/Sessions/Pages/Index.cshtml
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Areas/Sessions/Pages/Index.cshtml
@@ -1,0 +1,7 @@
+﻿@page
+@model TagHelpersBuiltIn.Areas.Sessions.Pages.IndexModel
+@{
+    ViewData["Title"] = "Sessions Index";
+}
+
+<h2>Sessions Index</h2>

--- a/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Areas/Sessions/Pages/Index.cshtml.cs
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Areas/Sessions/Pages/Index.cshtml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TagHelpersBuiltIn.Areas.Sessions.Pages
+{
+    public class IndexModel : PageModel
+    {
+        public void OnGet()
+        {
+
+        }
+    }
+}

--- a/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Areas/Sessions/Pages/_ViewStart.cshtml
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Areas/Sessions/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}

--- a/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Startup.cs
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Startup.cs
@@ -50,7 +50,7 @@ namespace TagHelpersBuiltIn
             app.UseMvc(routes =>
             {
                 // need route and attribute on controller: [Area("Blogs")]
-                routes.MapRoute(name: "areaRoute",
+                routes.MapRoute(name: "mvcAreaRoute",
                                 template: "{area:exists}/{controller=Home}/{action=Index}");
 
                 // default route for non-areas

--- a/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Startup.cs
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Startup.cs
@@ -26,7 +26,11 @@ namespace TagHelpersBuiltIn
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            //services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            #region snippet_AllowAreas
+            services.AddMvc()
+                    .AddRazorPagesOptions(options => options.AllowAreas = true);
+            #endregion
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Views/Home/Index.cshtml
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Views/Home/Index.cshtml
@@ -49,7 +49,7 @@
             </td>
         </tr>
         <tr>
-            <td>asp-area</td>
+            <td rowspan="2">asp-area</td>
             <td>
                 <code>
                     @Html.Raw(Html.Encode(@"<a asp-area=""Blogs"" asp-controller=""Home"" asp-action=""AboutBlog"">About Blog</a>"))
@@ -61,6 +61,19 @@
                    asp-controller="Home"
                    asp-action="AboutBlog">About Blog</a>
                 <!-- </snippet_AspArea> -->
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <code>
+                    @Html.Raw(Html.Encode(@"<a asp-area=""Sessions"" asp-page=""/Index"">View Sessions</a>"))
+                </code>
+            </td>
+            <td>
+                <!-- <snippet_AspAreaRazorPages> -->
+                <a asp-area="Sessions"
+                   asp-page="/Index">View Sessions</a>
+                <!-- </snippet_AspAreaRazorPages> -->
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
Fixes https://github.com/aspnet/Docs/issues/9834

Also converted API ref links to the xref style.

[Internal Review Page](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/built-in/anchor-tag-helper?branch=pr-en-us-10048&view=aspnetcore-2.2#asp-area)