### PR TITLE
Add more ANCM startup failures

### DIFF
--- a/aspnetcore/host-and-deploy/azure-iis-errors-reference.md
+++ b/aspnetcore/host-and-deploy/azure-iis-errors-reference.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Obtain troubleshooting advice for common errors when hosting ASP.NET Core apps on Azure Apps Service and IIS.
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/21/2019
+ms.date: 02/26/2019
 uid: host-and-deploy/azure-iis-errors-reference
 ---
 # Common errors reference for Azure App Service and IIS with ASP.NET Core
@@ -50,6 +50,28 @@ If the system doesn't have Internet access while [installing the .NET Core Hosti
 Troubleshooting:
 
 Non-OS files in the **C:\Windows\SysWOW64\inetsrv** directory aren't preserved during an OS upgrade. If the ASP.NET Core Module is installed prior to an OS upgrade and then any app pool is run in 32-bit mode after an OS upgrade, this issue is encountered. After an OS upgrade, repair the ASP.NET Core Module. See [Install the .NET Core Hosting bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). Select **Repair** when the installer is run.
+
+## Missing site extension, x86 and x64 site extensions installed, or wrong process bitness set for an Azure App
+
+* **Browser:** HTTP Error 500.0 - ANCM In-Process Handler Load Failure 
+
+* **Application Log:** Invoking hostfxr to find the inprocess request handler failed without finding any native dependencies. Could not find inprocess request handler. Captured output from invoking hostfxr: It was not possible to find any compatible framework version. The specified framework 'Microsoft.AspNetCore.App', version '{VERSION}-preview-\*' was not found. Failed to start application '/LM/W3SVC/1416782824/ROOT', ErrorCode '0x8000ffff'.
+
+* **ASP.NET Core Module stdout Log:** It was not possible to find any compatible framework version. The specified framework 'Microsoft.AspNetCore.App', version '{VERSION}-preview-\*' was not found.
+
+::: moniker range=">= aspnetcore-2.2"
+
+* **ASP.NET Core Module Debug Log:** Invoking hostfxr to find the inprocess request handler failed without finding any native dependencies. This most likely means the app is misconfigured, please check the versions of Microsoft.NetCore.App and Microsoft.AspNetCore.App that are targeted by the application and are installed on the machine. Failed HRESULT returned: 0x8000ffff. Could not find inprocess request handler. It was not possible to find any compatible framework version. The specified framework 'Microsoft.AspNetCore.App', version '{VERSION}-preview-\*' was not found.
+
+::: moniker-end
+
+Troubleshooting:
+
+If running the app on a preview runtime, install the correct site extension (x86 or x64). Restart the app. Wait several seconds for the restart to complete. For more information, see <xref:host-and-deploy/azure-apps/index#install-the-preview-site-extension>.
+
+If running the app on a preview runtime and both the x86 and x64 site extensions are installed, uninstall the [site extension](xref:host-and-deploy/azure-apps/index#install-the-preview-site-extension) that doesn't match the bitness of the app. After removing the site extension, restart the app. Wait several seconds for the restart to complete.
+
+Confirm that the app's **Platform** in **Application Settings** matches the bitness of the app.
 
 ## An x86 app is deployed but the app pool isn't enabled for 32-bit apps
 

--- a/aspnetcore/host-and-deploy/azure-iis-errors-reference.md
+++ b/aspnetcore/host-and-deploy/azure-iis-errors-reference.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Obtain troubleshooting advice for common errors when hosting ASP.NET Core apps on Azure Apps Service and IIS.
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/26/2019
+ms.date: 02/28/2019
 uid: host-and-deploy/azure-iis-errors-reference
 ---
 # Common errors reference for Azure App Service and IIS with ASP.NET Core
@@ -51,7 +51,9 @@ Troubleshooting:
 
 Non-OS files in the **C:\Windows\SysWOW64\inetsrv** directory aren't preserved during an OS upgrade. If the ASP.NET Core Module is installed prior to an OS upgrade and then any app pool is run in 32-bit mode after an OS upgrade, this issue is encountered. After an OS upgrade, repair the ASP.NET Core Module. See [Install the .NET Core Hosting bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). Select **Repair** when the installer is run.
 
-## Missing site extension, x86 and x64 site extensions installed, or wrong process bitness set for an Azure App
+## Missing site extension, 32-bit (x86) and 64-bit (x64) site extensions installed, or wrong process bitness set
+
+*Applies to apps hosted by Azure App Services.*
 
 * **Browser:** HTTP Error 500.0 - ANCM In-Process Handler Load Failure 
 
@@ -67,11 +69,20 @@ Non-OS files in the **C:\Windows\SysWOW64\inetsrv** directory aren't preserved d
 
 Troubleshooting:
 
-If running the app on a preview runtime, install the correct site extension (x86 or x64). Restart the app. Wait several seconds for the restart to complete. For more information, see <xref:host-and-deploy/azure-apps/index#install-the-preview-site-extension>.
+* If running the app on a preview runtime, install either the 32-bit (x86) **or** 64-bit (x64) site extension that matches the bitness of the app and the app's runtime version. **Don't install both extensions or multiple runtime versions of the extension.**
 
-If running the app on a preview runtime and both the x86 and x64 site extensions are installed, uninstall the [site extension](xref:host-and-deploy/azure-apps/index#install-the-preview-site-extension) that doesn't match the bitness of the app. After removing the site extension, restart the app. Wait several seconds for the restart to complete.
+  * ASP.NET Core {RUNTIME VERSION} (x86) Runtime
+  * ASP.NET Core {RUNTIME VERSION} (x64) Runtime
 
-Confirm that the app's **Platform** in **Application Settings** matches the bitness of the app.
+  Restart the app. Wait several seconds for the app to restart. 
+
+* If running the app on a preview runtime and both the 32-bit (x86) and 64-bit (x64) [site extensions](xref:host-and-deploy/azure-apps/index#install-the-preview-site-extension) are installed, uninstall the site extension that doesn't match the bitness of the app. After removing the site extension, restart the app. Wait several seconds for the app to restart.
+
+* If running the app on a preview runtime and the site extension's bitness matches that of the app, confirm that the preview site extension's *runtime version* matches the app's runtime version.
+
+* Confirm that the app's **Platform** in **Application Settings** matches the bitness of the app.
+
+For more information, see <xref:host-and-deploy/azure-apps/index#install-the-preview-site-extension>.
 
 ## An x86 app is deployed but the app pool isn't enabled for 32-bit apps
 


### PR DESCRIPTION
Fixes #10725 

> Confirm that the app's **Platform** in **Application Settings** matches the bitness of the app.

~I still haven't figured out how to recover a 32-bit app set to 64-bit in the portal and then set back to 32-bit. It doesn't seem to recover on its own by merely flipping the switch in the portal back to 32-bit and restarting the app. I show the errors from logging back over on the issue for this scenario.~

~It does recover if the x86 + x64 site extensions are present and then the x64 site extension is deleted (or the site extension is just added and then deleted and added back) ... of course, following a restart of the site.~

Checked with a fresh service this morning, and I can't repro the failure behavior. I think there is **_some combo_** of adding and subtracting site extensions and flipping the 32/64 platform setting that can lead to an unstable service, but I don't know exactly how to repro it. I was performing many service updates to characterize the behaviors for this PR **_using the same service instance_** that a normal dev under normal circumstances wouldn't be doing. Let's move on. I'm sure if their is a prob, we (or the Azure folks) will hear about it from users.