### PR TITLE
Update config doc with Java client

### DIFF
--- a/aspnetcore/signalr/configuration.md
+++ b/aspnetcore/signalr/configuration.md
@@ -162,7 +162,7 @@ let connection = new signalR.HubConnectionBuilder()
     .build();
 ```
 
-See [Logging in SignalR](xref:signalr/java-client#Add-logging) for how to enable logging in the Java client
+For details on how to enable logging in the Java client, see [Logging in SignalR](xref:signalr/java-client#Add-logging).
 
 > [!NOTE]
 > To disable logging entirely, specify `signalR.LogLevel.None` in the `configureLogging` method.
@@ -199,7 +199,7 @@ let connection = new signalR.HubConnectionBuilder()
     .build();
 ```
 
-In the Java client the transport is selected with the `withTransport` method on the HttpHubConnectionBuilder. The Java client defaults to using the WebSockets transport.
+In the Java client, the transport is selected with the `withTransport` method on the `HttpHubConnectionBuilder`. The Java client defaults to using the WebSockets transport.
 
 ```java
         HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")

--- a/aspnetcore/signalr/configuration.md
+++ b/aspnetcore/signalr/configuration.md
@@ -199,6 +199,14 @@ let connection = new signalR.HubConnectionBuilder()
     .build();
 ```
 
+::: moniker range=">= aspnetcore-2.2"
+
+In this version of the Java client websockets is the only available transport.
+
+::: moniker-end
+
+::: moniker range="= aspnetcore-3.0"
+
 In the Java client, the transport is selected with the `withTransport` method on the `HttpHubConnectionBuilder`. The Java client defaults to using the WebSockets transport.
 
 ```java
@@ -206,6 +214,8 @@ HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/m
     .withTransport(TransportEnum.WEBSOCKETS)
     .build();
 ```
+
+::: moniker-end
 
 > [!NOTE]
 > The SignalR Java client doesn't support transport fallback yet.

--- a/aspnetcore/signalr/configuration.md
+++ b/aspnetcore/signalr/configuration.md
@@ -132,7 +132,7 @@ The WebSocket transport has additional options that can be configured using the 
 
 ## Configure client options
 
-Client options can be configured on the `HubConnectionBuilder` type (available in the .NET and Javascipt clients. It is also available on the Java client but the `HttpHubConnectionBuilder` subclass is what contains the builder configuation options.), as well as on the `HubConnection` itself.
+Client options can be configured on the `HubConnectionBuilder` type (available in the .NET and JavaScript clients). It's also available in the Java client, but the `HttpHubConnectionBuilder` subclass is what contains the builder configuration options, as well as on the `HubConnection` itself.
 
 ### Configure logging
 

--- a/aspnetcore/signalr/configuration.md
+++ b/aspnetcore/signalr/configuration.md
@@ -162,8 +162,6 @@ let connection = new signalR.HubConnectionBuilder()
     .build();
 ```
 
-For details on how to enable logging in the Java client, see [Logging in SignalR](xref:signalr/java-client#Add-logging).
-
 > [!NOTE]
 > To disable logging entirely, specify `signalR.LogLevel.None` in the `configureLogging` method.
 
@@ -178,6 +176,8 @@ Log levels available to the JavaScript client are listed below. Setting the log 
 | `Information` | Informational messages. |
 | `Debug` | Diagnostic messages useful for debugging. |
 | `Trace` | Very detailed diagnostic messages designed for diagnosing specific issues. |
+
+For details on how to enable logging in the Java client, see [Logging in SignalR](xref:signalr/java-client#Add-logging).
 
 ### Configure allowed transports
 
@@ -215,10 +215,10 @@ HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/m
     .build();
 ```
 
-::: moniker-end
 
 > [!NOTE]
 > The SignalR Java client doesn't support transport fallback yet.
+::: moniker-end
 
 ### Configure bearer authentication
 
@@ -265,17 +265,10 @@ HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/m
 
 Additional options for configuring timeout and keep-alive behavior are available on the `HubConnection` object itself:
 
