### PR TITLE
Use singular TargetFramework element

### DIFF
--- a/aspnetcore/fundamentals/url-rewriting/samples/2.x/SampleApp/SampleApp.csproj
+++ b/aspnetcore/fundamentals/url-rewriting/samples/2.x/SampleApp/SampleApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Using the plural TargetFrameworks element will cause an 'unable to run your project' error on 'dotnet run' command. Switching to use singular TargetFramework can fix it and also avoid confusing beginners.

