### PR TITLE
Corrected typos

### DIFF
--- a/aspnetcore/security/authorization/policies.md
+++ b/aspnetcore/security/authorization/policies.md
@@ -114,7 +114,7 @@ The `HandleRequirementAsync` method you implement in an authorization handler ha
 
 For example, MVC passes an instance of [AuthorizationFilterContext](/dotnet/api/?term=AuthorizationFilterContext) in the `Resource` property. This property provides access to `HttpContext`, `RouteData`, and everything else provided by MVC and Razor Pages.
 
-The use of the `Resource` property is framework specific. Using information in the `Resource` property limits your authorization policies to particular frameworks. You should cast the `Resource` property using the `as` keyword, and then confirm the cast has succeed to ensure your code doesn't crash with an `InvalidCastException` when run on other frameworks:
+The use of the `Resource` property is framework specific. Using information in the `Resource` property limits your authorization policies to particular frameworks. You should cast the `Resource` property using the `is` keyword, and then confirm the cast has succeeded to ensure your code doesn't crash with an `InvalidCastException` when run on other frameworks:
 
 ```csharp
 // Requires the following import:


### PR DESCRIPTION
Corrected "has succeed" to "has succeeded"
Updated description to reflect the provided code sample: code used "is", description incorrectly suggested to use "as".