### PR TITLE
Moved PMC commands warning

### DIFF
--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -141,10 +141,6 @@ The *appsettings.json* file is updated with the connection string used to connec
 
 ---
 
-The preceding commands generate the following warning: "No type was specified for the decimal column 'Price' on entity type 'Movie'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()'."
-
-You can ignore that warning, it will be fixed in a later tutorial.
-
 The scaffold process creates and updates the following files:
 
 ### Files created
@@ -198,6 +194,10 @@ Update-Database
 
 ---  
 <!-- End of VS tabs -->
+
+The preceding commands generate the following warning: "No type was specified for the decimal column 'Price' on entity type 'Movie'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()'."
+
+You can ignore that warning, it will be fixed in a later tutorial.
 
 The `ef migrations add InitialCreate` command generates code to create the initial database schema. The schema is based on the model specified in the `DbContext` (In the *RazorPagesMovieContext.cs* file). The `InitialCreate` argument is used to name the migrations. Any name can be used, but by convention a name is selected that describes the migration.
 


### PR DESCRIPTION
Moved the PMC commands warning "The preceding commands generate the following warning..." to align with the section it is referring to.  It was presented too early in the topic.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->