### PR TITLE
Fixed Directive name does not render in column

### DIFF
--- a/aspnetcore/razor-components/components.md
+++ b/aspnetcore/razor-components/components.md
@@ -441,14 +441,14 @@ Razor directives are shown in the following table.
 
 | Directive | Description |
 | --------- | ----------- |
-| [@functions](xref:mvc/views/razor#section-5) | Adds a C# code block to a component. |
+| [\@functions](xref:mvc/views/razor#section-5) | Adds a C# code block to a component. |
 | `@implements` | Implements an interface for the generated component class. |
-| [@inherits](xref:mvc/views/razor#section-3) | Provides full control of the class that the component inherits. |
-| [@inject](xref:mvc/views/razor#section-4) | Enables service injection from the [service container](xref:fundamentals/dependency-injection). For more information, see [Dependency injection into views](xref:mvc/views/dependency-injection). |
+| [\@inherits](xref:mvc/views/razor#section-3) | Provides full control of the class that the component inherits. |
+| [\@inject](xref:mvc/views/razor#section-4) | Enables service injection from the [service container](xref:fundamentals/dependency-injection). For more information, see [Dependency injection into views](xref:mvc/views/dependency-injection). |
 | `@layout` | Specifies a layout component. Layout components are used to avoid code duplication and inconsistency. |
-| [@page](xref:razor-pages/index#razor-pages) | Specifies that the component should handle requests directly. The `@page` directive can be specified with a route and optional parameters. Unlike Razor Pages, the `@page` directive doesn't need to be the first directive at the top of the file. For more information, see [Routing](xref:razor-components/routing). |
-| [@using](xref:mvc/views/razor#using) | Adds the C# `using` directive to the generated component class. |
-| [@addTagHelper](xref:mvc/views/razor#tag-helpers) | Use `@addTagHelper` to use a component in a different assembly than the app's assembly. |
+| [\@page](xref:razor-pages/index#razor-pages) | Specifies that the component should handle requests directly. The `@page` directive can be specified with a route and optional parameters. Unlike Razor Pages, the `@page` directive doesn't need to be the first directive at the top of the file. For more information, see [Routing](xref:razor-components/routing). |
+| [\@using](xref:mvc/views/razor#using) | Adds the C# `using` directive to the generated component class. |
+| [\@addTagHelper](xref:mvc/views/razor#tag-helpers) | Use `@addTagHelper` to use a component in a different assembly than the app's assembly. |
 
 **Conditional attributes**
 


### PR DESCRIPTION
The @ symbol was causing the Directive column values to not render. Added `\` to have the values render properly on the final output.