### PR TITLE
Razor Components: 'introduction' over 'index' landing page

### DIFF
--- a/aspnetcore/razor-components/introduction.md
+++ b/aspnetcore/razor-components/introduction.md
@@ -6,7 +6,7 @@ monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 01/29/2019
-uid: razor-components/index
+uid: razor-components/introduction
 ---
 # Introduction to Razor Components
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -166,7 +166,7 @@
         - name: Unit test
           uid: mvc/controllers/testing
     - name: Razor Components
-      uid: razor-components/index
+      uid: razor-components/introduction
     - name: Session and app state
       uid: fundamentals/app-state
     - name: Tag Helpers
@@ -438,7 +438,7 @@
     - name: Razor Components
       items: 
         - name: Overview
-          uid: razor-components/index
+          uid: razor-components/introduction
         - name: FAQ
           uid: razor-components/faq
         - name: Get started


### PR DESCRIPTION
As I was working the redirects in Blazor.Docs, I noticed that the "index" landing page for the RC Overview doesn't work well in links. It results in ...

* **Overview:** https://docs.microsoft.com/aspnet/core/razor-components/
* **Components:** https://docs.microsoft.com/aspnet/core/razor-components/components

This would compose better for links as ...

* https://docs.microsoft.com/aspnet/core/razor-components/introduction

We do this in several spots, including most recently for SignalR docs (but note the kind'a strange "SignalR overview" link text in the TOC) ...

* https://docs.microsoft.com/aspnet/core/signalr/introduction
* *aspnetcore/signalr/introduction.md*

An alternative is to match the TOC heading of "Overview" [but this wouldn't match other places in the repo that have used the 'introduction' approach (e.g., SignalR, Data Protection, Authorization)].

* https://docs.microsoft.com/aspnet/core/razor-components/overview

How do you want to play it?

1. Go with the "introduction" approach (on this PR).
1. Go with the "overview" approach. This makes sense if APEX has embraced "Overview" as the link text. However, it seems like these other "introduction" topics (SignalR, DP, and authn) should embrace the **_"Overview" World_** in their file names/links if that's the case.
1. Close and keep what we have. :-1: