### PR TITLE
Add VS for Mac deploy articles to TOC

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -454,6 +454,8 @@
           uid: host-and-deploy/azure-apps/index
         - name: Publish with Visual Studio
           uid: tutorials/publish-to-azure-webapp-using-vs
+        - name: Publish with Visual Studio for Mac
+          href: /visualstudio/mac/publish-app-svc
         - name: Publish with CLI tools
           href: /azure/app-service/app-service-web-tutorial-dotnetcore-sqldb
         - name: Publish with Visual Studio and Git
@@ -522,6 +524,8 @@
       uid: host-and-deploy/web-farm
     - name: Visual Studio publish profiles
       uid: host-and-deploy/visual-studio-publish-profiles
+    - name: Visual Studio for Mac publish to folder
+      href: /visualstudio/mac/publish-folder
     - name: Directory structure
       uid: host-and-deploy/directory-structure
     - name: Health checks


### PR DESCRIPTION
Fixes #10699 

[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/publish-to-azure-webapp-using-vs?view=aspnetcore-1.0&branch=pr-en-us-10698) (goes to an article in the deployment section of the TOC.  Note that the new links 404 from staging -- when you get the 404, remove "review." from the link and you'll get the doc it's linking to.)