### PR TITLE
Update ws-federation.md

### DIFF
--- a/aspnetcore/security/authentication/ws-federation.md
+++ b/aspnetcore/security/authentication/ws-federation.md
@@ -4,7 +4,7 @@ author: chlowell
 description: This tutorial demonstrates how to use WS-Federation in an ASP.NET Core app.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 02/27/2018
+ms.date: 01/16/2019
 uid: security/authentication/ws-federation
 ---
 # Authenticate users with WS-Federation in ASP.NET Core
@@ -77,7 +77,7 @@ By default, the new middleware:
 ## Add WS-Federation as an external login provider for ASP.NET Core Identity
 
 * Add a dependency on [Microsoft.AspNetCore.Authentication.WsFederation](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.WsFederation) to the project.
-* Add WS-Federation to the `ConfigureServices` method in *Startup.cs*:
+* Add WS-Federation to `Startup.ConfigureServices`:
 
     ```csharp
     services.AddIdentity<ApplicationUser, IdentityRole>()

--- a/aspnetcore/security/authentication/ws-federation.md
+++ b/aspnetcore/security/authentication/ws-federation.md
@@ -77,7 +77,7 @@ By default, the new middleware:
 ## Add WS-Federation as an external login provider for ASP.NET Core Identity
 
 * Add a dependency on [Microsoft.AspNetCore.Authentication.WsFederation](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.WsFederation) to the project.
-* Add WS-Federation to the `Configure` method in *Startup.cs*:
+* Add WS-Federation to the `ConfigureServices` method in *Startup.cs*:
 
     ```csharp
     services.AddIdentity<ApplicationUser, IdentityRole>()


### PR DESCRIPTION
This documentation page appears to contain a minor mistake: it claims that the sample code provided for integrating WS-Federation with ASP.NET Core Identity should be added to the `Configure` method, not `ConfigureServices`. In addition to the `Configure` method not normally having an IServiceCollection object handy, this seems to disagree with both the code sample below on this page for the example without Core Identity and with every other example of using WS-Federation with Core Identity I can find online.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->