### PR TITLE
Add HostBuilder to 3.0 migration docs

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -84,7 +84,7 @@ The following code shows the ASP.NET Core 2.2 template-generated `Program` class
 
 ## Moving from WebHostBuilder to HostBuilder
 
-The most significant change from `WebHostBuilder` to `HostBuilder` is in [Dependency injection](xref:fundamentals/dependency-injection) (DI). `HostBuilder` can only inject <xref:Microsoft.Extensions.Configuration.IConfiguration> and <xref:Microsoft.Extensions.Hosting.IHostingEnvironment>. The DI limitations:
+The most significant change from `WebHostBuilder` to `HostBuilder` is in [dependency injection (DI)](xref:fundamentals/dependency-injection). `HostBuilder` can only inject <xref:Microsoft.Extensions.Configuration.IConfiguration> and <xref:Microsoft.Extensions.Hosting.IHostingEnvironment>. The DI limitations:
 
-* Enable the DI container to built once.
+* Enable the DI container to be built only one time.
 * Avoid several other DI issues.

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -72,7 +72,7 @@ Newtonsoft settings can be set with `AddNewtonsoftJson`:
 
 ## Generic host replaces WebHostBuilder
 
-The ASP.NET Core 3.0 templates use [Generic Host](fundamentals/host/generic-host). Previous versions used [WebHostBuilder](xref:fundamentals/host/web-host). The following code shows the ASP.NET Core 3.0 template generated `Program` class:
+The ASP.NET Core 3.0 templates use [Generic Host](xref:fundamentals/host/generic-host). Previous versions used [WebHostBuilder](xref:fundamentals/host/web-host). The following code shows the ASP.NET Core 3.0 template generated `Program` class:
 
 [!code-csharp[Main](22-to-30/samples/Program.cs?name=snippet)]
 

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -84,7 +84,7 @@ The following code shows the ASP.NET Core 2.2 template-generated `Program` class
 
 ## Moving from WebHostBuilder to HostBuilder
 
-The most significant change from `WebHostBuilder` to `HostBuilder` is in [dependency injection (DI)](xref:fundamentals/dependency-injection). `HostBuilder` can only inject <xref:Microsoft.Extensions.Configuration.IConfiguration> and <xref:Microsoft.Extensions.Hosting.IHostingEnvironment>. The `HostBuilder` DI limitations:
+The most significant change from `WebHostBuilder` to `HostBuilder` is in [dependency injection (DI)](xref:fundamentals/dependency-injection). When using `HostBuilder` you can only inject <xref:Microsoft.Extensions.Configuration.IConfiguration>, <xref:Microsoft.Extensions.Hosting.IHostingEnvironment>, and <xref:Microsoft.AspNetCore.Hosting.IHostingEnvironment> into Startup's constructor. The `HostBuilder` DI constraints:
 
 * Enable the DI container to be built only one time.
 * Avoid several other DI issues.

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -70,17 +70,17 @@ Newtonsoft settings can be set with `AddNewtonsoftJson`:
                   new CamelCasePropertyNamesContractResolver());
     ```
 
-## Generic host replaces WebHostBuilder
+## HostBuilder replaces WebHostBuilder
 
-The ASP.NET Core 3.0 templates use [Generic Host](xref:fundamentals/host/generic-host). Previous versions used [WebHostBuilder](xref:fundamentals/host/web-host). The following code shows the ASP.NET Core 3.0 template generated `Program` class:
+The ASP.NET Core 3.0 templates use [Generic Host](xref:fundamentals/host/generic-host). Previous versions used [Web Host](xref:fundamentals/host/web-host). The following code shows the ASP.NET Core 3.0 template generated `Program` class:
 
-[!code-csharp[Main](22-to-30/samples/Program.cs?name=snippet)]
+[!code-csharp[](22-to-30/samples/Program.cs?name=snippet)]
 
-The following code shows the ASP.NET Core 2.2 template generated `Program` class:
+The following code shows the ASP.NET Core 2.2 template-generated `Program` class:
 
-[!code-csharp[Main](22-to-30/samples/Program2.2.cs?name=snippet)]
+[!code-csharp[](22-to-30/samples/Program2.2.cs?name=snippet)]
 
-<xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> is used with the <xref:Microsoft.AspNetCore.Hosting.WebHostBuilder> (in the 2.2 templates) and with `webBuilder` (in the 3.0 templates). `WebHostBuilder` will be deprecated in a future release, and eventually removed.  `HostBuilder` will replace `WebHostBuilder`.
+<xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> remains in 3.0 and is the type of the `webBuilder` seen in the preceding code sample. <xref:Microsoft.AspNetCore.Hosting.WebHostBuilder> will be deprecated in a future release and replaced by `HostBuilder`.
 
 ## Moving from WebHostBuilder to HostBuilder
 

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -69,3 +69,22 @@ Newtonsoft settings can be set with `AddNewtonsoftJson`:
                options.SerializerSettings.ContractResolver = 
                   new CamelCasePropertyNamesContractResolver());
     ```
