### PR TITLE
Update BlazorLayoutComponent > LayoutComponentBase

### DIFF
--- a/aspnetcore/razor-components/components.md
+++ b/aspnetcore/razor-components/components.md
@@ -612,7 +612,7 @@ For example, the sample app specifies theme information (`ThemeInfo`) in one of 
 *Shared/CascadingValuesParametersLayout.cshtml*:
 
 ```cshtml
-@inherits BlazorLayoutComponent
+@inherits LayoutComponentBase
 @using BlazorSample.UIThemeClasses
 
 <div class="container-fluid">


### PR DESCRIPTION
`BlazorLayoutComponent` became `LayoutComponentBase` in ASP.NET Core preview 2 when Razor Components was extracted from Blazor.