### PR TITLE
Fixed wrong area name in the doc example

### DIFF
--- a/aspnetcore/mvc/controllers/routing.md
+++ b/aspnetcore/mvc/controllers/routing.md
@@ -677,7 +677,7 @@ The following example configures MVC to use the default conventional route and a
 
 [!code-csharp[](routing/sample/AreasRouting/Startup.cs?name=snippet1)]
 
-When matching a URL path like `/Manage/Users/AddUser`, the first route will produce the route values `{ area = Blog, controller = Users, action = AddUser }`. The `area` route value is produced by a default value for `area`, in fact the route created by `MapAreaRoute` is equivalent to the following:
+When matching a URL path like `/Manage/Users/AddUser`, the first route will produce the route values `{ area = Manage, controller = Users, action = AddUser }`. The `area` route value is produced by a default value for `area`, in fact the route created by `MapAreaRoute` is equivalent to the following:
 
 [!code-csharp[](routing/sample/AreasRouting/Startup.cs?name=snippet2)]
 


### PR DESCRIPTION
according to exampled url of "/Manage/Users/AddUser" the area name should be "Manage" not "Blog"



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->