### PR TITLE
Linux topics: Long request headers content

### DIFF
--- a/aspnetcore/host-and-deploy/linux-apache.md
+++ b/aspnetcore/host-and-deploy/linux-apache.md
@@ -4,7 +4,7 @@ description: Learn how to set up Apache as a reverse proxy server on CentOS to r
 author: spboyer
 ms.author: spboyer
 ms.custom: mvc
-ms.date: 12/01/2018
+ms.date: 12/20/2018
 uid: host-and-deploy/linux-apache
 ---
 # Host ASP.NET Core on Linux with Apache
@@ -465,6 +465,7 @@ Using *mod_ratelimit*, which is included in the *httpd* module, the bandwidth of
 ```bash
 sudo nano /etc/httpd/conf.d/ratelimit.conf
 ```
+
 The example file limits bandwidth as 600 KB/sec under the root location:
 
 ```
@@ -475,6 +476,13 @@ The example file limits bandwidth as 600 KB/sec under the root location:
     </Location>
 </IfModule>
 ```
+
+### Long request header fields
+
+If the app requires request header fields longer than permitted by the proxy server's default setting (typically 8,190 bytes), adjust the value of the [LimitRequestFieldSize](https://httpd.apache.org/docs/2.4/mod/core.html#LimitRequestFieldSize) directive. The value to apply is scenario-dependent. For more information, see your server's documentation.
+
+> [!WARNING]
+> Don't increase the default value of `LimitRequestFieldSize` unless necessary. Increasing the value increases the risk of buffer overrun (overflow) and Denial of Service (DoS) attacks by malicious users.
 
 ## Additional resources
 

--- a/aspnetcore/host-and-deploy/linux-nginx.md
+++ b/aspnetcore/host-and-deploy/linux-nginx.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to setup Nginx as a reverse proxy on Ubuntu 16.04 to forward HTTP traffic to an ASP.NET Core web app running on Kestrel.
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/26/2018
+ms.date: 12/20/2018
 uid: host-and-deploy/linux-nginx
 ---
 # Host ASP.NET Core on Linux with Nginx
@@ -290,6 +290,18 @@ To configure data protection to persist and encrypt the key ring, see:
 
 * <xref:security/data-protection/implementation/key-storage-providers>
 * <xref:security/data-protection/implementation/key-encryption-at-rest>
+
+## Long request header fields
+
+If the app requires request header fields longer than permitted by the proxy server's default settings (typically 4K or 8K depending on the platform), the following directives require adjustment. The values to apply are scenario-dependent. For more information, see your server's documentation.
+
+* [proxy_buffer_size](https://nginx.org/docs/http/ngx_http_proxy_module.html#proxy_buffer_size)
+* [proxy_buffers](https://nginx.org/docs/http/ngx_http_proxy_module.html#proxy_buffers)
+* [proxy_busy_buffers_size](https://nginx.org/docs/http/ngx_http_proxy_module.html#proxy_busy_buffers_size)
+* [large_client_header_buffers](https://nginx.org/docs/http/ngx_http_core_module.html#large_client_header_buffers)
+
+> [!WARNING]
+> Don't increase the default values of proxy buffers unless necessary. Increasing these values increases the risk of buffer overrun (overflow) and Denial of Service (DoS) attacks by malicious users.
 
 ## Secure the app
 


### PR DESCRIPTION
Fixes #8679 
Fixes #9997 

* No examples, since we're not pitching specific values.
* Didn't link DoS or buffer overrun. We don't have particularly good options on the MS end. We have [this topic for DoS](https://docs.microsoft.com/windows-hardware/drivers/ifs/denial-of-service), but that's not very satisfying as provided by Windows drivers docs. Same for buffer overrun. We have [this topic](https://docs.microsoft.com/windows/desktop/secbp/avoiding-buffer-overruns) via Windows Desktop docs. It was supposed to be in [this security glossary](https://docs.microsoft.com/security-updates/Glossary/glossary), but they removed it at some point (I sent them a note about that). If you want buffer overrun and DoS links here, we may need to ping Barry for a tip. There are *lots 'o options*.
* Nginx docs have a redirect issue: Removing the localization segment causes a redirect, but the redirect is to an insecure endpoint. I sent them a bug report on it: https://trac.nginx.org/nginx/ticket/1693#ticket