### PR TITLE
Updated namespace usage

### DIFF
--- a/aspnetcore/razor-components/javascript-interop.md
+++ b/aspnetcore/razor-components/javascript-interop.md
@@ -172,7 +172,7 @@ window.myLib = {
 *ElementRefExtensions.cs*:
 
 ```csharp
-using Microsoft.AspNetCore.Blazor;
+using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
`using Microsoft.AspNetCore.Blazor;` is now `using Microsoft.AspNetCore.Components;` as of ASP.NET Core 3.0 preivew 2