-| .NET Option | JavaScript Option | Java Option | Default Value | Description |
-| ----------- | ----------------- | ----------- | ------------- | ----------- |
-| `ServerTimeout` | `serverTimeoutInMilliseconds` | `getServerTimeout` `setServerTimeout` | 30 seconds (30,000 milliseconds) | Timeout for server activity. If the server hasn't sent a message in this interval, the client considers the server disconnected and triggers the `Closed` event (`onclose` in JavaScript). This value must be large enough for a ping message to be sent from the server **and** received by the client within the timeout interval. The recommended value is a number at least double the server's `KeepAliveInterval` value, to allow time for pings to arrive. |
-| `HandshakeTimeout` | Not configurable |  `withHandshakeResponseTimeout` | 15 seconds | Timeout for initial server handshake. If the server doesn't send a handshake response in this interval, the client cancels the handshake and triggers the `Closed` event (`onclose` in JavaScript). This is an advanced setting that should only be modified if handshake timeout errors are occurring due to severe network latency. For more detail on the Handshake process, see the [SignalR Hub Protocol Specification](https://github.com/aspnet/SignalR/blob/master/specs/HubProtocol.md). |
-
-In the .NET Client, timeout values are specified as `TimeSpan` values. In the JavaScript client, timeout values are specified as a number indicating the duration in milliseconds.
-
 # [.NET](#tab/dotnet)
 
 | Option | Default value | Description |
-| ----------- | ------------- | ----------- |
+| ------ | ------------- | ----------- |
 | `ServerTimeout` | 30 seconds (30,000 milliseconds) | Timeout for server activity. If the server hasn't sent a message in this interval, the client considers the server disconnected and triggers the `Closed` event (`onclose` in JavaScript). This value must be large enough for a ping message to be sent from the server **and** received by the client within the timeout interval. The recommended value is a number at least double the server's `KeepAliveInterval` value, to allow time for pings to arrive. |
 | `HandshakeTimeout` | 15 seconds | Timeout for initial server handshake. If the server doesn't send a handshake response in this interval, the client cancels the handshake and triggers the `Closed` event (`onclose` in JavaScript). This is an advanced setting that should only be modified if handshake timeout errors are occurring due to severe network latency. For more detail on the Handshake process, see the [SignalR Hub Protocol Specification](https://github.com/aspnet/SignalR/blob/master/specs/HubProtocol.md). |
 
@@ -284,8 +277,8 @@ In the .NET Client, timeout values are specified as `TimeSpan` values.
 # [JavaScript](#tab/javascript)
 
 | Option | Default value | Description |
-| ----------------- | ------------- | ----------- |
- `serverTimeoutInMilliseconds` | 30 seconds (30,000 milliseconds) | Timeout for server activity. If the server hasn't sent a message in this interval, the client considers the server disconnected and triggers the `onclose` event. This value must be large enough for a ping message to be sent from the server **and** received by the client within the timeout interval. The recommended value is a number at least double the server's `KeepAliveInterval` value, to allow time for pings to arrive. |
+| ------ | ------------- | ----------- |
+| `serverTimeoutInMilliseconds` | 30 seconds (30,000 milliseconds) | Timeout for server activity. If the server hasn't sent a message in this interval, the client considers the server disconnected and triggers the `onclose` event. This value must be large enough for a ping message to be sent from the server **and** received by the client within the timeout interval. The recommended value is a number at least double the server's `KeepAliveInterval` value, to allow time for pings to arrive. |
 
 # [Java](#tab/java)
 
@@ -300,21 +293,36 @@ In the .NET Client, timeout values are specified as `TimeSpan` values.
 
 Additional options can be configured in the `WithUrl` (`withUrl` in JavaScript) method on `HubConnectionBuilder` or on the various configuration APIs on the `HttpHubConnectionBuilder` in the Java client:
 