+
+## Generic host replaces WebHostBuilder
+
+The ASP.NET Core 3.0 templates use [Generic Host](fundamentals/host/generic-host). Previous versions used [WebHostBuilder](xref:fundamentals/host/web-host). The following code shows the ASP.NET Core 3.0 template generated `Program` class:
+
+[!code-csharp[Main](22-to-30/samples/Program.cs?name=snippet)]
+
+The following code shows the ASP.NET Core 2.2 template generated `Program` class:
+
+[!code-csharp[Main](22-to-30/samples/Program2.2.cs?name=snippet)]
+
+<xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> is used with the <xref:Microsoft.AspNetCore.Hosting.WebHostBuilder> (in the 2.2 templates) and with `webBuilder` (in the 3.0 templates). `WebHostBuilder` will be deprecated in a future release, and eventually removed.  `HostBuilder` will replace `WebHostBuilder`.
+
+## Moving from WebHostBuilder to HostBuilder
+
+The most significant change from `WebHostBuilder` to `HostBuilder` is in [Dependency injection](xref:fundamentals/dependency-injection) (DI). `HostBuilder` can only inject <xref:Microsoft.Extensions.Configuration.IConfiguration> and <xref:Microsoft.Extensions.Hosting.IHostingEnvironment>. The DI limitations:
+
+* Enable the DI container to built once.
+* Avoid several other DI issues.

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -84,7 +84,7 @@ The following code shows the ASP.NET Core 2.2 template-generated `Program` class
 
 ## Moving from WebHostBuilder to HostBuilder
 
-The most significant change from `WebHostBuilder` to `HostBuilder` is in [dependency injection (DI)](xref:fundamentals/dependency-injection). `HostBuilder` can only inject <xref:Microsoft.Extensions.Configuration.IConfiguration> and <xref:Microsoft.Extensions.Hosting.IHostingEnvironment>. The DI limitations:
+The most significant change from `WebHostBuilder` to `HostBuilder` is in [dependency injection (DI)](xref:fundamentals/dependency-injection). `HostBuilder` can only inject <xref:Microsoft.Extensions.Configuration.IConfiguration> and <xref:Microsoft.Extensions.Hosting.IHostingEnvironment>. The `HostBuilder` DI limitations:
 
 * Enable the DI container to be built only one time.
 * Avoid several other DI issues.

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -84,7 +84,7 @@ The following code shows the ASP.NET Core 2.2 template-generated `Program` class
 
 ## Moving from WebHostBuilder to HostBuilder
 
-The most significant change from `WebHostBuilder` to `HostBuilder` is in [dependency injection (DI)](xref:fundamentals/dependency-injection). When using `HostBuilder` you can only inject <xref:Microsoft.Extensions.Configuration.IConfiguration>, <xref:Microsoft.Extensions.Hosting.IHostingEnvironment>, and <xref:Microsoft.AspNetCore.Hosting.IHostingEnvironment> into Startup's constructor. The `HostBuilder` DI constraints:
+The most significant change from `WebHostBuilder` to `HostBuilder` is in [dependency injection (DI)](xref:fundamentals/dependency-injection). When using `HostBuilder`, you can only inject <xref:Microsoft.Extensions.Configuration.IConfiguration>, <xref:Microsoft.Extensions.Hosting.IHostingEnvironment>, and <xref:Microsoft.AspNetCore.Hosting.IHostingEnvironment> into Startup's constructor. The `HostBuilder` DI constraints:
 
 * Enable the DI container to be built only one time.
-* Avoid several other DI issues.
+* Avoids the resulting object lifetime issues like resolving multiple instances of singletons.

--- a/aspnetcore/migration/22-to-30/samples/Program.cs
+++ b/aspnetcore/migration/22-to-30/samples/Program.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace aspnetcoreapp
+{
+    #region snippet
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+    #endregion
+}

--- a/aspnetcore/migration/22-to-30/samples/Program2.2.cs
+++ b/aspnetcore/migration/22-to-30/samples/Program2.2.cs
@@ -15,5 +15,5 @@ namespace WebAPI
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>();
     }
-    #region snippet
+    #endregion
 }

--- a/aspnetcore/migration/22-to-30/samples/Program2.2.cs
+++ b/aspnetcore/migration/22-to-30/samples/Program2.2.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace WebAPI
+{
+    #region snippet
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+    #region snippet
+}


### PR DESCRIPTION
Fixes #10618, Fixes  #10711 

[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-3.0&branch=pr-en-us-10718&tabs=visual-studio#generic-host-replaces-webhostbuilder)