### PR TITLE
escape character in md

### DIFF
--- a/aspnetcore/tutorials/first-mongo-app.md
+++ b/aspnetcore/tutorials/first-mongo-app.md
@@ -48,7 +48,7 @@ In this tutorial, you learn how to:
 
 ## Configure MongoDB
 
-If using Windows, MongoDB is installed at *C:\Program Files\MongoDB* by default. Add *C:\Program Files\MongoDB\Server\<version_number>\bin* to the `Path` environment variable. This change enables MongoDB access from anywhere on your development machine.
+If using Windows, MongoDB is installed at *C:\Program Files\MongoDB* by default. Add *`C:\Program Files\MongoDB\Server\<version_number>\bin`* to the `Path` environment variable. This change enables MongoDB access from anywhere on your development machine.
 
 Use the mongo Shell in the following steps to create a database, make collections, and store documents. For more information on mongo Shell commands, see [Working with the mongo Shell](https://docs.mongodb.com/manual/mongo/#working-with-the-mongo-shell).
 

--- a/aspnetcore/tutorials/first-mongo-app.md
+++ b/aspnetcore/tutorials/first-mongo-app.md
@@ -4,7 +4,7 @@ author: prkhandelwal
 description: This tutorial demonstrates how to build an ASP.NET Core web API using a MongoDB NoSQL database.
 ms.author: scaddie
 ms.custom: "mvc, seodec18"
-ms.date: 01/22/2019
+ms.date: 01/23/2019
 uid: tutorials/first-mongo-app
 ---
 # Create a web API with ASP.NET Core and MongoDB
@@ -48,11 +48,11 @@ In this tutorial, you learn how to:
 
 ## Configure MongoDB
 
-If using Windows, MongoDB is installed at *C:\Program Files\MongoDB* by default. Add *`C:\Program Files\MongoDB\Server\<version_number>\bin`* to the `Path` environment variable. This change enables MongoDB access from anywhere on your development machine.
+If using Windows, MongoDB is installed at *C:\\Program Files\\MongoDB* by default. Add *C:\\Program Files\\MongoDB\\Server\\\<version_number>\\bin* to the `Path` environment variable. This change enables MongoDB access from anywhere on your development machine.
 
 Use the mongo Shell in the following steps to create a database, make collections, and store documents. For more information on mongo Shell commands, see [Working with the mongo Shell](https://docs.mongodb.com/manual/mongo/#working-with-the-mongo-shell).
 
-1. Choose a directory on your development machine for storing the data. For example, *C:\BooksData* on Windows. Create the directory if it doesn't exist. The mongo Shell doesn't create new directories.
+1. Choose a directory on your development machine for storing the data. For example, *C:\\BooksData* on Windows. Create the directory if it doesn't exist. The mongo Shell doesn't create new directories.
 1. Open a command shell. Run the following command to connect to MongoDB on default port 27017. Remember to replace `<data_directory_path>` with the directory you chose in the previous step.
 
     ```console


### PR DESCRIPTION
For some reason the \ is acting like an escape character in the md. Alternatively adding \\ between Server and version number <version_number> fixed it in the preview. "Server\\<version_number>



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->