-| .NET Option | JavaScript Option | Java Option | Default Value | Description |
-| ----------- | ----------------- | ----------- | ------------- | ----------- |
-| `AccessTokenProvider` | `accessTokenFactory` | `withAccessTokenProvider` | `null` | A function returning a string that is provided as a Bearer authentication token in HTTP requests. |
-| `SkipNegotiation` | `skipNegotiation` | `shouldSkipNegotiate` | `false` | Set this to `true` to skip the negotiation step. **Only supported when the WebSockets transport is the only enabled transport**. This setting can't be enabled when using the Azure SignalR Service. |
-| `ClientCertificates` | Not configurable * | Empty | A collection of TLS certificates to send to authenticate requests. |
-| `Cookies` | Not configurable * | Not configurable | Empty | A collection of HTTP cookies to send with every HTTP request. |
-| `Credentials` | Not configurable * | Not configurable | Empty | Credentials to send with every HTTP request. |
-| `CloseTimeout` | Not configurable * | Not configurable | 5 seconds | WebSockets only. The maximum amount of time the client waits after closing for the server to acknowledge the close request. If the server doesn't acknowledge the close within this time, the client disconnects. |
-| `Headers` | Not configurable * | `withHeader``withHeaders` | Empty | A Map of additional HTTP headers to send with every HTTP request. |
-| `HttpMessageHandlerFactory` | Not configurable * | Not configurable | `null` | A delegate that can be used to configure or replace the `HttpMessageHandler` used to send HTTP requests. Not used for WebSocket connections. This delegate must return a non-null value, and it receives the default value as a parameter. Either modify settings on that default value and return it, or return a new `HttpMessageHandler` instance. **When replacing the handler make sure to copy the settings you want to keep from the provided handler, otherwise, the configured options (such as Cookies and Headers) won't apply to the new handler.** |
-| `Proxy` | Not configurable * | Not configurable | `null` | An HTTP proxy to use when sending HTTP requests. |
-| `UseDefaultCredentials` | Not configurable * | Not configurable | `false` | Set this boolean to send the default credentials for HTTP and WebSockets requests. This enables the use of Windows authentication. |
-| `WebSocketConfiguration` | Not configurable * | Not configurable | `null` | A delegate that can be used to configure additional WebSocket options. Receives an instance of [ClientWebSocketOptions](/dotnet/api/system.net.websockets.clientwebsocketoptions) that can be used to configure the options. |
+# [.NET](#tab/dotnet)
 
-Options marked with an asterisk (*) aren't configurable in the JavaScript client, due to limitations in browser APIs.
+| .NET Option |  Default value | Description |
+| ----------- | -------------- | ----------- |
+| `AccessTokenProvider` | `null` | A function returning a string that is provided as a Bearer authentication token in HTTP requests. |
+| `SkipNegotiation` | `false` | Set this to `true` to skip the negotiation step. **Only supported when the WebSockets transport is the only enabled transport**. This setting can't be enabled when using the Azure SignalR Service. |
+| `ClientCertificates` | Empty | A collection of TLS certificates to send to authenticate requests. |
+| `Cookies` | Empty | A collection of HTTP cookies to send with every HTTP request. |
+| `Credentials` | Empty | Credentials to send with every HTTP request. |
+| `CloseTimeout` | 5 seconds | WebSockets only. The maximum amount of time the client waits after closing for the server to acknowledge the close request. If the server doesn't acknowledge the close within this time, the client disconnects. |
+| `Headers` | Empty | A Map of additional HTTP headers to send with every HTTP request. |
+| `HttpMessageHandlerFactory` | `null` | A delegate that can be used to configure or replace the `HttpMessageHandler` used to send HTTP requests. Not used for WebSocket connections. This delegate must return a non-null value, and it receives the default value as a parameter. Either modify settings on that default value and return it, or return a new `HttpMessageHandler` instance. **When replacing the handler make sure to copy the settings you want to keep from the provided handler, otherwise, the configured options (such as Cookies and Headers) won't apply to the new handler.** |
+| `Proxy` | `null` | An HTTP proxy to use when sending HTTP requests. |
+| `UseDefaultCredentials` | `false` | Set this boolean to send the default credentials for HTTP and WebSockets requests. This enables the use of Windows authentication. |
+| `WebSocketConfiguration` | `null` | A delegate that can be used to configure additional WebSocket options. Receives an instance of [ClientWebSocketOptions](/dotnet/api/system.net.websockets.clientwebsocketoptions) that can be used to configure the options. |
+
+# [JavaScript](#tab/javascript)
+| JavaScript Option | Default Value | Description |
+| ----------------- | ------------- | ----------- |
+| `accessTokenFactory` | `null` | A function returning a string that is provided as a Bearer authentication token in HTTP requests. |
+| `skipNegotiation` | `false` | Set this to `true` to skip the negotiation step. **Only supported when the WebSockets transport is the only enabled transport**. This setting can't be enabled when using the Azure SignalR Service. |
+
+# [Java](#tab/java)
+| Java Option | Default Value | Description |
+| ----------- | ------------- | ----------- |
+| `withAccessTokenProvider` | `null` | A function returning a string that is provided as a Bearer authentication token in HTTP requests. |
+| `shouldSkipNegotiate` | `false` | Set this to `true` to skip the negotiation step. **Only supported when the WebSockets transport is the only enabled transport**. This setting can't be enabled when using the Azure SignalR Service. |
+| `withHeader` `withHeaders` | Empty | A Map of additional HTTP headers to send with every HTTP request. |
+
+---
 
 In the .NET Client, these options can be modified by the options delegate provided to `WithUrl`:
 

