### PR TITLE
Add Request/Response reading/writing document

### DIFF
--- a/aspnetcore/fundamentals/request-response.md
+++ b/aspnetcore/fundamentals/request-response.md
@@ -1,0 +1,84 @@
+---
+title: Request and Response operations in ASP.NET Core
+author: jkotalik
+description: Learn how to get started with WebSockets in ASP.NET Core.
+monikerRange: '>= aspnetcore-3.0'
+ms.author: tdykstra
+ms.custom: mvc
+ms.date: 02/26/2019
+uid: fundamentals/request-response
+---
+# Request and response operations in ASP.NET Core
+
+By [Justin Kotalik](https://github.com/jkotalik)
+
+This article explains how to read from the HttpRequest Body and write to the HttpResponse Body.
+
+In ASP.NET Core 3.0, there are two abstractions for the HttpRequest and Response bodies: <xref:System.IO.Stream> and <xref:System.IO.Pipelines.Pipe>. For Request reading, the <xref:Microsoft.AspNetCore.Http.HttpRequest.Body> is a <xref:System.IO.Stream> and <xref:Microsoft.AspNetCore.Http.HttpRequest.BodyPipe> is <xref:System.IO.Pipelines.PipeReader>. For Response writing, the <xref:Microsoft.AspNetCore.Http.HttpResponse.Body> is a <xref:System.IO.Stream> and <xref:Microsoft.AspNetCore.Http.HttpResponse.BodyPipe> is <xref:System.IO.Pipelines.PipeWriter>.
+
+## How to Read and Write to the Request and Response bodies
+
+Below are examples of common usage patterns for reading and writing.
+### Streams
+
+```csharp
+public class MyTerminalMiddleware
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        Memory<byte> buffer = new Memory<byte>(new byte[4096]);
+        var length = await context.Request.Body.ReadAsync(buffer);
+
+        await context.Response.Body.WriteAsync(Encoding.UTF8.GetBytes("Hello World"));
+    }
+}
+```
+
+Benefits:
+- Still used by a majority of .NET APIs.
+Downsides:
+- Reading forces the middleware to allocate memory for the stream to read into. 
+
+### Pipelines
+
+```csharp
+public class MyTerminalMiddleware
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        ReadResult readResult = await context.Request.BodyPipe.ReadAsync();
+        ReadOnlySequence<byte> buffer = readResult.Buffer;
+        context.Request.BodyPipe.AdvanceTo(buffer.End);
+
+        await context.Response.StartAsync();
+
+        var helloWorldResponse = Encoding.UTF8.GetBytes("Hello World");
+
+        var memory = context.Response.BodyPipe.GetMemory();
+        helloWorldResponse.CopyTo(memory);
+        context.Response.BodyPipe.Advance(helloWorldResponse.Length);
+        await context.Response.BodyPipe.FlushAsync();
+    }
+}
+```
+
+```csharp
+public class MyTerminalMiddleware
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var helloWorldResponse = Encoding.UTF8.GetBytes("Hello World");
+
+        await context.Response.BodyPipe.WriteAsync(Encoding.UTF8.GetBytes("Hello World"));
+    }
+}
+```
+
+Benefits
+- Better performance (don't need to allocate a buffer for each read call)
+
+## StartAsync
+<xref:Microsoft.AspNetCore.Http.HttpResponse.StartAsync> is a new API on the HttpResponse. It is used to indicate that headers are unmodifiable and to run OnStarting callbacks. In 3.0-preview3, it is required to call StartAsync before using the <xref:Microsoft.AspNetCore.Http.HttpRequest.BodyPipe>, and in future releases, it will be a recommendation. When using Kestrel as a server, by calling StartAsync before using the PipeReader, it guarantees the memory returned by GetMemory will belong to Kestrel's internal <xref:System.IO.Pipelines.Pipe> rather than an external buffer.
+
+## Additional resources
+* [Introducing System.IO.Pipelines](https://devblogs.microsoft.com/dotnet/system-io-pipelines-high-performance-io-in-net/)


### PR DESCRIPTION
Fixes #11120 

@guardrex @tdykstra this is still a WIP (using the new draft feature 😄) but I wanted to get some advice on how to portray this. 

The goal of this doc is to show how a user can Read from the HttpRequest and Write to the HttpResponse. In 3.0, we are exposing a new property, BodyPipe, on both the HttpRequest and Response, which implements https://docs.microsoft.com/en-us/dotnet/api/system.io.pipelines.pipereader?view=dotnet-plat-ext-3.0 and https://docs.microsoft.com/en-us/dotnet/api/system.io.pipelines.pipewriter?view=dotnet-plat-ext-3.0. We want to push for people to start using these properties for future request and response reading as it is more performant and writing correct pipe code is easier than stream code for request/response reading. 

So I'm thinking of having a structure where we introduce both Streams and Pipes, then talk about how to use both and their trade offs. I'm not sure if a sample is required for this scenario, but I added some code samples for how to use each. Afterwards, I added a section about StartAsync, a new API in 3.0 that is very useful for pipes. Finally I was going to talk about how interop works between them. For example, what happens to the BodyPipe when you replace the Body with another Stream? What happens to the Body when you replace the BodyPipe with another PipeReader/PipeWriter?

We are also planning on exposing Pipes in a few other places across our stack, but those are less important.

Does this organizationally sound okay? Does fundamentals sound like the right place to put this?