### PR TITLE
Convert Normalized Identity column values to upper case

### DIFF
--- a/aspnetcore/migration/proper-to-2x/membership-to-core-identity.md
+++ b/aspnetcore/migration/proper-to-2x/membership-to-core-identity.md
@@ -30,12 +30,12 @@ ASP.NET Core 2.0 follows the [Identity](/aspnet/identity/index) principle introd
 
 The fastest way to view the schema for ASP.NET Core 2.0 Identity is to create a new ASP.NET Core 2.0 app. Follow these steps in Visual Studio 2017:
 
-* Select **File** > **New** > **Project**.
-* Create a new **ASP.NET Core Web Application** project named *CoreIdentitySample*.
-* Select **ASP.NET Core 2.0** in the dropdown and then select **Web Application**. This template produces a [Razor Pages](xref:razor-pages/index) app. Before clicking **OK**, click **Change Authentication**.
-* Choose **Individual User Accounts** for the Identity templates. Finally, click **OK**, then **OK**. Visual Studio creates a project using the ASP.NET Core Identity template.
-* Select **Tools** > **NuGet Package Manager** > **Package Manager Console** to open the **Package Manager Console** (PMC) window.
-* Navigate to the project root in PMC, and run the [Entity Framework (EF) Core](/ef/core) `Update-Database` command.
+1. Select **File** > **New** > **Project**.
+1. Create a new **ASP.NET Core Web Application** project named *CoreIdentitySample*.
+1. Select **ASP.NET Core 2.0** in the dropdown and then select **Web Application**. This template produces a [Razor Pages](xref:razor-pages/index) app. Before clicking **OK**, click **Change Authentication**.
+1. Choose **Individual User Accounts** for the Identity templates. Finally, click **OK**, then **OK**. Visual Studio creates a project using the ASP.NET Core Identity template.
+1. Select **Tools** > **NuGet Package Manager** > **Package Manager Console** to open the **Package Manager Console** (PMC) window.
+1. Navigate to the project root in PMC, and run the [Entity Framework (EF) Core](/ef/core) `Update-Database` command.
 
     ASP.NET Core 2.0 Identity uses EF Core to interact with the database storing the authentication data. In order for the newly created app to work, there needs to be a database to store this data. After creating a new app, the fastest way to inspect the schema in a database environment is to create the database using [EF Core Migrations](/ef/core/managing-schemas/migrations/). This process creates a database, either locally or elsewhere, which mimics that schema. Review the preceding documentation for more information.
 
