### PR TITLE
Make StartupTaskCompleted volatile

### DIFF
--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -5,7 +5,7 @@ description: Learn how to set up health checks for ASP.NET Core infrastructure, 
 monikerRange: '>= aspnetcore-2.2'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/13/2019
+ms.date: 03/11/2019
 uid: host-and-deploy/health-checks
 ---
 # Health checks in ASP.NET Core
@@ -387,7 +387,7 @@ The readiness check usually performs a more extensive and time-consuming set of 
 
 The sample app contains a health check to report the completion of long-running startup task in a [Hosted Service](xref:fundamentals/host/hosted-services). The `StartupHostedServiceHealthCheck` exposes a property, `StartupTaskCompleted`, that the hosted service can set to `true` when its long-running task is finished (*StartupHostedServiceHealthCheck.cs*):
 
-[!code-csharp[](health-checks/samples/2.x/HealthChecksSample/StartupHostedServiceHealthCheck.cs?name=snippet1&highlight=5)]
+[!code-csharp[](health-checks/samples/2.x/HealthChecksSample/StartupHostedServiceHealthCheck.cs?name=snippet1&highlight=18-22)]
 
 The long-running background task is started by a [Hosted Service](xref:fundamentals/host/hosted-services) (*Services/StartupHostedService*). At the conclusion of the task, `StartupHostedServiceHealthCheck.StartupTaskCompleted` is set to `true`:
 

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -387,7 +387,7 @@ The readiness check usually performs a more extensive and time-consuming set of 
 
 The sample app contains a health check to report the completion of long-running startup task in a [Hosted Service](xref:fundamentals/host/hosted-services). The `StartupHostedServiceHealthCheck` exposes a property, `StartupTaskCompleted`, that the hosted service can set to `true` when its long-running task is finished (*StartupHostedServiceHealthCheck.cs*):
 
-[!code-csharp[](health-checks/samples/2.x/HealthChecksSample/StartupHostedServiceHealthCheck.cs?name=snippet1&highlight=18-22)]
+[!code-csharp[](health-checks/samples/2.x/HealthChecksSample/StartupHostedServiceHealthCheck.cs?name=snippet1&highlight=7-11)]
 
 The long-running background task is started by a [Hosted Service](xref:fundamentals/host/hosted-services) (*Services/StartupHostedService*). At the conclusion of the task, `StartupHostedServiceHealthCheck.StartupTaskCompleted` is set to `true`:
 

--- a/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/StartupHostedServiceHealthCheck.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/2.x/HealthChecksSample/StartupHostedServiceHealthCheck.cs
@@ -11,9 +11,15 @@ namespace SampleApp
     #region snippet1
     public class StartupHostedServiceHealthCheck : IHealthCheck
     {
+        private volatile bool _startupTaskCompleted = false;
+
         public string Name => "slow_dependency_check";
 
-        public bool StartupTaskCompleted { get; set; } = false;
+        public bool StartupTaskCompleted
+        {
+            get => _startupTaskCompleted;
+            set => _startupTaskCompleted = value;
+        }
 
         public Task<HealthCheckResult> CheckHealthAsync(
             HealthCheckContext context, 


### PR DESCRIPTION
StartupTaskCompleted can potentially be modified by multiple threads that are executing at the same time.

This is literally [what `volatile` is for](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/volatile).
> The volatile keyword indicates that a field might be modified by multiple threads that are executing at the same time.

Fixes #10895

(waiting for a reply in the referenced issue, but this change should be correct)