### PR TITLE
Fix glob pattern in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ Project_Readme.html
 *.user
 *.userosscache
 *.sln.docstates
-.vscode/*
+*.vscode/
 !.vscode/extensions.json
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs


### PR DESCRIPTION
Related to https://github.com/aspnet/Docs/pull/11116. Restores the original *.vscode* pattern.