### PR TITLE
"Terminal middleware" enhancements

### DIFF
--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -28,7 +28,7 @@ The ASP.NET Core request pipeline consists of a sequence of request delegates, c
 
 ![Request processing pattern showing a request arriving, processing through three middlewares, and the response leaving the app. Each middleware runs its logic and hands off the request to the next middleware at the next() statement. After the third middleware processes the request, the request passes back through the prior two middlewares in reverse order for additional processing after their next() statements before leaving the app as a response to the client.](index/_static/request-delegate-pipeline.png)
 
-Each delegate can perform operations before and after the next delegate. Exception-handling delegates are called early in the pipeline, so they can catch exceptions that occur in later stages of the pipeline.
+Each delegate can perform operations before and after the next delegate. Exception-handling delegates should be called early in the pipeline, so they can catch exceptions that occur in later stages of the pipeline.
 
 The simplest possible ASP.NET Core app sets up a single request delegate that handles all requests. This case doesn't include an actual request pipeline. Instead, a single anonymous function is called in response to every HTTP request.
 
@@ -40,7 +40,7 @@ Chain multiple request delegates together with <xref:Microsoft.AspNetCore.Builde
 
 [!code-csharp[](index/snapshot/Chain/Startup.cs?name=snippet1)]
 
-When a delegate doesn't pass a request to the next delegate, it's called *short-circuiting the request pipeline*. Short-circuiting is often desirable because it avoids unnecessary work. For example, [Static File Middleware](xref:fundamentals/static-files) can act as a *terminal middleware* by returning a request for a static file and short-circuiting the rest of the pipeline. Middleware added to the pipeline before the middleware that terminates further processing still processes code after their `next.Invoke` statements. However, see the following warning about attempting to write to a response that has already been sent.
+When a delegate doesn't pass a request to the next delegate, it's called *short-circuiting the request pipeline*. Short-circuiting is often desirable because it avoids unnecessary work. For example, [Static File Middleware](xref:fundamentals/static-files) can act as a *terminal middleware* by processing a request for a static file and short-circuiting the rest of the pipeline. Middleware added to the pipeline before the middleware that terminates further processing still processes code after their `next.Invoke` statements. However, see the following warning about attempting to write to a response that has already been sent.
 
 > [!WARNING]
 > Don't call `next.Invoke` after the response has been sent to the client. Changes to <xref:Microsoft.AspNetCore.Http.HttpResponse> after the response has started throw an exception. For example, changes such as setting headers and a status code throw an exception. Writing to the response body after calling `next`:

--- a/aspnetcore/performance/caching/middleware.md
+++ b/aspnetcore/performance/caching/middleware.md
@@ -132,7 +132,7 @@ When testing and troubleshooting caching behavior, a browser may set request hea
 
 * The request must result in a server response with a 200 (OK) status code.
 * The request method must be GET or HEAD.
-* In `Startup.Configure`, Response Caching Middleware must be placed before middleware scenarios that require compression. For more information, see <xref:fundamentals/middleware/index>.
+* In `Startup.Configure`, Response Caching Middleware must be placed before middleware that require compression. For more information, see <xref:fundamentals/middleware/index>.
 * The `Authorization` header must not be present.
 * `Cache-Control` header parameters must be valid, and the response must be marked `public` and not marked `private`.
 * The `Pragma: no-cache` header must not be present if the `Cache-Control` header isn't present, as the `Cache-Control` header overrides the `Pragma` header when present.

--- a/aspnetcore/performance/caching/middleware.md
+++ b/aspnetcore/performance/caching/middleware.md
@@ -5,7 +5,7 @@ description: Learn how to configure and use Response Caching Middleware in ASP.N
 monikerRange: '>= aspnetcore-1.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/16/2019
+ms.date: 02/17/2019
 uid: performance/caching/middleware
 ---
 # Response Caching Middleware in ASP.NET Core
@@ -132,7 +132,7 @@ When testing and troubleshooting caching behavior, a browser may set request hea
 
 * The request must result in a server response with a 200 (OK) status code.
 * The request method must be GET or HEAD.
-* Terminal middleware must not process the response prior to the Response Caching Middleware.
+* [Terminal middleware](xref:fundamentals/middleware/index#built-in-middleware) must not process the response before Response Caching Middleware in the middleware request processing pipeline. For more information, see <xref:fundamentals/middleware/index>.
 * The `Authorization` header must not be present.
 * `Cache-Control` header parameters must be valid, and the response must be marked `public` and not marked `private`.
 * The `Pragma: no-cache` header must not be present if the `Cache-Control` header isn't present, as the `Cache-Control` header overrides the `Pragma` header when present.

--- a/aspnetcore/performance/caching/middleware.md
+++ b/aspnetcore/performance/caching/middleware.md
@@ -5,7 +5,7 @@ description: Learn how to configure and use Response Caching Middleware in ASP.N
 monikerRange: '>= aspnetcore-1.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/17/2019
+ms.date: 02/20/2019
 uid: performance/caching/middleware
 ---
 # Response Caching Middleware in ASP.NET Core
@@ -132,7 +132,7 @@ When testing and troubleshooting caching behavior, a browser may set request hea
 
 * The request must result in a server response with a 200 (OK) status code.
 * The request method must be GET or HEAD.
-* [Terminal middleware](xref:fundamentals/middleware/index#built-in-middleware) must not process the response before Response Caching Middleware in the middleware request processing pipeline. For more information, see <xref:fundamentals/middleware/index>.
+* In `Startup.Configure`, Response Caching Middleware must be placed before middleware scenarios that require compression. For more information, see <xref:fundamentals/middleware/index>.
 * The `Authorization` header must not be present.
 * `Cache-Control` header parameters must be valid, and the response must be marked `public` and not marked `private`.
 * The `Pragma: no-cache` header must not be present if the `Cache-Control` header isn't present, as the `Cache-Control` header overrides the `Pragma` header when present.


### PR DESCRIPTION
**Apologies for the length of these remarks :point_down:, but there be 🐉 here.**

Addresses #10987 

@shapeh and I deliberated a bit further: Turns out that we aren't covering "terminal middleware" very well. The last PR didn't go far enough.

"Terminal middleware" only appears in the *Built-in middleware* table of the Middleware topic and assumes that the reader will define it correctly.

* I've elaborated on it in the Middleware topic ... both early where "short-circuiting" is described and later where it's used in the table.
* The Response Caching topic now has a spot that we can link directly for *terminal middleware* (and then links to the whole topic as 'for more info, see'). I link to the table because the caching topic is saying that 'a terminal middleware' must not process the request first and the table indicates which middlewares can act as a terminal middleware. Since that condition of caching now links to both the table and the topic as a whole, I think we're covered.
* The paragraph at Line 31 of the Middleware topic is a bit disorganized. I update it here so that the concepts pertaining to short-circuiting/terminal middleware are in their own paragraph. Also ...
* :dragon: I move the paragraph on terminal middleware down in the section because I'd like to make a point about earlier middleware that still processes its post-`next.Invoke` code *after* the terminal middleware runs. The only way to do that is to move this paragraph down below where `next` is described.
* :dragon: The current text implies (via the `HasStarted` check remark) that *completely terminating request processing* (i.e., including any post-`next.Invoke` code in *prior* middleware) isn't possible. Just making sure the doc is correct on that point. We could add a `HasStarted` example to the warning where a prior middleware checks before it processes any post-`next.Invoke` code. Let me know if you'd like to see that drafted in here.

Thanks @shapeh! :rocket: