### PR TITLE
Change VS version for 3.0 on macOS

### DIFF
--- a/aspnetcore/includes/net-core-prereqs-mac-3.0.md
+++ b/aspnetcore/includes/net-core-prereqs-mac-3.0.md
@@ -1,2 +1,2 @@
-* [Visual Studio for Mac version 7.7 or later](https://visualstudio.microsoft.com/vs/mac/)
+* [Visual Studio for Mac version 8.0 or later](https://visualstudio.microsoft.com/vs/mac/)
 * [.NET Core SDK 3.0](https://dotnet.microsoft.com/download/dotnet-core/3.0)


### PR DESCRIPTION
From Matt Ward ...

> Unfortunately Visual Studio for Mac 7.7 does not support .NET Core 3.0. The bug here is that the New Project dialog shows 3.0 as a target framework - it should not be listed.

> More recent Visual Studio for Mac 8.0 versions should have support for .NET Core 3.0.

> New project templates need to be enabled in Visual Studio for Mac. New project templates available in the installed .NET Core sdk are not automatically available in the IDE. Right now Visual Studio on Windows has more project templates enabled than Visual Studio for Mac, such as the angular and react templates.

This came about because I attempted to use the 3.0 Preview 2 SDK with VS for Mac 7.7.4 and it :boom:.

Not sure if the last point will require another line in the prereqs here. I suspect that 8.0 with 3.0 will display the templates in VS normally. I think he's describing the state with 7.7 and 2.2.

AFAIK, there's no VS for Mac 8.0 Preview out yet.

Reference: https://developercommunity.visualstudio.com/content/problem/444024/create-button-doesnt-create-new-project-for-30-pre.html