@@ -48,11 +48,11 @@ The fastest way to view the schema for ASP.NET Core 2.0 Identity is to create a 
       }
     }
     ```
-* Select **View** > **SQL Server Object Explorer**. Expand the node corresponding to the database name specified in the `ConnectionStrings:DefaultConnection` property of *appsettings.json*.
+1. Select **View** > **SQL Server Object Explorer**. Expand the node corresponding to the database name specified in the `ConnectionStrings:DefaultConnection` property of *appsettings.json*.
 
     The `Update-Database` command created the database specified with the schema and any data needed for app initialization. The following image depicts the table structure that's created with the preceding steps.
 
-       ![Identity Tables](identity/_static/identity-tables.png)
+    ![Identity Tables](identity/_static/identity-tables.png)
 
 ## Migrate the schema
 

--- a/aspnetcore/migration/proper-to-2x/membership-to-core-identity.md
+++ b/aspnetcore/migration/proper-to-2x/membership-to-core-identity.md
@@ -4,7 +4,7 @@ author: isaac2004
 description: Learn how to migrate existing ASP.NET apps using Membership authentication to ASP.NET Core 2.0 Identity.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 04/24/2018
+ms.date: 01/10/2019
 uid: migration/proper-to-2x/membership-to-core-identity
 ---
 # Migrate from ASP.NET Membership authentication to ASP.NET Core 2.0 Identity
@@ -31,27 +31,28 @@ ASP.NET Core 2.0 follows the [Identity](/aspnet/identity/index) principle introd
 The fastest way to view the schema for ASP.NET Core 2.0 Identity is to create a new ASP.NET Core 2.0 app. Follow these steps in Visual Studio 2017:
 
 * Select **File** > **New** > **Project**.
-* Create a new **ASP.NET Core Web Application** and name the project *CoreIdentitySample*.
+* Create a new **ASP.NET Core Web Application** project named *CoreIdentitySample*.
 * Select **ASP.NET Core 2.0** in the dropdown and then select **Web Application**. This template produces a [Razor Pages](xref:razor-pages/index) app. Before clicking **OK**, click **Change Authentication**.
 * Choose **Individual User Accounts** for the Identity templates. Finally, click **OK**, then **OK**. Visual Studio creates a project using the ASP.NET Core Identity template.
+* Select **Tools** > **NuGet Package Manager** > **Package Manager Console** to open the **Package Manager Console** (PMC) window.
+* Navigate to the project root in PMC, and run the [Entity Framework (EF) Core](/ef/core) `Update-Database` command.
 
-ASP.NET Core 2.0 Identity uses [Entity Framework Core](/ef/core) to interact with the database storing the authentication data. In order for the newly created app to work, there needs to be a database to store this data. After creating a new app, the fastest way to inspect the schema in a database environment is to create the database using Entity Framework migrations. This process creates a database, either locally or elsewhere, which mimics that schema. Review the preceding documentation for more information.
+    ASP.NET Core 2.0 Identity uses EF Core to interact with the database storing the authentication data. In order for the newly created app to work, there needs to be a database to store this data. After creating a new app, the fastest way to inspect the schema in a database environment is to create the database using [EF Core Migrations](/ef/core/managing-schemas/migrations/). This process creates a database, either locally or elsewhere, which mimics that schema. Review the preceding documentation for more information.
 
-To create a database with the ASP.NET Core Identity schema, run the `Update-Database` command in Visual Studio's **Package Manager Console** (PMC) window&mdash;it's located at **Tools** > **NuGet Package Manager** > **Package Manager Console**. PMC supports running Entity Framework commands.
+    EF Core commands use the connection string for the database specified in *appsettings.json*. The following connection string targets a database on *localhost* named *asp-net-core-identity*. In this setting, EF Core is configured to use the `DefaultConnection` connection string.
 
-Entity Framework commands use the connection string for the database specified in *appsettings.json*. The following connection string targets a database on *localhost* named *asp-net-core-identity*. In this setting, Entity Framework is configured to use the `DefaultConnection` connection string.
+    ```json
+    {
+      "ConnectionStrings": {
+        "DefaultConnection": "Server=localhost;Database=aspnet-core-identity;Trusted_Connection=True;MultipleActiveResultSets=true"
+      }
+    }
+    ```
+* Select **View** > **SQL Server Object Explorer**. Expand the node corresponding to the database name specified in the `ConnectionStrings:DefaultConnection` property of *appsettings.json*.
 
-```json
-{
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Database=aspnet-core-identity;Trusted_Connection=True;MultipleActiveResultSets=true"
-  }
-}
-```
+    The `Update-Database` command created the database specified with the schema and any data needed for app initialization. The following image depicts the table structure that's created with the preceding steps.
 
-This command builds the database specified with the schema and any data needed for app initialization. The following image depicts the table structure that's created with the preceding steps.
-
-   ![Identity Tables](identity/_static/identity-tables.png)
+       ![Identity Tables](identity/_static/identity-tables.png)
 
 ## Migrate the schema
 
@@ -59,105 +60,116 @@ There are subtle differences in the table structures and fields for both Members
 
 ### Users
 
-| *Identity(AspNetUsers)* |   | *Membership(aspnet_Users/aspnet_Membership)* ||
-| --- | --- | --- | --- | --- | --- |
-| **Field Name** | **Type**  |   **Field Name** | **Type**  |
-|`Id` | string | `aspnet_Users.UserId` | string
-|`UserName` | string | `aspnet_Users.UserName` | string
-|`Email` | string | `aspnet_Membership.Email` | string
-|`NormalizedUserName` | string | `aspnet_Users.LoweredUserName` | string
-|`NormalizedEmail` | string | `aspnet_Membership.LoweredEmail` | string
-|`PhoneNumber` | string | `aspnet_Users.MobileAlias` | string
-|`LockoutEnabled` | bit | `aspnet_Membership.IsLockedOut` | bit
+|*Identity<br>(dbo.AspNetUsers)*        ||*Membership<br>(dbo.aspnet_Users / dbo.aspnet_Membership)*||
+|----------------------------------------|-----------------------------------------------------------|
+|**Field Name**                 |**Type**|**Field Name**                                    |**Type**|
+|`Id`                           |string  |`aspnet_Users.UserId`                             |string  |
+|`UserName`                     |string  |`aspnet_Users.UserName`                           |string  |
+|`Email`                        |string  |`aspnet_Membership.Email`                         |string  |
+|`NormalizedUserName`           |string  |`aspnet_Users.LoweredUserName`                    |string  |
+|`NormalizedEmail`              |string  |`aspnet_Membership.LoweredEmail`                  |string  |
+|`PhoneNumber`                  |string  |`aspnet_Users.MobileAlias`                        |string  |
+|`LockoutEnabled`               |bit     |`aspnet_Membership.IsLockedOut`                   |bit     |
 
 > [!NOTE]
 > Not all the field mappings resemble one-to-one relationships from Membership to ASP.NET Core Identity. The preceding table takes the default Membership User schema and maps it to the ASP.NET Core Identity schema. Any other custom fields that were used for Membership need to be mapped manually. In this mapping, there's no map for passwords, as both password criteria and password salts don't migrate between the two. **It's recommended to leave the password as null and to ask users to reset their passwords.** In ASP.NET Core Identity, `LockoutEnd` should be set to some date in the future if the user is locked out. This is shown in the migration script.
 
 ### Roles
 
-| *Identity(AspNetRoles)* |   | *Membership(aspnet_Roles)* ||
-| --- | --- | --- | --- | --- | --- |
-| **Field Name** | **Type**  |   **Field Name** | **Type**  |
-|`Id` | string | `RoleId` | string
-|`Name` | string | `RoleName` | string
-|`NormalizedName` | string | `LoweredRoleName` | string
+|*Identity<br>(dbo.AspNetRoles)*        ||*Membership<br>(dbo.aspnet_Roles)*||
+|----------------------------------------|-----------------------------------|
+|**Field Name**                 |**Type**|**Field Name**   |**Type**         |
+|`Id`                           |string  |`RoleId`         | string          |
+|`Name`                         |string  |`RoleName`       | string          |
+|`NormalizedName`               |string  |`LoweredRoleName`| string          |
 
 ### User Roles
 
-| *Identity(AspNetUserRoles)* |   | *Membership(aspnet_UsersInRoles)* ||
-| --- | --- | --- | --- | --- | --- |
-| **Field Name** | **Type**  |   **Field Name** | **Type**  |
-|`RoleId` | string | `RoleId` | string
-|`UserId` | string | `UserId` | string
+|*Identity<br>(dbo.AspNetUserRoles)*||*Membership<br>(dbo.aspnet_UsersInRoles)*||
+|------------------------------------|------------------------------------------|
+|**Field Name**           |**Type**  |**Field Name**|**Type**                   |
+|`RoleId`                 |string    |`RoleId`      |string                     |
+|`UserId`                 |string    |`UserId`      |string                     |
 
-Reference the preceding mapping tables when creating a migration script for *Users* and *Roles*. The following example assumes you have two databases on a database server. One database contains the existing ASP.NET Membership schema and data. The other database was created using steps described earlier. Comments are included inline for more details.
+Reference the preceding mapping tables when creating a migration script for *Users* and *Roles*. The following example assumes you have two databases on a database server. One database contains the existing ASP.NET Membership schema and data. The other *CoreIdentitySample* database was created using steps described earlier. Comments are included inline for more details.
 
 ```sql
 -- THIS SCRIPT NEEDS TO RUN FROM THE CONTEXT OF THE MEMBERSHIP DB
 BEGIN TRANSACTION MigrateUsersAndRoles
