### PR TITLE
Java server to client streaming

### DIFF
--- a/aspnetcore/signalr/streaming.md
+++ b/aspnetcore/signalr/streaming.md
@@ -142,10 +142,11 @@ The SignalR Java client uses the `stream` method to invoke streaming methods. It
 * Arguments defined in the hub method. 
 
 ```java
-Observable<String> result = hubConnection.stream(String.class, "ExampleStreamingHubMethod", "Arg1");
-Disposable subscription = result.subscribe((item) -> {/*onNext*/ },
-        (error) -> {/*onError*/},
-        () -> {/*onCompleted*/completed.set(true);});
+hubConnection.stream(String.class, "ExampleStreamingHubMethod", "Arg1")
+    .subscribe(
+        (item) -> {/* Define your onNext handler here. */ },
+        (error) -> {/* Define your onError handler here. */},
+        () -> {/* Define your onCompleted handler here. */});
 ```
 The `stream` method on `HubConnection` returns an Observable of the stream item type. The Observable types `susbscribe` method is where you define your `onNext`,  `onError` and  `onCompleted`
 

--- a/aspnetcore/signalr/streaming.md
+++ b/aspnetcore/signalr/streaming.md
@@ -156,7 +156,4 @@ The `stream` method on `HubConnection` returns an Observable of the stream item 
 * [Hubs](xref:signalr/hubs)
 * [.NET client](xref:signalr/dotnet-client)
 * [JavaScript client](xref:signalr/javascript-client)
-::: moniker range=">= aspnetcore-3.0"
-* [Java client](xref:signalr/java-client)
-::: moniker-end
 * [Publish to Azure](xref:signalr/publish-to-azure-web-app)

--- a/aspnetcore/signalr/streaming.md
+++ b/aspnetcore/signalr/streaming.md
@@ -135,7 +135,7 @@ To end the stream from the client, call the `dispose` method on the `ISubscripti
 
 ::: moniker range=">= aspnetcore-3.0"
 ## Java client
-The SignalR Java client uses the `stream` method to invoke streaming methods. It accepts three arguments:
+The SignalR Java client uses the `stream` method to invoke streaming methods. It accepts three or more arguments:
 
 * The expected type of the stream items 
 * The name of the hub method.

--- a/aspnetcore/signalr/streaming.md
+++ b/aspnetcore/signalr/streaming.md
@@ -138,7 +138,7 @@ To end the stream from the client, call the `dispose` method on the `ISubscripti
 The SignalR Java client uses the `stream` method to invoke streaming methods. It accepts three arguments:
 
 * The expected type of the stream items 
-* The name of the hub method. In the following example we use an example server hub method.
+* The name of the hub method.
 * Arguments defined in the hub method. 
 
 ```java
@@ -148,7 +148,7 @@ hubConnection.stream(String.class, "ExampleStreamingHubMethod", "Arg1")
         (error) -> {/* Define your onError handler here. */},
         () -> {/* Define your onCompleted handler here. */});
 ```
-The `stream` method on `HubConnection` returns an Observable of the stream item type. The Observable types `susbscribe` method is where you define your `onNext`,  `onError` and  `onCompleted`
+The `stream` method on `HubConnection` returns an Observable of the stream item type. The Observable type's `subscribe` method is where you define your `onNext`,  `onError` and  `onCompleted` handlers.
 
 ::: moniker-end
 

--- a/aspnetcore/signalr/streaming.md
+++ b/aspnetcore/signalr/streaming.md
@@ -133,9 +133,30 @@ To end the stream from the client, call the `dispose` method on the `ISubscripti
 
 ::: moniker-end
 
+::: moniker range=">= aspnetcore-3.0"
+## Java client
+The SignalR Java client uses the `stream` method to invoke streaming methods. It accepts three arguments:
+
+* The expected type of the stream items 
+* The name of the hub method. In the following example we use an example server hub method.
+* Arguments defined in the hub method. 
+
+```java
+Observable<String> result = hubConnection.stream(String.class, "ExampleStreamingHubMethod", "Arg1");
+Disposable subscription = result.subscribe((item) -> {/*onNext*/ },
+        (error) -> {/*onError*/},
+        () -> {/*onCompleted*/completed.set(true);});
+```
+The `stream` method on `HubConnection` returns an Observable of the stream item type. The Observable types `susbscribe` method is where you define your `onNext`,  `onError` and  `onCompleted`
+
+::: moniker-end
+
 ## Related resources
 
 * [Hubs](xref:signalr/hubs)
 * [.NET client](xref:signalr/dotnet-client)
 * [JavaScript client](xref:signalr/javascript-client)
+::: moniker range=">= aspnetcore-3.0"
+* [Java client](xref:signalr/java-client)
+::: moniker-end
 * [Publish to Azure](xref:signalr/publish-to-azure-web-app)


### PR DESCRIPTION
Fixes: #9771 
Adding a section on the `hubConnection.stream` api for the java client

[Internal review link](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/streaming?view=aspnetcore-2.1&branch=pr-en-us-11227)