### PR TITLE
Surface hosting bundle downgrade common error

### DIFF
--- a/aspnetcore/host-and-deploy/azure-iis-errors-reference.md
+++ b/aspnetcore/host-and-deploy/azure-iis-errors-reference.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Obtain troubleshooting advice for common errors when hosting ASP.NET Core apps on Azure Apps Service and IIS.
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/05/2019
+ms.date: 02/21/2019
 uid: host-and-deploy/azure-iis-errors-reference
 ---
 # Common errors reference for Azure App Service and IIS with ASP.NET Core
@@ -156,6 +156,14 @@ Troubleshooting:
   For more information, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle).
 
 * Make sure that the **Application Pool** > **Process Model** > **Identity** is set to **ApplicationPoolIdentity** or the custom identity has the correct permissions to access the app's deployment folder.
+
+* If you uninstalled the ASP.NET Core Hosting Bundle and installed an earlier version of the hosting bundle, the *applicationHost.config* file doesn't include a section for the ASP.NET Core Module. Open *applicationHost.config* at *%windir%/System32/inetsrv/config* and find the `<configuration><configSections><sectionGroup name="system.webServer">` section group. If the section for the ASP.NET Core Module is missing from the section group, add the section element:
+
+  ```xml
+  <section name="aspNetCore" overrideModeDefault="Allow" />
+  ```
+  
+  Alternatively, install the lastest version of the ASP.NET Core Hosting Bundle. The latest version is backwards-compatible with supported ASP.NET Core apps.
 
 ## Incorrect processPath, missing PATH variable, Hosting Bundle not installed, system/IIS not restarted, VC++ Redistributable not installed, or dotnet.exe access violation
 


### PR DESCRIPTION
Fixes #10940

@shirhatti This is a bit detailed in terms of providing a solution that would allow an earlier hosting bundle install to work.

The alternative is to describe the problem generally and don't give the dev an option on using the latest hosting bundle ... just guide them to use the latest if uninstalling and installing an earlier version isn't supported by engineering. Let me know if you prefer that approach.