-use aspnetdb
+USE aspnetdb
 
 -- INSERT USERS
-INSERT INTO coreidentity.dbo.aspnetusers
-            (id,
-             username,
-             normalizedusername,
-             passwordhash,
-             securitystamp,
-             emailconfirmed,
-             phonenumber,
-             phonenumberconfirmed,
-             twofactorenabled,
-             lockoutend,
-             lockoutenabled,
-             accessfailedcount,
-             email,
-             normalizedemail)
-SELECT aspnet_users.userid,
-       aspnet_users.username,
-       aspnet_users.loweredusername,
-       --Creates an empty password since passwords don't map between the two schemas
+INSERT INTO CoreIdentitySample.dbo.AspNetUsers
+            (Id,
+             UserName,
+             NormalizedUserName,
+             PasswordHash,
+             SecurityStamp,
+             EmailConfirmed,
+             PhoneNumber,
+             PhoneNumberConfirmed,
+             TwoFactorEnabled,
+             LockoutEnd,
+             LockoutEnabled,
+             AccessFailedCount,
+             Email,
+             NormalizedEmail)
+SELECT aspnet_Users.UserId,
+       aspnet_Users.UserName,
+       -- The NormalizedUserName value is upper case in ASP.NET Core Identity
+       UPPER(aspnet_Users.UserName),
+       -- Creates an empty password since passwords don't map between the 2 schemas
        '',
