### PR TITLE
removed unused using statement

### DIFF
--- a/aspnetcore/data/ef-rp/intro/samples/cu21/Pages/About.cshtml.cs
+++ b/aspnetcore/data/ef-rp/intro/samples/cu21/Pages/About.cshtml.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using ContosoUniversity.Models;
-using ContosoUniversity.Data;
 
 namespace ContosoUniversity.Pages
 {


### PR DESCRIPTION

Fixes #10676

This pull request will fix the below issue:
In section "Update the About page model", in the About.cshtml.cs code, the reference to ContosoUniversity.Data isn't mandatory as the 2 classes in the Data folder (Dbinitializer.cs and Schollcontext.cs) are in the ContosoUniversity.Models namespace.