### PR TITLE
Directly link partial view discovery in Layouts

### DIFF
--- a/aspnetcore/mvc/views/layout.md
+++ b/aspnetcore/mvc/views/layout.md
@@ -3,7 +3,7 @@ title: Layout in ASP.NET Core
 author: ardalis
 description: Learn how to use common layouts, share directives, and run common code before rendering views in an ASP.NET Core app.
 ms.author: riande
-ms.date: 10/18/2018
+ms.date: 02/26/2019
 uid: mvc/views/layout
 ---
 # Layout in ASP.NET Core
@@ -43,15 +43,15 @@ The layout defines a top level template for views in the app. Apps don't require
 
 The following code shows the layout file for a template created project with a controller and views:
 
-[!code-html[](~/common/samples/WebApplication1/Views/Shared/_Layout.cshtml?highlight=44,72)]
+[!code-cshtml[](~/common/samples/WebApplication1/Views/Shared/_Layout.cshtml?highlight=44,72)]
 
 ## Specifying a Layout
 
 Razor views have a `Layout` property. Individual views specify a layout by setting this property:
 
-[!code-html[](../../common/samples/WebApplication1/Views/_ViewStart.cshtml?highlight=2)]
+[!code-cshtml[](../../common/samples/WebApplication1/Views/_ViewStart.cshtml?highlight=2)]
 
-The layout specified can use a full path (for example, */Pages/Shared/_Layout.cshtml* or */Views/Shared/_Layout.cshtml*) or a partial name (example: `_Layout`). When a partial name is provided, the Razor view engine will search for the layout file using its standard discovery process. The folder where the handler method (or controller) exists is searched first, followed by the *Shared* folder. This discovery process is identical to the one used to discover [partial views](partial.md).
+The layout specified can use a full path (for example, */Pages/Shared/_Layout.cshtml* or */Views/Shared/_Layout.cshtml*) or a partial name (example: `_Layout`). When a partial name is provided, the Razor view engine searches for the layout file using its standard discovery process. The folder where the handler method (or controller) exists is searched first, followed by the *Shared* folder. This discovery process is identical to the process used to discover [partial views](xref:mvc/views/partial#partial-view-discovery).
 
 By default, every layout must call `RenderBody`. Wherever the call to `RenderBody` is placed, the contents of the view will be rendered.
 
@@ -117,7 +117,7 @@ The file doesn't support other Razor features, such as functions and section def
 
 A sample `_ViewImports.cshtml` file:
 
-[!code-html[](../../common/samples/WebApplication1/Views/_ViewImports.cshtml)]
+[!code-cshtml[](../../common/samples/WebApplication1/Views/_ViewImports.cshtml)]
 
 The *_ViewImports.cshtml* file for an ASP.NET Core MVC app is typically placed in the *Pages* (or *Views*) folder. A *_ViewImports.cshtml* file can be placed within any folder, in which case it will only be applied to pages or views within that folder and its subfolders. `_ViewImports` files are processed starting at the root level and then for each folder leading up to the location of the page or view itself. `_ViewImports` settings specified at the root level may be overridden at the folder level.
 
@@ -145,7 +145,7 @@ Code that needs to run before each view or page should be placed in the *_ViewSt
 
 A sample *_ViewStart.cshtml* file:
 
-[!code-html[](../../common/samples/WebApplication1/Views/_ViewStart.cshtml)]
+[!code-cshtml[](../../common/samples/WebApplication1/Views/_ViewStart.cshtml)]
 
 The file above specifies that all views will use the *_Layout.cshtml* layout.
 


### PR DESCRIPTION
Fixes #11110

I'm not super happy with the oversimplification here ...

> The folder where the handler method (or controller) exists is searched first, followed by the *Shared* folder.

... but for the algorithm that searches, it's not really inaccurate, just oversimplified. We could pull this sentence here and let the link *do the talk'in*.