-       --Security Stamp is a token used to verify the state of an account and is subject to change at any time. It should be initialized as a new ID.
+       /*
+        The SecurityStamp token is used to verify the state of an account and 
+        is subject to change at any time. It should be initialized as a new ID.
+       */
        NewID(),
-       --EmailConfirmed is set when a new user is created and confirmed via email. Users must have this set during migration to ensure they're able to reset passwords.
+       /*
+        EmailConfirmed is set when a new user is created and confirmed via email.
+        Users must have this set during migration to reset passwords.
+       */
        1,
-       aspnet_users.mobilealias,
+       aspnet_Users.MobileAlias,
        CASE
-         WHEN aspnet_Users.MobileAlias is null THEN 0
+         WHEN aspnet_Users.MobileAlias IS NULL THEN 0
          ELSE 1
        END,
-       --2-factor Auth likely wasn't setup in Membership for users, so setting as false.
+       -- 2FA likely wasn't setup in Membership for users, so setting as false.
        0,
        CASE
-         --Setting lockout date to time in the future (1000 years)
-         WHEN aspnet_membership.islockedout = 1 THEN Dateadd(year, 1000,
+         -- Setting lockout date to time in the future (1,000 years)
+         WHEN aspnet_Membership.IsLockedOut = 1 THEN Dateadd(year, 1000,
                                                      Sysutcdatetime())
          ELSE NULL
        END,
-       aspnet_membership.islockedout,
-       --AccessFailedAccount is used to track failed logins. This is stored in membership in multiple columns. Setting to 0 arbitrarily.
+       aspnet_Membership.IsLockedOut,
+       /*
+        AccessFailedAccount is used to track failed logins. This is stored in
+        Membership in multiple columns. Setting to 0 arbitrarily.
+       */
        0,
-       aspnet_membership.email,
-       aspnet_membership.loweredemail
-FROM   aspnet_users
-       LEFT OUTER JOIN aspnet_membership
-                    ON aspnet_membership.applicationid =
-                       aspnet_users.applicationid
-                       AND aspnet_users.userid = aspnet_membership.userid
-       LEFT OUTER JOIN coreidentity.dbo.aspnetusers
-                    ON aspnet_membership.userid = aspnetusers.id
-WHERE  aspnetusers.id IS NULL
+       aspnet_Membership.Email,
+       -- The NormalizedEmail value is upper case in ASP.NET Core Identity
+       UPPER(aspnet_Membership.Email)
+FROM   aspnet_Users
+       LEFT OUTER JOIN aspnet_Membership
+                    ON aspnet_Membership.ApplicationId =
+                       aspnet_Users.ApplicationId
+                       AND aspnet_Users.UserId = aspnet_Membership.UserId
+       LEFT OUTER JOIN CoreIdentitySample.dbo.AspNetUsers
+                    ON aspnet_Membership.UserId = AspNetUsers.Id
+WHERE  AspNetUsers.Id IS NULL
 
 -- INSERT ROLES
-INSERT INTO coreIdentity.dbo.aspnetroles(id,name)
-SELECT roleId,rolename
-FROM aspnet_roles;
+INSERT INTO CoreIdentitySample.dbo.AspNetRoles(Id, Name)
+SELECT RoleId, RoleName
+FROM aspnet_Roles;
 
 -- INSERT USER ROLES
-INSERT INTO coreidentity.dbo.aspnetuserroles(userid,roleid)
-SELECT userid,roleid
-FROM aspnet_usersinroles;
+INSERT INTO CoreIdentitySample.dbo.AspNetUserRoles(UserId, RoleId)
+SELECT UserId, RoleId
+FROM aspnet_UsersInRoles;
 
 IF @@ERROR <> 0
   BEGIN
@@ -168,7 +180,7 @@ IF @@ERROR <> 0
 COMMIT TRANSACTION MigrateUsersAndRoles
 ```
 
-After completion of this script, the ASP.NET Core Identity app created earlier is populated with Membership users. Users need to change their passwords before logging in.
+After completion of the preceding script, the ASP.NET Core Identity app created earlier is populated with Membership users. Users need to change their passwords before logging in.
 
 > [!NOTE]
 > If the Membership system had users with user names that didn't match their email address, changes are required to the app created earlier to accommodate this. The default template expects `UserName` and `Email` to be the same. For situations in which they're different, the login process needs to be modified to use `UserName` instead of `Email`.


### PR DESCRIPTION
Fixes https://github.com/aspnet/Docs/issues/8022

- Added UPPER function calls in the SQL script for the 2 Normalized columns used in Identity
- Improved readability of the SQL script
- Improved Markdown formatting of tables
- Added a missing step for viewing the local Identity DB