### PR TITLE
Added note about deprecated features

### DIFF
--- a/aspnetcore/test/load-tests.md
+++ b/aspnetcore/test/load-tests.md
@@ -20,8 +20,11 @@ Load testing and stress testing are important to ensure a web app is performant 
 
 Under stress, can the app recover from failure and gracefully return to expected behavior? Under stress, the app is *not* run under normal conditions.
 
-> [!NOTE]
-> Web performance and load test functionality is deprecated. Visual Studio 2019 is the last version where web performance and load testing will be available. Additionally, the Azure DevOps cloud-based load testing service will close down March 31st, 2020.
+Visual Studio 2019 will be the last version of Visual Studio with load test features. For customers requiring load testing tools, we recommend using alternate load testing tools such as Apache JMeter, Akamai CloudTest, Blazemeter. For more informations, see the [Visual Studio 2019 Preview Release Notes](/visualstudio/releases/2019/release-notes-preview#test-tools).
+
+Web performance and load test functionality is deprecated. Visual Studio 2019 is the last version where web performance and load testing will be available. Additionally, the Azure DevOps cloud-based load testing service will close down March 31st, 2020.
+
+The load testing service in Azure DevOps is ending in 2020. For more information see [Cloud-based load testing service end of life](https://devblogs.microsoft.com/devops/cloud-based-load-testing-service-eol/).
 
 ## Visual Studio Tools
 

--- a/aspnetcore/test/load-tests.md
+++ b/aspnetcore/test/load-tests.md
@@ -20,6 +20,9 @@ Load testing and stress testing are important to ensure a web app is performant 
 
 Under stress, can the app recover from failure and gracefully return to expected behavior? Under stress, the app is *not* run under normal conditions.
 
+> [!NOTE]
+> Web performance and load test functionality is deprecated. Visual Studio 2019 is the last version where web performance and load testing will be available. Additionally, the Azure DevOps cloud-based load testing service will close down March 31st, 2020.
+
 ## Visual Studio Tools
 
 Visual Studio allows users to create, develop, and debug web performance and load tests. An option is available to create tests by recording actions in web browser.

--- a/aspnetcore/test/load-tests.md
+++ b/aspnetcore/test/load-tests.md
@@ -20,9 +20,7 @@ Load testing and stress testing are important to ensure a web app is performant 
 
 Under stress, can the app recover from failure and gracefully return to expected behavior? Under stress, the app is *not* run under normal conditions.
 
-Visual Studio 2019 will be the last version of Visual Studio with load test features. For customers requiring load testing tools, we recommend using alternate load testing tools such as Apache JMeter, Akamai CloudTest, Blazemeter. For more informations, see the [Visual Studio 2019 Preview Release Notes](/visualstudio/releases/2019/release-notes-preview#test-tools).
-
-Web performance and load test functionality is deprecated. Visual Studio 2019 is the last version where web performance and load testing will be available. Additionally, the Azure DevOps cloud-based load testing service will close down March 31st, 2020.
+Visual Studio 2019 will be the last version of Visual Studio with load test features. For customers requiring load testing tools, we recommend using alternate load testing tools such as Apache JMeter, Akamai CloudTest, Blazemeter. For more information, see the [Visual Studio 2019 Preview Release Notes](/visualstudio/releases/2019/release-notes-preview#test-tools).
 
 The load testing service in Azure DevOps is ending in 2020. For more information see [Cloud-based load testing service end of life](https://devblogs.microsoft.com/devops/cloud-based-load-testing-service-eol/).
 


### PR DESCRIPTION
Added a note that the web performance and load testing tools in Visual Studio is deprecated and will be removed after VS 2019 as was announced here: https://docs.microsoft.com/en-us/visualstudio/releases/2019/release-notes-preview#test-tools

In the same note, a line was added about the load testing service in Azure DevOps closing in 2020 from the announcement here: https://devblogs.microsoft.com/devops/cloud-based-load-testing-service-eol/



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->