### PR TITLE
Fix format

### DIFF
--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -102,9 +102,10 @@ public async Task<IActionResult> Register(RegisterViewModel model)
     ViewData["ReturnUrl"] = returnUrl;
     if  (ModelState.IsValid)
     {
-        var user = new ApplicationUser {
-          UserName = model.Email,
-          Email = model.Email
+        var user = new ApplicationUser 
+        {
+            UserName = model.Email,
+            Email = model.Email
         };
         using (var memoryStream = new MemoryStream())
         {


### PR DESCRIPTION
In [corefx/coding-style.md at master · dotnet/corefx](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md ) NO.1, we use Allman style braces, where each brace begins on a new line. A single line statement block can go without braces but the block must be properly indented on its own line and must not be nested in other statement blocks that use braces (See issue 381 for examples). One exception is that a using statement is permitted to be nested within another using statement by starting on the following line at the same indentation level, even if the nested using contains a controlled block.

![image](https://user-images.githubusercontent.com/16054566/52923125-147b9b00-3361-11e9-8e8e-68972160fffd.png)
