### PR TITLE
Link to MvcOptions doc instead of source code

### DIFF
--- a/aspnetcore/mvc/compatibility-version.md
+++ b/aspnetcore/mvc/compatibility-version.md
@@ -39,6 +39,6 @@ For apps that encounter breaking behavior changes, using the appropriate compati
 * Allows you to use the latest release and opt out of specific breaking behavior changes.
 * Gives you time to update your app so it works with the latest changes.
 
-The [MvcOptions](https://github.com/aspnet/AspNetCore/blob/release/2.2/src/Mvc/Mvc.Core/src/MvcOptions.cs) class source comments have a good explanation of what changed and why the changes are an improvement for most users.
+The <xref:Microsoft.AspNetCore.Mvc.MvcOptions> documentation has a good explanation of what changed and why the changes are an improvement for most users.
 
 At some future date, there will be an [ASP.NET Core 3.0 version](https://github.com/aspnet/Home/wiki/Roadmap). Old behaviors supported by compatibility switches will be removed in the 3.0 version. We feel these are positive changes benefitting nearly all users. By introducing these changes now, most apps can benefit now, and the others will have time to update their apps.


### PR DESCRIPTION
Because it's much easier to read and navigate a rendered html page than comments on GitHub.