### PR TITLE
Add suggested extensions file for aspnet/Docs repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ Project_Readme.html
 *.user
 *.userosscache
 *.sln.docstates
-*.vscode/
+.vscode/*
+!.vscode/extensions.json
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"docsmsft.docs-authoring-pack"
+	]
+}


### PR DESCRIPTION
Fixes https://github.com/aspnet/Docs/issues/11115

Altered the *.gitignore* file to allow check-in of the *extensions.json* file. Suggests the Docs Authoring Pack extension for VS Code.