### PR TITLE
Update snapshot to show Tag Helper

### DIFF
--- a/aspnetcore/fundamentals/environments/sample-snapshot/EnvironmentsSample/Pages/About.cshtml
+++ b/aspnetcore/fundamentals/environments/sample-snapshot/EnvironmentsSample/Pages/About.cshtml
@@ -1,10 +1,11 @@
-﻿@page
-@inject Microsoft.AspNetCore.Hosting.IHostingEnvironment hostingEnv
-@model AboutModel
-@{
-    ViewData["Title"] = "About";
-}
-<h2>@ViewData["Title"]</h2>
-<h3>@Model.Message</h3>
-
-<p> ASPNETCORE_ENVIRONMENT = @hostingEnv.EnvironmentName</p>
+<environment include="Development">
+    <div>&lt;environment include="Development"&gt;</div>
+</environment>
+<environment exclude="Development">
+    <div>&lt;environment exclude="Development"&gt;</div>
+</environment>
+<environment include="Staging,Development,Staging_2">
+    <div>
+        &lt;environment include="Staging,Development,Staging_2"&gt;
+    </div>
+</environment>


### PR DESCRIPTION
Fixes #10228 

Quick patch for the *About.cshtml* snapshot that the topic states will show how the Environment Tag Helper works. One way to fix this would be to use a snippet block in the non-snapshot *About.cshtml* file. However since the snapshot exists, the fastest way to fix this is just to place the TH code into the snapshot file. The next author to perform a major update on the topic can take further steps.

The code appears for the 2nd code block of :point_right: https://docs.microsoft.com/aspnet/core/fundamentals/environments#environments

Thanks @serpent5 :rocket: for reporting this.