### PR TITLE
Clarify that it is _.NET Core_ File Providers

### DIFF
--- a/aspnetcore/fundamentals/file-providers.md
+++ b/aspnetcore/fundamentals/file-providers.md
@@ -11,7 +11,7 @@ uid: fundamentals/file-providers
 
 By [Steve Smith](https://ardalis.com/) and [Luke Latham](https://github.com/guardrex)
 
-ASP.NET Core abstracts file system access through the use of File Providers. File Providers are used throughout the ASP.NET Core framework:
+ASP.NET Core abstracts file system access through the use of .NET Core File Providers. File Providers are used throughout the ASP.NET Core framework:
 
 * [IHostingEnvironment](/dotnet/api/microsoft.extensions.hosting.ihostingenvironment) exposes the app's content root and web root as `IFileProvider` types.
 * [Static File Middleware](xref:fundamentals/static-files) uses File Providers to locate static files.


### PR DESCRIPTION
I originally thought that File Providers were an ASP.NET Core feature, as I was trying to figure out why Razor Pages depended on ASP.NET Core at all.  My use case is to understand how to run Razor Engine through a Console Application that sends e-mails, without all the heavy dependencies of ASP.NET.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->