### PR TITLE
Configure automatic labeling of SignalR issues

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -2,6 +2,10 @@
   "labels": {
     "product": {
       "(?i).*": "Source - Docs.ms"
+    },
+    "contentsource": {
+      "(?i).*master\/aspnetcore\/signalr.*": "SignalR",
+      "(?i).*master\/aspnetcore\/tutorials\/signalr*.*": "SignalR"
     }
   }
 }


### PR DESCRIPTION
Automatically apply the **SignalR** label to issues for docs residing in the following paths of the **master** branch:

1. aspnetcore/signalr
1. aspnetcore/tutorials/signalr*