### PR TITLE
The hostcontext did not have the environment variable information in …

### DIFF
--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-GenericHost/Program.cs
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-GenericHost/Program.cs
@@ -18,6 +18,10 @@ namespace BackgroundTasksSample
                     config.AddConsole();
                     config.AddDebug();
                 })
+                .ConfigureHostConfiguration(configHost =>
+                {
+                    configHost.AddEnvironmentVariables(prefix: "ASPNET_");
+                })
                 .ConfigureAppConfiguration((hostContext, config) =>
                 {
                     config.AddEnvironmentVariables();

--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-GenericHost/Program.cs
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-GenericHost/Program.cs
@@ -18,9 +18,9 @@ namespace BackgroundTasksSample
                     config.AddConsole();
                     config.AddDebug();
                 })
-                .ConfigureHostConfiguration(configHost =>
+                .ConfigureHostConfiguration(config =>
                 {
-                    configHost.AddEnvironmentVariables();
+                    config.AddEnvironmentVariables();
                 })
                 .ConfigureAppConfiguration((hostContext, config) =>
                 {

--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-GenericHost/Program.cs
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-GenericHost/Program.cs
@@ -24,7 +24,6 @@ namespace BackgroundTasksSample
                 })
                 .ConfigureAppConfiguration((hostContext, config) =>
                 {
-                    config.AddEnvironmentVariables();
                     config.AddJsonFile("appsettings.json", optional: true);
                     config.AddJsonFile($"appsettings.{hostContext.HostingEnvironment.EnvironmentName}.json", optional: true);
                     config.AddCommandLine(args);

--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-GenericHost/Program.cs
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-GenericHost/Program.cs
@@ -20,7 +20,7 @@ namespace BackgroundTasksSample
                 })
                 .ConfigureHostConfiguration(configHost =>
                 {
-                    configHost.AddEnvironmentVariables(prefix: "ASPNET_");
+                    configHost.AddEnvironmentVariables();
                 })
                 .ConfigureAppConfiguration((hostContext, config) =>
                 {


### PR DESCRIPTION
…ConfigureAppConfiguration.  ConfigureHostConfiguration must be called first



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #10528


NOTE: This is a comment; please type your descriptions above or below it.
-->

I've tested this locally.  The original code would always use production as the hosted environment.