--- a/aspnetcore/signalr/configuration.md
+++ b/aspnetcore/signalr/configuration.md
@@ -177,7 +177,21 @@ Log levels available to the JavaScript client are listed below. Setting the log 
 | `Debug` | Diagnostic messages useful for debugging. |
 | `Trace` | Very detailed diagnostic messages designed for diagnosing specific issues. |
 
-For details on how to enable logging in the Java client, see [Logging in SignalR](xref:signalr/java-client#Add-logging).
+The SignalR Java client uses the [SLF4J](https://www.slf4j.org/) library for logging. It's a high-level logging API that allows users of the library to chose their own specific logging implementation by bringing in a specific logging dependency. The following code snippet shows how to use `java.util.logging` with the SignalR Java client.
+
+```gradle
+implementation 'org.slf4j:slf4j-jdk14:1.7.25'
+```
+
+If you don't configure logging in your dependencies, SLF4J loads a default no-operation logger with the following warning message:
+
+```
+SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
+SLF4J: Defaulting to no-operation (NOP) logger implementation
+SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
+```
+
+This can safely be ignored.
 
 ### Configure allowed transports
 
@@ -214,10 +228,9 @@ HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/m
     .withTransport(TransportEnum.WEBSOCKETS)
     .build();
 ```
-
-
 > [!NOTE]
 > The SignalR Java client doesn't support transport fallback yet.
+
 ::: moniker-end
 
 ### Configure bearer authentication

--- a/aspnetcore/signalr/configuration.md
+++ b/aspnetcore/signalr/configuration.md
@@ -272,24 +272,29 @@ Additional options for configuring timeout and keep-alive behavior are available
 
 In the .NET Client, timeout values are specified as `TimeSpan` values. In the JavaScript client, timeout values are specified as a number indicating the duration in milliseconds.
 
-[.NET](#tab/dotnet)
-| .NET Option | Default Value | Description |
+# [.NET](#tab/dotnet)
+
+| Option | Default value | Description |
 | ----------- | ------------- | ----------- |
 | `ServerTimeout` | 30 seconds (30,000 milliseconds) | Timeout for server activity. If the server hasn't sent a message in this interval, the client considers the server disconnected and triggers the `Closed` event (`onclose` in JavaScript). This value must be large enough for a ping message to be sent from the server **and** received by the client within the timeout interval. The recommended value is a number at least double the server's `KeepAliveInterval` value, to allow time for pings to arrive. |
 | `HandshakeTimeout` | 15 seconds | Timeout for initial server handshake. If the server doesn't send a handshake response in this interval, the client cancels the handshake and triggers the `Closed` event (`onclose` in JavaScript). This is an advanced setting that should only be modified if handshake timeout errors are occurring due to severe network latency. For more detail on the Handshake process, see the [SignalR Hub Protocol Specification](https://github.com/aspnet/SignalR/blob/master/specs/HubProtocol.md). |
 
 In the .NET Client, timeout values are specified as `TimeSpan` values.
 
-[Javascript](#tab/javascript)
-| JavaScript Option | Default Value | Description |
+# [JavaScript](#tab/javascript)
+
+| Option | Default value | Description |
 | ----------------- | ------------- | ----------- |
  `serverTimeoutInMilliseconds` | 30 seconds (30,000 milliseconds) | Timeout for server activity. If the server hasn't sent a message in this interval, the client considers the server disconnected and triggers the `onclose` event. This value must be large enough for a ping message to be sent from the server **and** received by the client within the timeout interval. The recommended value is a number at least double the server's `KeepAliveInterval` value, to allow time for pings to arrive. |
 
- [Java](#tab/java)
-| Java Option | Default Value | Description |
+# [Java](#tab/java)
+
+| Option | Default value | Description |
 | ----------- | ------------- | ----------- |
 |`getServerTimeout` `setServerTimeout` | 30 seconds (30,000 milliseconds) | Timeout for server activity. If the server hasn't sent a message in this interval, the client considers the server disconnected and triggers the `onClose` event. This value must be large enough for a ping message to be sent from the server **and** received by the client within the timeout interval. The recommended value is a number at least double the server's `KeepAliveInterval` value, to allow time for pings to arrive. |
 | `withHandshakeResponseTimeout` | 15 seconds | Timeout for initial server handshake. If the server doesn't send a handshake response in this interval, the client cancels the handshake and triggers the `onClose` event. This is an advanced setting that should only be modified if handshake timeout errors are occurring due to severe network latency. For more detail on the Handshake process, see the [SignalR Hub Protocol Specification](https://github.com/aspnet/SignalR/blob/master/specs/HubProtocol.md). |
+
+---
 
 ### Configure additional options
 

--- a/aspnetcore/signalr/configuration.md
+++ b/aspnetcore/signalr/configuration.md
@@ -202,9 +202,9 @@ let connection = new signalR.HubConnectionBuilder()
 In the Java client, the transport is selected with the `withTransport` method on the `HttpHubConnectionBuilder`. The Java client defaults to using the WebSockets transport.
 
 ```java
-        HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
-                .withTransport(TransportEnum.WEBSOCKETS)
-                .build();
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+    .withTransport(TransportEnum.WEBSOCKETS)
+    .build();
 ```
 
 > [!NOTE]
@@ -241,7 +241,7 @@ let connection = new signalR.HubConnectionBuilder()
 ```
 
 
-In the SignalR Java client, you can configure a bearer token to use for authentication by providing an "access token factory" to the [HttpHubConnectionBuilder](/java/api/com.microsoft.signalr._http_hub_connection_builder?view=aspnet-signalr-java). Use [withAccessTokenFactory](/java/api/com.microsoft.signalr._http_hub_connection_builder.withaccesstokenprovider?view=aspnet-signalr-java#com_microsoft_signalr__http_hub_connection_builder_withAccessTokenProvider_Single_String__) to provide an [RxJava](https://github.com/ReactiveX/RxJava) [Single<String>](http://reactivex.io/documentation/single.html). With a call to [Single.defer](http://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#defer-java.util.concurrent.Callable-), you can write logic to produce access tokens for your client.
+In the SignalR Java client, you can configure a bearer token to use for authentication by providing an access token factory to the [HttpHubConnectionBuilder](/java/api/com.microsoft.signalr._http_hub_connection_builder?view=aspnet-signalr-java). Use [withAccessTokenFactory](/java/api/com.microsoft.signalr._http_hub_connection_builder.withaccesstokenprovider?view=aspnet-signalr-java#com_microsoft_signalr__http_hub_connection_builder_withAccessTokenProvider_Single_String__) to provide an [RxJava](https://github.com/ReactiveX/RxJava) [Single<String>](http://reactivex.io/documentation/single.html). With a call to [Single.defer](http://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#defer-java.util.concurrent.Callable-), you can write logic to produce access tokens for your client.
 
 ```java
 HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
@@ -262,6 +262,25 @@ Additional options for configuring timeout and keep-alive behavior are available
 
 In the .NET Client, timeout values are specified as `TimeSpan` values. In the JavaScript client, timeout values are specified as a number indicating the duration in milliseconds.
 
+[.NET](#tab/dotnet)
+| .NET Option | Default Value | Description |
+| ----------- | ------------- | ----------- |
+| `ServerTimeout` | 30 seconds (30,000 milliseconds) | Timeout for server activity. If the server hasn't sent a message in this interval, the client considers the server disconnected and triggers the `Closed` event (`onclose` in JavaScript). This value must be large enough for a ping message to be sent from the server **and** received by the client within the timeout interval. The recommended value is a number at least double the server's `KeepAliveInterval` value, to allow time for pings to arrive. |
+| `HandshakeTimeout` | 15 seconds | Timeout for initial server handshake. If the server doesn't send a handshake response in this interval, the client cancels the handshake and triggers the `Closed` event (`onclose` in JavaScript). This is an advanced setting that should only be modified if handshake timeout errors are occurring due to severe network latency. For more detail on the Handshake process, see the [SignalR Hub Protocol Specification](https://github.com/aspnet/SignalR/blob/master/specs/HubProtocol.md). |
+
+In the .NET Client, timeout values are specified as `TimeSpan` values.
+
+[Javascript](#tab/javascript)
+| JavaScript Option | Default Value | Description |
+| ----------------- | ------------- | ----------- |
+ `serverTimeoutInMilliseconds` | 30 seconds (30,000 milliseconds) | Timeout for server activity. If the server hasn't sent a message in this interval, the client considers the server disconnected and triggers the `onclose` event. This value must be large enough for a ping message to be sent from the server **and** received by the client within the timeout interval. The recommended value is a number at least double the server's `KeepAliveInterval` value, to allow time for pings to arrive. |
+
+ [Java](#tab/java)
+| Java Option | Default Value | Description |
+| ----------- | ------------- | ----------- |
+|`getServerTimeout` `setServerTimeout` | 30 seconds (30,000 milliseconds) | Timeout for server activity. If the server hasn't sent a message in this interval, the client considers the server disconnected and triggers the `onClose` event. This value must be large enough for a ping message to be sent from the server **and** received by the client within the timeout interval. The recommended value is a number at least double the server's `KeepAliveInterval` value, to allow time for pings to arrive. |
+| `withHandshakeResponseTimeout` | 15 seconds | Timeout for initial server handshake. If the server doesn't send a handshake response in this interval, the client cancels the handshake and triggers the `onClose` event. This is an advanced setting that should only be modified if handshake timeout errors are occurring due to severe network latency. For more detail on the Handshake process, see the [SignalR Hub Protocol Specification](https://github.com/aspnet/SignalR/blob/master/specs/HubProtocol.md). |
+
 ### Configure additional options
 
 Additional options can be configured in the `WithUrl` (`withUrl` in JavaScript) method on `HubConnectionBuilder` or on the various configuration APIs on the `HttpHubConnectionBuilder` in the Java client:
@@ -269,12 +288,12 @@ Additional options can be configured in the `WithUrl` (`withUrl` in JavaScript) 
 | .NET Option | JavaScript Option | Java Option | Default Value | Description |
 | ----------- | ----------------- | ----------- | ------------- | ----------- |
 | `AccessTokenProvider` | `accessTokenFactory` | `withAccessTokenProvider` | `null` | A function returning a string that is provided as a Bearer authentication token in HTTP requests. |
-| `SkipNegotiation` | `skipNegotiation` | `shoudlSkipNegotiate` | `false` | Set this to `true` to skip the negotiation step. **Only supported when the WebSockets transport is the only enabled transport**. This setting can't be enabled when using the Azure SignalR Service. |
+| `SkipNegotiation` | `skipNegotiation` | `shouldSkipNegotiate` | `false` | Set this to `true` to skip the negotiation step. **Only supported when the WebSockets transport is the only enabled transport**. This setting can't be enabled when using the Azure SignalR Service. |
 | `ClientCertificates` | Not configurable * | Empty | A collection of TLS certificates to send to authenticate requests. |
 | `Cookies` | Not configurable * | Not configurable | Empty | A collection of HTTP cookies to send with every HTTP request. |
 | `Credentials` | Not configurable * | Not configurable | Empty | Credentials to send with every HTTP request. |
 | `CloseTimeout` | Not configurable * | Not configurable | 5 seconds | WebSockets only. The maximum amount of time the client waits after closing for the server to acknowledge the close request. If the server doesn't acknowledge the close within this time, the client disconnects. |
-| `Headers` | Not configurable * | `withHeader``withHeaders` | Empty | A dictionary of additional HTTP headers to send with every HTTP request. |
+| `Headers` | Not configurable * | `withHeader``withHeaders` | Empty | A Map of additional HTTP headers to send with every HTTP request. |
 | `HttpMessageHandlerFactory` | Not configurable * | Not configurable | `null` | A delegate that can be used to configure or replace the `HttpMessageHandler` used to send HTTP requests. Not used for WebSocket connections. This delegate must return a non-null value, and it receives the default value as a parameter. Either modify settings on that default value and return it, or return a new `HttpMessageHandler` instance. **When replacing the handler make sure to copy the settings you want to keep from the provided handler, otherwise, the configured options (such as Cookies and Headers) won't apply to the new handler.** |
 | `Proxy` | Not configurable * | Not configurable | `null` | An HTTP proxy to use when sending HTTP requests. |
 | `UseDefaultCredentials` | Not configurable * | Not configurable | `false` | Set this boolean to send the default credentials for HTTP and WebSockets requests. This enables the use of Windows authentication. |
@@ -309,11 +328,11 @@ In the Java client, these options can be configured with the methods on the `Htt
 
 
 ```java
-    HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
-            .withHeader("Foo", "Bar")
-            .shoudldSkipNegotiate(true)
-            .withHandshakeResponseTimeout(30*1000)
-            .build();
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+        .withHeader("Foo", "Bar")
+        .shouldSkipNegotiate(true)
+        .withHandshakeResponseTimeout(30*1000)
+        .build();
 ```
 
 ## Additional resources


### PR DESCRIPTION
Fixes #11125 

Adds guidance on how to configure the various options on the SignalR Java client. 

[Internal review](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/configuration?view=aspnetcore-2.1&branch=pr-en-us-11143)