### PR TITLE
dB scope in a hosted service example + 2.2 updates

### DIFF
--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -5,7 +5,7 @@ description: Learn how to implement background tasks with hosted services in ASP
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/28/2018
+ms.date: 02/20/2019
 uid: fundamentals/host/hosted-services
 ---
 # Background tasks with hosted services in ASP.NET Core
@@ -93,7 +93,10 @@ The services are registered in `Startup.ConfigureServices`. The `IHostedService`
 
 [!code-csharp[](hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Startup.cs?name=snippet3)]
 
-In the Index page model class, the `IBackgroundTaskQueue` is injected into the constructor and assigned to `Queue`:
+In the Index page model class:
+
+* The `IBackgroundTaskQueue` is injected into the constructor and assigned to `Queue`.
+* An <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory> is injected and assigned to `_serviceScopeFactory`. The factory is used to create instances of <xref:Microsoft.Extensions.DependencyInjection.IServiceScope>, which is used to create services within a scope. A scope is created in order to use the app's `AppDbContext` (a scoped service) to write database records in the `IBackgroundTaskQueue` (a singleton service).
 
 [!code-csharp[](hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Pages/Index.cshtml.cs?name=snippet1)]
 
@@ -104,4 +107,4 @@ When the **Add Task** button is selected on the Index page, the `OnPostAddTask` 
 ## Additional resources
 
 * [Implement background tasks in microservices with IHostedService and the BackgroundService class](/dotnet/standard/microservices-architecture/multi-container-microservice-net-applications/background-tasks-with-ihostedservice)
-* [System.Threading.Timer](xref:System.Threading.Timer)
+* <xref:System.Threading.Timer>

--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-GenericHost/BackgroundTasksSample.csproj
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-GenericHost/BackgroundTasksSample.csproj
@@ -3,19 +3,20 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
   </ItemGroup>
   
 </Project>

--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-GenericHost/Program.cs
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-GenericHost/Program.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using BackgroundTasksSample.Services;
-using System.Threading;
 
 namespace BackgroundTasksSample
 {

--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/BackgroundTasksSample.csproj
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/BackgroundTasksSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Data/AppDbContext.cs
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Data/AppDbContext.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace BackgroundTasksSample.Data
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Message> Messages { get; set; }
+    }
+}

--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Data/Message.cs
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Data/Message.cs
@@ -1,0 +1,8 @@
+namespace BackgroundTasksSample.Data
+{
+    public class Message
+    {
+        public int Id { get; set; }
+        public string Text { get; set; }
+    }
+}

--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Pages/Error.cshtml
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Pages/Error.cshtml
@@ -19,5 +19,8 @@
     Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
 </p>
 <p>
-    <strong>The Development environment shouldn't be enabled for deployed applications</strong>. It can result in displaying sensitive information from exceptions to end users. For local debugging, enable the Development environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong> and restarting the app or adding <code>.UseEnvironment("Development")</code> to <code>WebHost</code> in <i>Program.cs</i> and restarting the app.
+    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
+    It can result in displaying sensitive information from exceptions to end users.
+    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
+    and restarting the app.
 </p>

--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Pages/Error.cshtml.cs
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Pages/Error.cshtml.cs
@@ -1,16 +1,20 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace BackgroundTasksSample.Pages
 {
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
     public class ErrorModel : PageModel
     {
         public string RequestId { get; set; }
-        
+
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
-        [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public void OnGet()
         {
             RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;

--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Pages/Index.cshtml
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Pages/Index.cshtml
@@ -9,7 +9,7 @@
 <p>Run the app locally and monitor console output to track background service processing.</p>
 
 <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-8">
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h2 class="panel-title">Timed Hosted Service</h2>
@@ -22,7 +22,7 @@
 </div>
 
 <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-8">
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h2 class="panel-title">Scoped Hosted Service</h2>
@@ -35,7 +35,7 @@
 </div>
 
 <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-8">
         <form method="post">
             <div class="panel panel-default">
                 <div class="panel-heading">
@@ -48,6 +48,16 @@
                     <div class="form-group">
                         <button type="submit" asp-page-handler="AddTask" class="btn btn-default">Add Task</button>
                     </div>
+                    <h3>Database Messages</h3>
+                    <p>After selecting the <b>Add Task</b> button a few times. Refresh the page in the browser every few seconds. As the tasks are running, task status messages are saved into the database. The page shows the current contents of the database on each page refresh.</p>
+                    <ol>
+                        @foreach (var message in Model.Messages)
+                        {
+                            <li>
+                                @message.Text
+                            </li>
+                        }
+                    </ol>
                 </div>
             </div>
         </form>

--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Pages/Shared/_Layout.cshtml
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Pages/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>@ViewData["Title"] - Background Tasks Sample</title>
+    <title>@ViewData["Title"]</title>
     <environment include="Development">
         <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css">
         <link rel="stylesheet" href="~/css/site.css">

--- a/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Startup.cs
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/2.x/BackgroundTasksSample-WebHost/Startup.cs
@@ -3,7 +3,9 @@ using Microsoft.Extensions.DependencyInjection;
 using BackgroundTasksSample.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
+using BackgroundTasksSample.Data;
 
 namespace BackgroundTasksSample
 {
@@ -17,7 +19,9 @@ namespace BackgroundTasksSample
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            services.AddDbContext<AppDbContext>(options => options.UseInMemoryDatabase("InMemoryDb"));
+
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
 
             #region snippet1
             services.AddHostedService<TimedHostedService>();


### PR DESCRIPTION
Fixes #10381 

[Internal Review Topic (Queued background tasks section)](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-2.1&branch=pr-en-us-11035#queued-background-tasks)

* Have the queued background task write status messages to a database.
* Take both of the hosted services samples to 2.2.