### PR TITLE
Common errors topic update

### DIFF
--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -1,10 +1,10 @@
 ---
-title: Troubleshoot ASP.NET Core startup errors on Azure App Service
+title: Troubleshoot ASP.NET Core on Azure App Service
 author: guardrex
 description: Learn how to diagnose problems with ASP.NET Core Azure App Service deployments.
 ms.author: riande
 ms.custom: mvc
-ms.date: 12/18/2018
+ms.date: 01/11/2019
 uid: host-and-deploy/azure-apps/troubleshoot
 ---
 # Troubleshoot ASP.NET Core on Azure App Service
@@ -43,17 +43,17 @@ The ASP.NET Core Module is configured with a default *startupTimeLimit* of 120 s
 
 ### Application Event Log
 
-To access the Application Event Log, use the **Diagnose and solve problems** blade in the Azure portal :
+To access the Application Event Log, use the **Diagnose and solve problems** blade in the Azure portal:
 
-1. In the Azure portal, open the app's blade in the **App Services** blade.
-1. Select the **Diagnose and solve problems** blade.
-1. Under **SELECT PROBLEM CATEGORY**, select the **Web App Down** button.
-1. Under **Suggested Solutions**, open the pane for **Open Application Event Logs**. Select the **Open Application Event Logs** button.
-1. Examine the latest error provided by the *IIS AspNetCoreModule* in the **Source** column.
+1. In the Azure portal, open the app in **App Services**.
+1. Select **Diagnose and solve problems**.
+1. Select the **Diagnostic Tools** heading.
+1. Under **Support Tools**, select the **Application Events** button.
+1. Examine the latest error provided by the *IIS AspNetCoreModule V2* in the **Source** column.
 
 An alternative to using the **Diagnose and solve problems** blade is to examine the Application Event Log file directly using [Kudu](https://github.com/projectkudu/kudu/wiki):
 
-1. Select the **Advanced Tools** blade in the **DEVELOPMENT TOOLS** area. Select the **Go&rarr;** button. The Kudu console opens in a new browser tab or window.
+1. Open **Advanced Tools** in the **Development Tools** area. Select the **Go&rarr;** button. The Kudu console opens in a new browser tab or window.
 1. Using the navigation bar at the top of the page, open **Debug console** and select **CMD**.
 1. Open the **LogFiles** folder.
 1. Select the pencil icon next to the *eventlog.xml* file.
@@ -63,7 +63,7 @@ An alternative to using the **Diagnose and solve problems** blade is to examine 
 
 Many startup errors don't produce useful information in the Application Event Log. You can run the app in the [Kudu](https://github.com/projectkudu/kudu/wiki) Remote Execution Console to discover the error:
 
-1. Select the **Advanced Tools** blade in the **DEVELOPMENT TOOLS** area. Select the **Go&rarr;** button. The Kudu console opens in a new browser tab or window.
+1. Open **Advanced Tools** in the **Development Tools** area. Select the **Go&rarr;** button. The Kudu console opens in a new browser tab or window.
 1. Using the navigation bar at the top of the page, open **Debug console** and select **CMD**.
 1. Open the folders to the path **site** > **wwwroot**.
 1. In the console, run the app by executing the app's assembly.
@@ -100,7 +100,33 @@ The ASP.NET Core Module stdout log often records useful error messages not found
 >
 > For general logging in an ASP.NET Core app after startup, use a logging library that limits log file size and rotates logs. For more information, see [third-party logging providers](xref:fundamentals/logging/index#third-party-logging-providers).
 
-## Common startup errors 
+### ASP.NET Core Module debug log
+
+The ASP.NET Core Module debug log provides additional, deeper logging from the ASP.NET Core Module. To enable and view stdout logs:
+
+1. To enable the enhanced diagnostic log, perform either of the following:
+   * Follow the instructions in [Enhanced diagnostic logs](xref:host-and-deploy/aspnet-core-module#enhanced-diagnostic-logs) to configure the app for an enhanced diagnostic logging. Redeploy the app.
+   * Add the `<handlerSettings>` shown in [Enhanced diagnostic logs](xref:host-and-deploy/aspnet-core-module#enhanced-diagnostic-logs) to the live app's *web.config* file using the Kudu console:
+     1. Open **Advanced Tools** in the **Development Tools** area. Select the **Go&rarr;** button. The Kudu console opens in a new browser tab or window.
+     1. Using the navigation bar at the top of the page, open **Debug console** and select **CMD**.
+     1. Open the folders to the path **site** > **wwwroot**. Edit the *web.config* file by selecting the pencil button. Add the `<handlerSettings>` section as shown in [Enhanced diagnostic logs](xref:host-and-deploy/aspnet-core-module#enhanced-diagnostic-logs). Select the **Save** button.
+1. Open **Advanced Tools** in the **Development Tools** area. Select the **Go&rarr;** button. The Kudu console opens in a new browser tab or window.
+1. Using the navigation bar at the top of the page, open **Debug console** and select **CMD**.
+1. Open the folders to the path **site** > **wwwroot**. If you didn't supply a path for the *aspnetcore-debug.log* file, the file appears in the list. If you supplied a path, navigate to the location of the log file.
+1. Open the log file with the pencil button next to the file name.
+
+**Important!** Disable debug logging when troubleshooting is complete.
+
+1. To disable the enhanced debug log, peform either of the following:
+   * Remove the `<handlerSettings>` from the *web.config* file locally and redeploy the app.
+   * Use the Kudu console to edit the *web.config* file and remove the `<handlerSettings>` section. Save the file.
+
+> [!WARNING]
+> Failure to disable the debug log can lead to app or server failure. There's no limit on log file size. Only use debug logging to troubleshoot app startup problems.
+>
+> For general logging in an ASP.NET Core app after startup, use a logging library that limits log file size and rotates logs. For more information, see [third-party logging providers](xref:fundamentals/logging/index#third-party-logging-providers).
+
+## Common startup errors
 
 See <xref:host-and-deploy/azure-iis-errors-reference>. Most of the common problems that prevent app startup are covered in the reference topic.
 

--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -89,7 +89,7 @@ The ASP.NET Core Module stdout log often records useful error messages not found
 1. Inspect the **Modified** column and select the pencil icon to edit the stdout log with the latest modification date.
 1. When the log file opens, the error is displayed.
 
-**Important!** Disable stdout logging when troubleshooting is complete.
+Disable stdout logging when troubleshooting is complete:
 
 1. In the Kudu **Diagnostic Console**, return to the path **site** > **wwwroot** to reveal the *web.config* file. Open the **web.config** file again by selecting the pencil icon.
 1. Set **stdoutLogEnabled** to `false`.
@@ -117,7 +117,7 @@ The ASP.NET Core Module debug log provides additional, deeper logging from the A
 1. Open the folders to the path **site** > **wwwroot**. If you didn't supply a path for the *aspnetcore-debug.log* file, the file appears in the list. If you supplied a path, navigate to the location of the log file.
 1. Open the log file with the pencil button next to the file name.
 
-**Important!** Disable debug logging when troubleshooting is complete.
+Disable debug logging when troubleshooting is complete:
 
 1. To disable the enhanced debug log, peform either of the following:
    * Remove the `<handlerSettings>` from the *web.config* file locally and redeploy the app.
@@ -181,7 +181,7 @@ Proceed to activate diagnostic logging:
 1. Make a request to the app.
 1. Within the log stream data, the cause of the error is indicated.
 
-**Important!** Be sure to disable stdout logging when troubleshooting is complete. See the instructions in the [ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log) section.
+Be sure to disable stdout logging when troubleshooting is complete. See the instructions in the [ASP.NET Core Module stdout log](#aspnet-core-module-stdout-log) section.
 
 To view the failed request tracing logs (FREB logs):
 

--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -49,7 +49,7 @@ To access the Application Event Log, use the **Diagnose and solve problems** bla
 1. Select **Diagnose and solve problems**.
 1. Select the **Diagnostic Tools** heading.
 1. Under **Support Tools**, select the **Application Events** button.
-1. Examine the latest error provided by the *IIS AspNetCoreModule V2* in the **Source** column.
+1. Examine the latest error provided by the *IIS AspNetCoreModule* or *IIS AspNetCoreModule V2* entry in the **Source** column.
 
 An alternative to using the **Diagnose and solve problems** blade is to examine the Application Event Log file directly using [Kudu](https://github.com/projectkudu/kudu/wiki):
 
@@ -100,6 +100,8 @@ The ASP.NET Core Module stdout log often records useful error messages not found
 >
 > For general logging in an ASP.NET Core app after startup, use a logging library that limits log file size and rotates logs. For more information, see [third-party logging providers](xref:fundamentals/logging/index#third-party-logging-providers).
 
+::: moniker range=">= aspnetcore-2.2"
+
 ### ASP.NET Core Module debug log
 
 The ASP.NET Core Module debug log provides additional, deeper logging from the ASP.NET Core Module. To enable and view stdout logs:
@@ -125,6 +127,8 @@ The ASP.NET Core Module debug log provides additional, deeper logging from the A
 > Failure to disable the debug log can lead to app or server failure. There's no limit on log file size. Only use debug logging to troubleshoot app startup problems.
 >
 > For general logging in an ASP.NET Core app after startup, use a logging library that limits log file size and rotates logs. For more information, see [third-party logging providers](xref:fundamentals/logging/index#third-party-logging-providers).
+
+::: moniker-end
 
 ## Common startup errors
 

--- a/aspnetcore/host-and-deploy/azure-iis-errors-reference.md
+++ b/aspnetcore/host-and-deploy/azure-iis-errors-reference.md
@@ -1,85 +1,117 @@
 ---
 title: Common errors reference for Azure App Service and IIS with ASP.NET Core
 author: guardrex
-description: Distinguish common errors when hosting ASP.NET Core apps on Azure Apps Service and IIS.
+description: Obtain troubleshooting advice for common errors when hosting ASP.NET Core apps on Azure Apps Service and IIS.
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/13/2017
+ms.date: 01/11/2018
 uid: host-and-deploy/azure-iis-errors-reference
 ---
 # Common errors reference for Azure App Service and IIS with ASP.NET Core
 
 By [Luke Latham](https://github.com/guardrex)
 
-The following isn't a complete list of errors. If you encounter an error not listed here, [open a new issue](https://github.com/aspnet/Docs/issues/new) with detailed instructions to reproduce the error.
+This topic offers troubleshooting advice for common errors when hosting ASP.NET Core apps on Azure Apps Service and IIS.
 
 Collect the following information:
 
-* Browser behavior
+* Browser behavior (status code and error message)
 * Application Event Log entries
-* ASP.NET Core Module stdout log entries
+  * Azure App Service &ndash; See <xref:host-and-deploy/azure-apps/troubleshoot>.
+  * IIS
+    1. Select **Start** on the **Windows** menu, type *Event Viewer*, and press **Enter**.
+    1. After the **Event Viewer** opens, expand **Windows Logs** > **Application** in the sidebar.
+* ASP.NET Core Module stdout and debug log entries
+  * Azure App Service &ndash; See <xref:host-and-deploy/azure-apps/troubleshoot>.
+  * IIS &ndash; Follow the instructions in the [Log creation and redirection](xref:host-and-deploy/aspnet-core-module#log-creation-and-redirection) and [Enhanced diagnostic logs](xref:host-and-deploy/aspnet-core-module#enhanced-diagnostic-logs) sections of the ASP.NET Core Module topic.
 
-Compare the information to the following common errors. If a match is found, follow the troubleshooting advice.
+Compare error information to the following common errors. If a match is found, follow the troubleshooting advice.
 
-[!INCLUDE [Azure App Service Preview Notice](../includes/azure-apps-preview-notice.md)]
+The list of errors in this topic isn't exhaustive. If you encounter an error not listed here, open a new issue using the **Content feedback** button at the bottom of this topic with detailed instructions on how to reproduce the error.
+
+[!INCLUDE[Azure App Service Preview Notice](../includes/azure-apps-preview-notice.md)]
 
 ## Installer unable to obtain VC++ Redistributable
 
-* **Installer Exception:** 0x80072efd or 0x80072f76 - Unspecified error
+* **Installer Exception:** 0x80072efd **--OR--** 0x80072f76 - Unspecified error
 
-* **Installer Log Exception&#8224;:** Error 0x80072efd or 0x80072f76: Failed to execute EXE package
+* **Installer Log Exception&#8224;:** Error 0x80072efd **--OR--** 0x80072f76: Failed to execute EXE package
 
-  &#8224;The log is located at C:\Users\\{USER}\AppData\Local\Temp\dd_DotNetCoreWinSvrHosting__{timestamp}.log.
+  &#8224;The log is located at *C:\Users\{USER}\AppData\Local\Temp\dd_DotNetCoreWinSvrHosting__{TIMESTAMP}.log*.
 
 Troubleshooting:
 
-* If the system doesn't have Internet access while installing the Hosting Bundle, this exception occurs when the installer is prevented from obtaining the *Microsoft Visual C++ 2015 Redistributable*. Obtain an installer from the [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=53840). If the installer fails, the server may not receive the .NET Core runtime required to host a framework-dependent deployment (FDD). If hosting an FDD, confirm that the runtime is installed in Programs &amp; Features. If needed, obtain a runtime installer from [.NET All Downloads](https://www.microsoft.com/net/download/all). After installing the runtime, restart the system or restart IIS by executing **net stop was /y** followed by **net start w3svc** from a command prompt.
+If the system doesn't have Internet access while [installing the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle), this exception occurs when the installer is prevented from obtaining the *Microsoft Visual C++ 2015 Redistributable*. Obtain an installer from the [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=53840). If the installer fails, the server may not receive the .NET Core runtime required to host a [framework-dependent deployment (FDD)](/dotnet/core/deploying/#framework-dependent-deployments-fdd). If hosting an FDD, confirm that the runtime is installed in **Programs & Features** or **Apps & features**. If a specific runtime is required, download the runtime from the [.NET Download Archives](https://dotnet.microsoft.com/download/archives) and install it on the system. After installing the runtime, restart the system or restart IIS by executing **net stop was /y** followed by **net start w3svc** from a command prompt.
 
 ## OS upgrade removed the 32-bit ASP.NET Core Module
 
-* **Application Log:** The Module DLL **C:\WINDOWS\system32\inetsrv\aspnetcore.dll** failed to load. The data is the error.
+**Application Log:** The Module DLL **C:\WINDOWS\system32\inetsrv\aspnetcore.dll** failed to load. The data is the error.
 
 Troubleshooting:
 
-* Non-OS files in the **C:\Windows\SysWOW64\inetsrv** directory aren't preserved during an OS upgrade. If the ASP.NET Core Module is installed prior to an OS upgrade and then any AppPool is run in 32-bit mode after an OS upgrade, this issue is encountered. After an OS upgrade, repair the ASP.NET Core Module. See [Install the .NET Core Hosting bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). Select **Repair** when the installer is run.
+Non-OS files in the **C:\Windows\SysWOW64\inetsrv** directory aren't preserved during an OS upgrade. If the ASP.NET Core Module is installed prior to an OS upgrade and then any app pool is run in 32-bit mode after an OS upgrade, this issue is encountered. After an OS upgrade, repair the ASP.NET Core Module. See [Install the .NET Core Hosting bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). Select **Repair** when the installer is run.
+
+## An x86 app is deployed but the app pool isn't enabled for 32-bit apps
+
+* **Browser:** HTTP Error 500.30 - ANCM In-Process Start Failure
+
+* **Application Log:** Application '/LM/W3SVC/5/ROOT' with physical root '{PATH}' hit unexpected managed exception, exception code = '0xe0434352'. Please check the stderr logs for more information. Application '/LM/W3SVC/5/ROOT' with physical root '{PATH}' failed to load clr and managed application. CLR worker thread exited prematurely
+
+* **ASP.NET Core Module stdout Log:** The log file is created but empty.
+
+::: moniker range=">= aspnetcore-2.2"
+
+* **ASP.NET Core Module Debug Log:** Failed HRESULT returned: 0x8007023e
+
+::: moniker-end
+
+This scenario is trapped by the SDK when publishing a self-contained app. The SDK produces an error if the RID doesn't match the platform target (for example, `win10-x64` RID with `<PlatformTarget>x86</PlatformTarget>` in the project file).
+
+Troubleshooting:
+
+For an x86 framework-dependent deployment (`<PlatformTarget>x86</PlatformTarget>`), enable the IIS app pool for 32-bit apps. In IIS Manager, open the app pool's **Advanced Settings** and set **Enable 32-Bit Applications** to **True**.
 
 ## Platform conflicts with RID
 
 * **Browser:** HTTP Error 502.5 - Process Failure
 
-* **Application Log:** Application 'MACHINE/WEBROOT/APPHOST/{ASSEMBLY}' with physical root 'C:\{PATH}\' failed to start process with commandline '"C:\\{PATH}{assembly}.{exe|dll}" ', ErrorCode = '0x80004005 : ff.
+* **Application Log:** Application 'MACHINE/WEBROOT/APPHOST/{ASSEMBLY}' with physical root 'C:\{PATH}\' failed to start process with commandline '"C:\{PATH}{ASSEMBLY}.{exe|dll}" ', ErrorCode = '0x80004005 : ff.
 
-* **ASP.NET Core Module Log:** Unhandled Exception: System.BadImageFormatException: Could not load file or assembly '{assembly}.dll'. An attempt was made to load a program with an incorrect format.
+* **ASP.NET Core Module stdout Log:** Unhandled Exception: System.BadImageFormatException: Could not load file or assembly '{ASSEMBLY}.dll'. An attempt was made to load a program with an incorrect format.
 
 Troubleshooting:
 
-* Confirm that the app runs locally on Kestrel. A process failure might be the result of a problem within the app. For more information, see [Troubleshooting](xref:host-and-deploy/iis/troubleshoot).
-
-* Confirm that the `<PlatformTarget>` in the *.csproj* doesn't conflict with the RID. For example, don't specify a `<PlatformTarget>` of `x86` and publish with an RID of `win10-x64`, either by using *dotnet publish -c Release -r win10-x64* or by setting the `<RuntimeIdentifiers>` in the *.csproj* to `win10-x64`. The project publishes without warning or error but fails with the above logged exceptions on the system.
+* Confirm that the app runs locally on Kestrel. A process failure might be the result of a problem within the app. For more information, see [Troubleshoot (IIS)](xref:host-and-deploy/iis/troubleshoot) or [Troubleshoot (Azure App Service)](xref:host-and-deploy/azure-apps/troubleshoot).
 
 * If this exception occurs for an Azure Apps deployment when upgrading an app and deploying newer assemblies, manually delete all files from the prior deployment. Lingering incompatible assemblies can result in a `System.BadImageFormatException` exception when deploying an upgraded app.
 
 ## URI endpoint wrong or stopped website
 
-* **Browser:** ERR_CONNECTION_REFUSED
+* **Browser:** ERR_CONNECTION_REFUSED **--OR--** Unable to connect
 
 * **Application Log:** No entry
 
-* **ASP.NET Core Module Log:** Log file not created
+* **ASP.NET Core Module stdout Log:** The log file isn't created.
+
+::: moniker range=">= aspnetcore-2.2"
+
+* **ASP.NET Core Module Debug Log:** The log file isn't created.
+
+::: moniker-end
 
 Troubleshooting:
 
-* Confirm the correct URI endpoint for the app is being used. Check the bindings.
+* Confirm the correct URI endpoint for the app is in use. Check the bindings.
 
 * Confirm that the IIS website isn't in the *Stopped* state.
 
 ## CoreWebEngine or W3SVC server features disabled
 
-* **OS Exception:** The IIS 7.0 CoreWebEngine and W3SVC features must be installed to use the ASP.NET Core Module.
+**OS Exception:** The IIS 7.0 CoreWebEngine and W3SVC features must be installed to use the ASP.NET Core Module.
 
 Troubleshooting:
 
-* Confirm that the proper role and features are enabled. See [IIS Configuration](xref:host-and-deploy/iis/index#iis-configuration).
+Confirm that the proper role and features are enabled. See [IIS Configuration](xref:host-and-deploy/iis/index#iis-configuration).
 
 ## Incorrect website physical path or app missing
 
@@ -87,79 +119,139 @@ Troubleshooting:
 
 * **Application Log:** No entry
 
-* **ASP.NET Core Module Log:** Log file not created
+* **ASP.NET Core Module stdout Log:** The log file isn't created.
+
+::: moniker range=">= aspnetcore-2.2"
+
+* **ASP.NET Core Module Debug Log:** The log file isn't created.
+
+::: moniker-end
 
 Troubleshooting:
 
-* Check the IIS website **Basic Settings** and the physical app folder. Confirm that the app is in the folder at the IIS website **Physical path**.
+Check the IIS website **Basic Settings** and the physical app folder. Confirm that the app is in the folder at the IIS website **Physical path**.
 
-## Incorrect role, module not installed, or incorrect permissions
+## Incorrect role, ASP.NET Core Module not installed, or incorrect permissions
 
-* **Browser:** 500.19 Internal Server Error - The requested page cannot be accessed because the related configuration data for the page is invalid.
+* **Browser:** 500.19 Internal Server Error - The requested page cannot be accessed because the related configuration data for the page is invalid. **--OR--** This page can't be displayed
 
 * **Application Log:** No entry
 
-* **ASP.NET Core Module Log:** Log file not created
+* **ASP.NET Core Module stdout Log:** The log file isn't created.
+
+::: moniker range=">= aspnetcore-2.2"
+
+* **ASP.NET Core Module Debug Log:** The log file isn't created.
+
+::: moniker-end
 
 Troubleshooting:
 
 * Confirm that the proper role is enabled. See [IIS Configuration](xref:host-and-deploy/iis/index#iis-configuration).
 
-* Check **Programs &amp; Features** and confirm that the **Microsoft ASP.NET Core Module** has been installed. If the **Microsoft ASP.NET Core Module** isn't present in the list of installed programs, install the module. See [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle).
+* Open **Programs & Features** or **Apps & features** and confirm that **Windows Server Hosting** is installed. If **Windows Server Hosting** isn't present in the list of installed programs, download and install the .NET Core Hosting Bundle.
+
+  [Current .NET Core Hosting Bundle installer (direct download)](https://www.microsoft.com/net/permalink/dotnetcore-current-windows-runtime-bundle-installer)
+
+  For more information, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle).
 
 * Make sure that the **Application Pool** > **Process Model** > **Identity** is set to **ApplicationPoolIdentity** or the custom identity has the correct permissions to access the app's deployment folder.
 
 ## Incorrect processPath, missing PATH variable, Hosting Bundle not installed, system/IIS not restarted, VC++ Redistributable not installed, or dotnet.exe access violation
 
+::: moniker range=">= aspnetcore-2.2"
+
+* **Browser:** HTTP Error 500.0 - ANCM In-Process Handler Load Failure
+
+* **Application Log:** Application '{PATH}' wasn't able to start. Executable was not found at '{PATH}'. Failed to start application '/LM/W3SVC/2/ROOT', ErrorCode '0x8007023e'.
+
+* **ASP.NET Core Module stdout Log:** The log file isn't created.
+
+* **ASP.NET Core Module Debug Log:** Event Log: 'Application '{PATH}' wasn't able to start. Executable was not found at '{PATH}'. Failed HRESULT returned: 0x8007023e
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.2"
+
 * **Browser:** HTTP Error 502.5 - Process Failure
 
-* **Application Log:** Application 'MACHINE/WEBROOT/APPHOST/{ASSEMBLY}' with physical root 'C:\\{PATH}\' failed to start process with commandline '".\{assembly}.exe" ', ErrorCode = '0x80070002 : 0.
+* **Application Log:** Application 'MACHINE/WEBROOT/APPHOST/{ASSEMBLY}' with physical root 'C:\{PATH}\' failed to start process with commandline '".\{ASSEMBLY}.exe" ', ErrorCode = '0x80070002 : 0.
 
-* **ASP.NET Core Module Log:** Log file created but empty
+* **ASP.NET Core Module stdout Log:** The log file is created but empty.
+
+::: moniker-end
 
 Troubleshooting:
 
-* Confirm that the app runs locally on Kestrel. A process failure might be the result of a problem within the app. For more information, see [Troubleshooting](xref:host-and-deploy/iis/troubleshoot).
+* Confirm that the app runs locally on Kestrel. A process failure might be the result of a problem within the app. For more information, see [Troubleshoot (IIS)](xref:host-and-deploy/iis/troubleshoot) or [Troubleshoot (Azure App Service)](xref:host-and-deploy/azure-apps/troubleshoot).
 
-* Check the *processPath* attribute on the `<aspNetCore>` element in *web.config* to confirm that it's *dotnet* for a framework-dependent deployment (FDD) or *.\{assembly}.exe* for a self-contained deployment (SCD).
+* Check the *processPath* attribute on the `<aspNetCore>` element in *web.config* to confirm that it's `dotnet` for a framework-dependent deployment (FDD) or `.\{ASSEMBLY}.exe` for a [self-contained deployment (SCD)](/dotnet/core/deploying/#self-contained-deployments-scd).
 
 * For an FDD, *dotnet.exe* might not be accessible via the PATH settings. Confirm that *C:\Program Files\dotnet\* exists in the System PATH settings.
 
-* For an FDD, *dotnet.exe* might not be accessible for the user identity of the Application Pool. Confirm that the AppPool user identity has access to the *C:\Program Files\dotnet* directory. Confirm that there are no deny rules configured for the AppPool user identity on the *C:\Program Files\dotnet* and app directories.
+* For an FDD, *dotnet.exe* might not be accessible for the user identity of the app pool. Confirm that the app pool user identity has access to the *C:\Program Files\dotnet* directory. Confirm that there are no deny rules configured for the app pool user identity on the *C:\Program Files\dotnet* and app directories.
 
 * An FDD may have been deployed and .NET Core installed without restarting IIS. Either restart the server or restart IIS by executing **net stop was /y** followed by **net start w3svc** from a command prompt.
 
-* An FDD may have been deployed without installing the .NET Core runtime on the hosting system. If the .NET Core runtime hasn't been installed, run the **.NET Core Hosting Bundle installer** on the system. See [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). If attempting to install the .NET Core runtime on a system without an Internet connection, obtain the runtime from [.NET All Downloads](https://www.microsoft.com/net/download/all) and run the Hosting Bundle installer to install the ASP.NET Core Module. Complete the installation by restarting the system or restarting IIS by executing **net stop was /y** followed by **net start w3svc** from a command prompt.
+* An FDD may have been deployed without installing the .NET Core runtime on the hosting system. If the .NET Core runtime hasn't been installed, run the **.NET Core Hosting Bundle installer** on the system.
+
+  [Current .NET Core Hosting Bundle installer (direct download)](https://www.microsoft.com/net/permalink/dotnetcore-current-windows-runtime-bundle-installer)
+
+  For more information, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle).
+
+  If a specific runtime is required, download the runtime from the [.NET Download Archives](https://dotnet.microsoft.com/download/archives) and install it on the system. Complete the installation by restarting the system or restarting IIS by executing **net stop was /y** followed by **net start w3svc** from a command prompt.
 
 * An FDD may have been deployed and the *Microsoft Visual C++ 2015 Redistributable (x64)* isn't installed on the system. Obtain an installer from the [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=53840).
 
-## Incorrect arguments of \<aspNetCore\> element
+## Incorrect arguments of \<aspNetCore> element
+
+::: moniker range=">= aspnetcore-2.2"
+
+* **Browser:** HTTP Error 500.0 - ANCM In-Process Handler Load Failure
+
+* **Application Log:** Invoking hostfxr to find the inprocess request handler failed without finding any native dependencies. This most likely means the app is misconfigured, please check the versions of Microsoft.NetCore.App and Microsoft.AspNetCore.App that are targeted by the application and are installed on the machine. Could not find inprocess request handler. Captured output from invoking hostfxr: Did you mean to run dotnet SDK commands? Please install dotnet SDK from: https://go.microsoft.com/fwlink/?LinkID=798306&clcid=0x409 Failed to start application '/LM/W3SVC/3/ROOT', ErrorCode '0x8000ffff'.
+
+* **ASP.NET Core Module stdout Log:** Did you mean to run dotnet SDK commands? Please install dotnet SDK from: https://go.microsoft.com/fwlink/?LinkID=798306&clcid=0x409
+
+* **ASP.NET Core Module Debug Log:** Invoking hostfxr to find the inprocess request handler failed without finding any native dependencies. This most likely means the app is misconfigured, please check the versions of Microsoft.NetCore.App and Microsoft.AspNetCore.App that are targeted by the application and are installed on the machine. Failed HRESULT returned: 0x8000ffff Could not find inprocess request handler. Captured output from invoking hostfxr: Did you mean to run dotnet SDK commands? Please install dotnet SDK from: https://go.microsoft.com/fwlink/?LinkID=798306&clcid=0x409 Failed HRESULT returned: 0x8000ffff
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.2"
 
 * **Browser:** HTTP Error 502.5 - Process Failure
 
-* **Application Log:** Application 'MACHINE/WEBROOT/APPHOST/{ASSEMBLY}' with physical root 'C:\\{PATH}\' failed to start process with commandline '"dotnet" .\{assembly}.dll', ErrorCode = '0x80004005 : 80008081.
+* **Application Log:** Application 'MACHINE/WEBROOT/APPHOST/{ASSEMBLY}' with physical root 'C:\{PATH}\' failed to start process with commandline '"dotnet" .\{ASSEMBLY}.dll', ErrorCode = '0x80004005 : 80008081.
 
-* **ASP.NET Core Module Log:** The application to execute does not exist: 'PATH\{assembly}.dll'
+* **ASP.NET Core Module stdout Log:** The application to execute does not exist: 'PATH\{ASSEMBLY}.dll'
 
-Troubleshooting:
-
-* Confirm that the app runs locally on Kestrel. A process failure might be the result of a problem within the app. For more information, see [Troubleshooting](xref:host-and-deploy/iis/troubleshoot).
-
-* Examine the *arguments* attribute on the `<aspNetCore>` element in *web.config* to confirm that it's either (a) *.\{assembly}.dll* for a framework-dependent deployment (FDD); or (b) not present, an empty string (*arguments=""*), or a list of the app's arguments (*arguments="arg1, arg2, ..."*) for a self-contained deployment (SCD).
-
-## Missing .NET Framework version
-
-* **Browser:** 502.3 Bad Gateway - There was a connection error while trying to route the request.
-
-* **Application Log:** ErrorCode = Application 'MACHINE/WEBROOT/APPHOST/{ASSEMBLY}' with physical root 'C:\\{PATH}\' failed to start process with commandline '"dotnet" .\{assembly}.dll', ErrorCode = '0x80004005 : 80008081.
-
-* **ASP.NET Core Module Log:** Missing method, file, or assembly exception. The method, file, or assembly specified in the exception is a .NET Framework method, file, or assembly.
+::: moniker-end
 
 Troubleshooting:
 
-* Install the .NET Framework version missing from the system.
+* Confirm that the app runs locally on Kestrel. A process failure might be the result of a problem within the app. For more information, see [Troubleshoot (IIS)](xref:host-and-deploy/iis/troubleshoot) or [Troubleshoot (Azure App Service)](xref:host-and-deploy/azure-apps/troubleshoot).
 
-* For a framework-dependent deployment (FDD), confirm that the correct runtime installed on the system. If the project is upgraded from 1.1 to 2.0, deployed to the hosting system, and this exception results, ensure that the 2.0 framework is on the hosting system.
+* Examine the *arguments* attribute on the `<aspNetCore>` element in *web.config* to confirm that it's either (a) `.\{ASSEMBLY}.dll` for a framework-dependent deployment (FDD); or (b) not present, an empty string (`arguments=""`), or a list of the app's arguments (`arguments="{ARGUMENT_1}, {ARGUMENT_2}, ... {ARGUMENT_X}"`) for a self-contained deployment (SCD).
+
+::: moniker range=">= aspnetcore-2.2"
+
+## Missing .NET Core shared framework
+
+* **Browser:** HTTP Error 500.0 - ANCM In-Process Handler Load Failure
+
+* **Application Log:** Invoking hostfxr to find the inprocess request handler failed without finding any native dependencies. This most likely means the app is misconfigured, please check the versions of Microsoft.NetCore.App and Microsoft.AspNetCore.App that are targeted by the application and are installed on the machine. Could not find inprocess request handler. Captured output from invoking hostfxr: It was not possible to find any compatible framework version. The specified framework 'Microsoft.AspNetCore.App', version '{VERSION}' was not found.
+
+Failed to start application '/LM/W3SVC/5/ROOT', ErrorCode '0x8000ffff'.
+
+* **ASP.NET Core Module stdout Log:** It was not possible to find any compatible framework version. The specified framework 'Microsoft.AspNetCore.App', version '{VERSION}' was not found.
+
+* **ASP.NET Core Module Debug Log:** Failed HRESULT returned: 0x8000ffff
+
+::: moniker-end
+
+Troubleshooting:
+
+For a framework-dependent deployment (FDD), confirm that the correct runtime installed on the system.
 
 ## Stopped Application Pool
 
@@ -167,62 +259,106 @@ Troubleshooting:
 
 * **Application Log:** No entry
 
-* **ASP.NET Core Module Log:** Log file not created
+* **ASP.NET Core Module stdout Log:** The log file isn't created.
 
-Troubleshooting
+::: moniker range=">= aspnetcore-2.2"
 
-* Confirm that the Application Pool isn't in the *Stopped* state.
+* **ASP.NET Core Module Debug Log:** The log file isn't created.
 
-## IIS Integration middleware not implemented
+::: moniker-end
 
-* **Browser:** HTTP Error 502.5 - Process Failure
+Troubleshooting:
 
-* **Application Log:** Application 'MACHINE/WEBROOT/APPHOST/{ASSEMBLY}' with physical root 'C:\\{PATH}\' created process with commandline '"C:\\{PATH}\{assembly}.{exe|dll}" ' but either crashed or did not reponse or did not listen on the given port '{PORT}', ErrorCode = '0x800705b4'
+Confirm that the Application Pool isn't in the *Stopped* state.
 
-* **ASP.NET Core Module Log:** Log file created and shows normal operation.
-
-Troubleshooting
-
-* Confirm that the app runs locally on Kestrel. A process failure might be the result of a problem within the app. For more information, see [Troubleshooting](xref:host-and-deploy/iis/troubleshoot).
-
-* Confirm that either:
-  * The IIS Integration middleware is referencedby calling the `UseIISIntegration` method on the app's `WebHostBuilder` (ASP.NET Core 1.x)
-  * The apps uses the `CreateDefaultBuilder` method (ASP.NET Core 2.x).
-  
-  See [Host in ASP.NET Core](xref:fundamentals/host/index) for details.
-
-## Sub-application includes a \<handlers\> section
+## Sub-application includes a \<handlers> section
 
 * **Browser:** HTTP Error 500.19 - Internal Server Error
 
 * **Application Log:** No entry
 
-* **ASP.NET Core Module Log:** Log file created and shows normal operation for the root app. Log file not created for the sub-app.
+* **ASP.NET Core Module stdout Log:** The root app's log file is created and shows normal operation. The sub-app's log file isn't created.
 
-Troubleshooting
+::: moniker range=">= aspnetcore-2.2"
 
-* Confirm that the sub-app's *web.config* file doesn't include a `<handlers>` section.
+* **ASP.NET Core Module Debug Log:** The root app's log file is created and shows normal operation. The sub-app's log file isn't created.
+
+::: moniker-end
+
+Troubleshooting:
+
+::: moniker range=">= aspnetcore-2.2"
+
+Confirm that the sub-app's *web.config* file doesn't include a `<handlers>` section or that the sub-app doesn't inherit the parent app's handlers.
+
+The parent app's `<system.webServer>` section of *web.config* is placed inside of a `<location>` element. The <xref:System.Configuration.SectionInformation.InheritInChildApplications*> property is set to `false` to indicate that the settings specified within the [\<location>](/iis/manage/managing-your-configuration-settings/understanding-iis-configuration-delegation#the-concept-of-location) element aren't inherited by apps that reside in a subdirectory of the parent app. For more information, see <xref:host-and-deploy/aspnet-core-module>.
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.2"
+
+Confirm that the sub-app's *web.config* file doesn't include a `<handlers>` section.
+
+::: moniker-end
 
 ## stdout log path incorrect
 
 * **Browser:** The app responds normally.
 
-* **Application Log:** Warning: Could not create stdoutLogFile \\?\C:\_apps\app_folder\bin\Release\netcoreapp2.0\win10-x64\publish\logs\path_doesnt_exist\stdout_8748_201831835937.log, ErrorCode = -2147024893.
+::: moniker range=">= aspnetcore-2.2"
 
-* **ASP.NET Core Module Log:** Log file not created
+* **Application Log:** Could not start stdout redirection in C:\Program Files\IIS\Asp.Net Core Module\V2\aspnetcorev2.dll. Exception message: HRESULT 0x80070005 returned at {PATH}\aspnetcoremodulev2\commonlib\fileoutputmanager.cpp:84. Could not stop stdout redirection in C:\Program Files\IIS\Asp.Net Core Module\V2\aspnetcorev2.dll. Exception message: HRESULT 0x80070002 returned at {PATH}. Could not start stdout redirection in {PATH}\aspnetcorev2_inprocess.dll.
 
-Troubleshooting
+* **ASP.NET Core Module stdout Log:** The log file isn't created.
 
-* The `stdoutLogFile` path specified in the `<aspNetCore>` element of *web.config* doesn't exist. For more information, see the [Log creation and redirection](xref:host-and-deploy/aspnet-core-module#log-creation-and-redirection) section of the ASP.NET Core Module configuration reference topic.
+* **ASP.NET Core Module debug Log:** Could not start stdout redirection in C:\Program Files\IIS\Asp.Net Core Module\V2\aspnetcorev2.dll. Exception message: HRESULT 0x80070005 returned at {PATH}\aspnetcoremodulev2\commonlib\fileoutputmanager.cpp:84. Could not stop stdout redirection in C:\Program Files\IIS\Asp.Net Core Module\V2\aspnetcorev2.dll. Exception message: HRESULT 0x80070002 returned at {PATH}. Could not start stdout redirection in {PATH}\aspnetcorev2_inprocess.dll.
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.2"
+
+* **Application Log:** Warning: Could not create stdoutLogFile \\?\{PATH}\path_doesnt_exist\stdout_{PROCESS ID}_{TIMESTAMP}.log, ErrorCode = -2147024893.
+
+* **ASP.NET Core Module stdout Log:** The log file isn't created.
+
+::: moniker-end
+
+Troubleshooting:
+
+* The `stdoutLogFile` path specified in the `<aspNetCore>` element of *web.config* doesn't exist. For more information, see [ASP.NET Core Module: Log creation and redirection](xref:host-and-deploy/aspnet-core-module#log-creation-and-redirection).
+
+* The app pool user doesn't have write access to the stdout log path.
 
 ## Application configuration general issue
 
+::: moniker range=">= aspnetcore-2.2"
+
+* **Browser:** HTTP Error 500.0 - ANCM In-Process Handler Load Failure **--OR--** HTTP Error 500.30 - ANCM In-Process Start Failure
+
+* **Application Log:** Variable
+
+* **ASP.NET Core Module stdout Log:** The log file is created but empty or created with normal entries until the point of the app failing.
+
+* **ASP.NET Core Module Debug Log:** Variable
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.2"
+
 * **Browser:** HTTP Error 502.5 - Process Failure
 
-* **Application Log:** Application 'MACHINE/WEBROOT/APPHOST/{ASSEMBLY}' with physical root 'C:\\{PATH}\' created process with commandline '"C:\\{PATH}\{assembly}.{exe|dll}" ' but either crashed or did not reponse or did not listen on the given port '{PORT}', ErrorCode = '0x800705b4'
+* **Application Log:** Application 'MACHINE/WEBROOT/APPHOST/{ASSEMBLY}' with physical root 'C:\{PATH}\' created process with commandline '"C:\{PATH}\{ASSEMBLY}.{exe|dll}" ' but either crashed or did not respond or did not listen on the given port '{PORT}', ErrorCode = '{ERROR CODE}'
 
-* **ASP.NET Core Module Log:** Log file created but empty
+* **ASP.NET Core Module stdout Log:** The log file is created but empty.
 
-Troubleshooting
+::: moniker-end
 
-* This general exception indicates that the process failed to start, most likely due to an app configuration issue. Referring to [Directory Structure](xref:host-and-deploy/directory-structure), confirm that the app's deployed files and folders are appropriate and that the app's configuration files are present and contain the correct settings for the app and environment. For more information, see [Troubleshooting](xref:host-and-deploy/iis/troubleshoot).
+Troubleshooting:
+
+The process failed to start, most likely due to an app configuration or programming issue.
+
+For more information, see the following topics:
+
+* <xref:host-and-deploy/iis/troubleshoot>
+* <xref:host-and-deploy/azure-apps/troubleshoot>
+* <xref:test/troubleshoot>

--- a/aspnetcore/host-and-deploy/azure-iis-errors-reference.md
+++ b/aspnetcore/host-and-deploy/azure-iis-errors-reference.md
@@ -163,7 +163,7 @@ Troubleshooting:
 
 * **Browser:** HTTP Error 500.0 - ANCM In-Process Handler Load Failure
 
-* **Application Log:** Application '{PATH}' wasn't able to start. Executable was not found at '{PATH}'. Failed to start application '/LM/W3SVC/2/ROOT', ErrorCode '0x8007023e'.
+* **Application Log:** Application 'MACHINE/WEBROOT/APPHOST/{ASSEMBLY}' with physical root 'C:\{PATH}\' failed to start process with commandline '"{...}" ', ErrorCode = '0x80070002 : 0. Application '{PATH}' wasn't able to start. Executable was not found at '{PATH}'. Failed to start application '/LM/W3SVC/2/ROOT', ErrorCode '0x8007023e'.
 
 * **ASP.NET Core Module stdout Log:** The log file isn't created.
 
@@ -175,7 +175,7 @@ Troubleshooting:
 
 * **Browser:** HTTP Error 502.5 - Process Failure
 
-* **Application Log:** Application 'MACHINE/WEBROOT/APPHOST/{ASSEMBLY}' with physical root 'C:\{PATH}\' failed to start process with commandline '".\{ASSEMBLY}.exe" ', ErrorCode = '0x80070002 : 0.
+* **Application Log:** Application 'MACHINE/WEBROOT/APPHOST/{ASSEMBLY}' with physical root 'C:\{PATH}\' failed to start process with commandline '"{...}" ', ErrorCode = '0x80070002 : 0.
 
 * **ASP.NET Core Module stdout Log:** The log file is created but empty.
 

--- a/aspnetcore/toc.md
+++ b/aspnetcore/toc.md
@@ -241,7 +241,9 @@
 ### [Publish with CLI tools](/azure/app-service/app-service-web-tutorial-dotnetcore-sqldb)
 ### [Publish with Visual Studio and Git](xref:host-and-deploy/azure-apps/azure-continuous-deployment)
 ### [Continuous deployment with Azure Pipelines](/azure/devops/pipelines/get-started-yaml)
-### [Troubleshoot startup errors](xref:host-and-deploy/azure-apps/troubleshoot)
+### [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module)
+### [Troubleshoot](xref:host-and-deploy/azure-apps/troubleshoot)
+### [Errors reference](xref:host-and-deploy/azure-iis-errors-reference)
 ## DevOps 
 ### [Overview](xref:azure/devops/index)
 ### [Tools and downloads](xref:azure/devops/tools-and-downloads)
@@ -251,10 +253,11 @@
 ### [Next steps](xref:azure/devops/next-steps)
 ## Host on Windows with IIS
 ### [Overview](xref:host-and-deploy/iis/index)
-### [Troubleshoot on IIS](xref:host-and-deploy/iis/troubleshoot)
 ### [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module)
 ### [IIS support in Visual Studio](xref:host-and-deploy/iis/development-time-iis-support)
 ### [IIS Modules](xref:host-and-deploy/iis/modules)
+### [Troubleshoot](xref:host-and-deploy/iis/troubleshoot)
+### [Errors reference](xref:host-and-deploy/azure-iis-errors-reference)
 ## [Kestrel](xref:fundamentals/servers/kestrel)
 ## [HTTP.sys](xref:fundamentals/servers/httpsys)
 ## [Host in a Windows service](xref:host-and-deploy/windows-service)
@@ -269,7 +272,6 @@
 ## [Host in a web farm](xref:host-and-deploy/web-farm)
 ## [Visual Studio publish profiles](xref:host-and-deploy/visual-studio-publish-profiles)
 ## [Directory structure](xref:host-and-deploy/directory-structure)
-## [Errors reference for Azure App Service and IIS](xref:host-and-deploy/azure-iis-errors-reference)
 ## [Health checks](xref:host-and-deploy/health-checks)
 
 # Security and Identity
@@ -379,7 +381,7 @@
 ## [Globalization and localization](xref:fundamentals/localization)
 ## [Portable Object localization with Orchard Core](xref:fundamentals/portable-object-localization)
 ## [URL rewriting](xref:fundamentals/url-rewriting)
-## [File providers](xref:fundamentals/file-providers)
+## [File Providers](xref:fundamentals/file-providers)
 ## [Request Features](xref:fundamentals/request-features)
 ## [Access HttpContext](xref:fundamentals/httpcontext)
 ## [Change tokens](xref:fundamentals/change-tokens)


### PR DESCRIPTION
Fixes #5297 

Always a **_"fun"_** one to work. 😅 lol

* Updated common errors for ANCM v2/2.2 scenarios. Includes:
  * *Missing .NET Core shared framework* section
  * Direct download for the hosting bundle
* Azure Apps *Troubleshoot* topic
  * The portal changed. This re-aligns the topic to the portal.
  * We should remove "startup errors" from the Azure Apps *Troubleshoot* title. It's for more than that.
  * Add the ASP.NET Core Module debug log.
* TOC
  * You moved the ANCM topic out of the *host-and-deploy* node, but that was placed there by-design so as not to hide it from Azure Apps users who might not look inside the IIS node. The content is *highly relevant* to Azure Apps scenarios. However, it isn't much more useful than that, so I figure what we can do is add the same link in the Azure Apps node.
  * Same deal with the *Common Errors* topic ("Errors reference"): I propose we place a link to it at the bottoms of the Azure Apps and IIS nodes.
  * "File Providers" (capital "P") is a proper noun ... quick patch on that while I'm in here.

@Tratcher Who would be best for the engineering review?