### PR TITLE
Update Redis section of dist caching

### DIFF
--- a/aspnetcore/performance/caching/distributed.md
+++ b/aspnetcore/performance/caching/distributed.md
@@ -134,8 +134,23 @@ The sample app implements <xref:Microsoft.Extensions.Caching.SqlServer.SqlServer
 
 ### Distributed Redis Cache
 
-[Redis](https://redis.io/) is an open source in-memory data store, which is often used as a distributed cache. You can use Redis locally, and you can configure an [Azure Redis Cache](https://azure.microsoft.com/services/cache/) for an Azure-hosted ASP.NET Core app. An app configures the cache implementation using a <xref:Microsoft.Extensions.Caching.Redis.RedisCache> instance (<xref:Microsoft.Extensions.DependencyInjection.RedisCacheServiceCollectionExtensions.AddDistributedRedisCache*>):
+::: moniker range=">= aspnetcore-2.2"
 
+[Redis](https://redis.io/) is an open source in-memory data store, which is often used as a distributed cache. You can use Redis locally, and you can configure an [Azure Redis Cache](https://azure.microsoft.com/services/cache/) for an Azure-hosted ASP.NET Core app. An app configures the cache implementation using a `RedisCache` instance (`AddStackExchangeRedisCache`):
+
+```csharp
+services.AddStackExchangeRedisCache(options =>
+{
+    options.Configuration = "localhost";
+    options.InstanceName = "SampleInstance";
+});
+```
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-2.2"
+
+[Redis](https://redis.io/) is an open source in-memory data store, which is often used as a distributed cache. You can use Redis locally, and you can configure an [Azure Redis Cache](https://azure.microsoft.com/services/cache/) for an Azure-hosted ASP.NET Core app. An app configures the cache implementation using a <xref:Microsoft.Extensions.Caching.Redis.RedisCache> instance (<xref:Microsoft.Extensions.DependencyInjection.RedisCacheServiceCollectionExtensions.AddDistributedRedisCache*>):
 ```csharp
 services.AddDistributedRedisCache(options =>
 {
@@ -143,6 +158,8 @@ services.AddDistributedRedisCache(options =>
     options.InstanceName = "SampleInstance";
 });
 ```
+
+::: moniker-end
 
 To install Redis on your local machine:
 


### PR DESCRIPTION
Addresses #11118 

Thanks @marekkar

@natemcmaster Need a tip .... I couldn't get API Browser links for: 

* `AddStackExchangeRedisCache`
* `RedisCache` (in the `Microsoft.Extensions.Caching.StackExchangeRedis` namespace)

They live for 2.2 ...

https://github.com/aspnet/Extensions/blob/release/2.2/src/Caching/StackExchangeRedis/src/StackExchangeRedisCacheServiceCollectionExtensions.cs#L23

https://github.com/aspnet/Extensions/blob/release/2.2/src/Caching/StackExchangeRedis/src/RedisCache.cs#L13

... and here's the 2.2 package ...

https://www.nuget.org/packages/Microsoft.Extensions.Caching.StackExchangeRedis/2.2.0

... but no :heart: from the API Browser ...

<img width="271" alt="capture2" src="https://user-images.githubusercontent.com/1622880/53467791-481f8a80-3a1d-11e9-8fce-06c9107f148d.PNG">

Is that something that someone needs to know?

I've code-fenced them into the topic, so we can proceed here without the API pages if that's what we need to do for now.