### PR TITLE
Fix casing of configuration property

### DIFF
--- a/aspnetcore/migration/21-to-22.md
+++ b/aspnetcore/migration/21-to-22.md
@@ -223,7 +223,7 @@ Visual Studio's **Auto build on browser request** experience doesn't function wi
   ```csharp
   public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
   {
-      loggerFactory.AddConsole(configuration);
+      loggerFactory.AddConsole(Configuration);
   }
   ```
 
@@ -233,7 +233,7 @@ Visual Studio's **Auto build on browser request** experience doesn't function wi
   public void ConfigureServices(IServiceCollection services)
   {
       services.AddLogging(builder => builder
-          .AddConfiguration(configuration)
+          .AddConfiguration(Configuration)
           .AddConsole());
   }
   ```


### PR DESCRIPTION
Encountered a typo while browsing the migration guide from ASP.NET Core 2.1 to 2.2.