### PR TITLE
Fixed broken link to MvcOptions source file

### DIFF
--- a/aspnetcore/mvc/compatibility-version.md
+++ b/aspnetcore/mvc/compatibility-version.md
@@ -5,7 +5,7 @@ description: Discover how the Startup class in ASP.NET Core configures services 
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 12/10/2018
+ms.date: 02/15/2019
 uid: mvc/compatibility-version
 ---
 # Compatibility version for ASP.NET Core MVC
@@ -29,8 +29,8 @@ The default compatibility for ASP.NET Core 2.1 and later 2.x apps that do **not*
 
 The following code sets the compatibility mode to ASP.NET Core 2.2, except for the following behaviors:
 
-* [AllowCombiningAuthorizeFilters](https://docs.microsoft.com/en-gb/dotnet/api/microsoft.aspnetcore.mvc.mvcoptions.allowcombiningauthorizefilters?view=aspnetcore-2.2#Microsoft_AspNetCore_Mvc_MvcOptions_AllowCombiningAuthorizeFilters)
-* [InputFormatterExceptionPolicy](https://docs.microsoft.com/en-gb/dotnet/api/microsoft.aspnetcore.mvc.mvcoptions.inputformatterexceptionpolicy?view=aspnetcore-2.2#Microsoft_AspNetCore_Mvc_MvcOptions_InputFormatterExceptionPolicy)
+* <xref:Microsoft.AspNetCore.Mvc.MvcOptions.AllowCombiningAuthorizeFilters>
+* <xref:Microsoft.AspNetCore.Mvc.MvcOptions.InputFormatterExceptionPolicy>
 
 [!code-csharp[Main](compatibility-version/samples/2.x/CompatibilityVersionSample/Startup2.cs?name=snippet1)]
 

--- a/aspnetcore/mvc/compatibility-version.md
+++ b/aspnetcore/mvc/compatibility-version.md
@@ -29,8 +29,8 @@ The default compatibility for ASP.NET Core 2.1 and later 2.x apps that do **not*
 
 The following code sets the compatibility mode to ASP.NET Core 2.2, except for the following behaviors:
 
-* [AllowCombiningAuthorizeFilters](https://docs.microsoft.com/en-gb/dotnet/api/microsoft.aspnetcore.mvc.mvcoptions?view=aspnetcore-2.2#properties)
-* [InputFormatterExceptionPolicy](https://docs.microsoft.com/en-gb/dotnet/api/microsoft.aspnetcore.mvc.mvcoptions?view=aspnetcore-2.2#properties)
+* [AllowCombiningAuthorizeFilters](https://docs.microsoft.com/en-gb/dotnet/api/microsoft.aspnetcore.mvc.mvcoptions.allowcombiningauthorizefilters?view=aspnetcore-2.2#Microsoft_AspNetCore_Mvc_MvcOptions_AllowCombiningAuthorizeFilters)
+* [InputFormatterExceptionPolicy](https://docs.microsoft.com/en-gb/dotnet/api/microsoft.aspnetcore.mvc.mvcoptions.inputformatterexceptionpolicy?view=aspnetcore-2.2#Microsoft_AspNetCore_Mvc_MvcOptions_InputFormatterExceptionPolicy)
 
 [!code-csharp[Main](compatibility-version/samples/2.x/CompatibilityVersionSample/Startup2.cs?name=snippet1)]
 

--- a/aspnetcore/mvc/compatibility-version.md
+++ b/aspnetcore/mvc/compatibility-version.md
@@ -39,6 +39,6 @@ For apps that encounter breaking behavior changes, using the appropriate compati
 * Allows you to use the latest release and opt out of specific breaking behavior changes.
 * Gives you time to update your app so it works with the latest changes.
 
-The [MvcOptions](https://github.com/aspnet/AspNetCore/blob/master/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/MvcOptions.cs) class source comments have a good explanation of what changed and why the changes are an improvement for most users.
+The [MvcOptions](https://github.com/aspnet/AspNetCore/blob/master/src/Mvc/Mvc.Core/src/MvcOptions.cs) class source comments have a good explanation of what changed and why the changes are an improvement for most users.
 
 At some future date, there will be an [ASP.NET Core 3.0 version](https://github.com/aspnet/Home/wiki/Roadmap). Old behaviors supported by compatibility switches will be removed in the 3.0 version. We feel these are positive changes benefitting nearly all users. By introducing these changes now, most apps can benefit now, and the others will have time to update their apps.

--- a/aspnetcore/mvc/compatibility-version.md
+++ b/aspnetcore/mvc/compatibility-version.md
@@ -29,8 +29,8 @@ The default compatibility for ASP.NET Core 2.1 and later 2.x apps that do **not*
 
 The following code sets the compatibility mode to ASP.NET Core 2.2, except for the following behaviors:
 
-* [AllowCombiningAuthorizeFilters](https://github.com/aspnet/AspNetCore/blob/master/src/Mvc/Mvc.Core/src/MvcOptions.cs)
-* [InputFormatterExceptionPolicy](https://github.com/aspnet/AspNetCore/blob/master/src/Mvc/Mvc.Core/src/MvcOptions.cs)
+* [AllowCombiningAuthorizeFilters](https://docs.microsoft.com/en-gb/dotnet/api/microsoft.aspnetcore.mvc.mvcoptions?view=aspnetcore-2.2#properties)
+* [InputFormatterExceptionPolicy](https://docs.microsoft.com/en-gb/dotnet/api/microsoft.aspnetcore.mvc.mvcoptions?view=aspnetcore-2.2#properties)
 
 [!code-csharp[Main](compatibility-version/samples/2.x/CompatibilityVersionSample/Startup2.cs?name=snippet1)]
 
@@ -39,6 +39,6 @@ For apps that encounter breaking behavior changes, using the appropriate compati
 * Allows you to use the latest release and opt out of specific breaking behavior changes.
 * Gives you time to update your app so it works with the latest changes.
 
-The [MvcOptions](https://github.com/aspnet/AspNetCore/blob/master/src/Mvc/Mvc.Core/src/MvcOptions.cs) class source comments have a good explanation of what changed and why the changes are an improvement for most users.
+The [MvcOptions](https://github.com/aspnet/AspNetCore/blob/release/2.2/src/Mvc/Mvc.Core/src/MvcOptions.cs) class source comments have a good explanation of what changed and why the changes are an improvement for most users.
 
 At some future date, there will be an [ASP.NET Core 3.0 version](https://github.com/aspnet/Home/wiki/Roadmap). Old behaviors supported by compatibility switches will be removed in the 3.0 version. We feel these are positive changes benefitting nearly all users. By introducing these changes now, most apps can benefit now, and the others will have time to update their apps.


### PR DESCRIPTION
Fixed the link to MvcOptions in Compatibility Version documentation
[Link to current docs](https://docs.microsoft.com/en-us/aspnet/core/mvc/compatibility-version?view=aspnetcore-2.2)