### PR TITLE
Update jqXHR.error() method into jqXHR.fail() method after jQuery 3.0

### DIFF
--- a/aspnet/web-api/overview/security/enabling-cross-origin-requests-in-web-api/samples/sample2.cshtml
+++ b/aspnet/web-api/overview/security/enabling-cross-origin-requests-in-web-api/samples/sample2.cshtml
@@ -21,7 +21,7 @@
             url: serviceUrl
         }).done(function (data) {
             $('#value1').text(data);
-        }).error(function (jqXHR, textStatus, errorThrown) {
+        }).fail(function (jqXHR, textStatus, errorThrown) {
             $('#value1').text(jqXHR.responseText || textStatus);
         });
     }


### PR DESCRIPTION
The current version of default scaffolding jQuery library in ASP.NET MVC is v3.3.1. 
And the jqXHR.error() method has been replaced with jqXHR.fail() after jQuery 3.0.

You can see this on this page: http://api.jquery.com/jQuery.ajax/#jqXHR
```
Deprecation Notice: The jqXHR.success(), jqXHR.error(), and jqXHR.complete() callbacks are removed as of jQuery 3.0. You can use jqXHR.done(), jqXHR.fail(), and jqXHR.always() instead.
```



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->