### PR TITLE
Update for 64-bit

### DIFF
--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn how to diagnose problems with ASP.NET Core Azure App Service deployments.
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/04/2019
+ms.date: 03/05/2019
 uid: host-and-deploy/azure-apps/troubleshoot
 ---
 # Troubleshoot ASP.NET Core on Azure App Service
@@ -70,10 +70,10 @@ Many startup errors don't produce useful information in the Application Event Lo
 
 ##### Current release
 
-1. Open the folders to the path **site** > **wwwroot**.
-1. In the console, run the app:
-   * If the app is a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd), run the app's assembly with `dotnet .\{ASSEMBLY NAME}.dll`.
-   * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app's executable with `{ASSEMBLY NAME}.exe`.
+1. Execute `cd d:\home\site\wwwroot`.
+1. Run the app:
+   * If the app is a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd), run the app with `dotnet .\{ASSEMBLY NAME}.dll`.
+   * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app with `{ASSEMBLY NAME}.exe`.
    
 The console output from the app, showing any errors, is piped to the Kudu console.
    
@@ -88,10 +88,23 @@ The console output from the app, showing any errors, is piped to the Kudu consol
 
 #### Test a 64-bit (x64) app
 
+##### Current release
+
 * If the app is a 64-bit (x64) [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd):
-  1. In the console, execute `cd D:\Program Files\dotnet` when running on the current release. When running on a preview release with the ASP.NET Core {VERSION} (x64) Runtime site extension installed, execute `cd D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.x64`, where `{X.Y}` is the runtime version.
-  1. Run the app: `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`.
-* If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app's executable with `{ASSEMBLY NAME}.exe` from the `\home\site\wwwroot` directory.
+  1. Execute `cd D:\Program Files\dotnet`.
+  1. Run the app with `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`.
+* If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd):
+  1. Execute `cd D:\home\site\wwwroot`.
+  1. Run the app with `{ASSEMBLY NAME}.exe`.
+
+The console output from the app, showing any errors, is piped to the Kudu console.
+
+##### Framework-depdendent deployment running on a preview release
+
+*Requires installation of the the ASP.NET Core {VERSION} (x64) Runtime site extension.*
+
+1. Execute `cd D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.x64`, where `{X.Y}` is the runtime version.
+1. Run the app: `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`.
 
 The console output from the app, showing any errors, is piped to the Kudu console.
 

--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -78,7 +78,7 @@ The console output from the app, showing any errors, is piped to the Kudu consol
 #### Test a 64-bit (x64) app
 
 * If the app is a 64-bit (x64) [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd):
-  1. In the console, execute `cd D:\Program Files\dotnet`.
+  1. In the console, execute `cd D:\Program Files\dotnet` when running on the current release. When running on a preview release with the 64-bit site extension installed, execute `cd D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.x64`, where `{X.Y}` is the runtime version.
   1. Run the app: `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`.
 * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app's executable with `{ASSEMBLY NAME}.exe`.
 

--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -70,19 +70,27 @@ Many startup errors don't produce useful information in the Application Event Lo
 
 ##### Current release
 
-1. Execute `cd d:\home\site\wwwroot`.
+1. `cd d:\home\site\wwwroot`
 1. Run the app:
-   * If the app is a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd), run the app with `dotnet .\{ASSEMBLY NAME}.dll`.
-   * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app with `{ASSEMBLY NAME}.exe`.
+   * If the app is a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd):
+
+     ```console
+     dotnet .\{ASSEMBLY NAME}.dll
+     ```
+   * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd):
+
+     ```console
+     {ASSEMBLY NAME}.exe`
+     ```
    
 The console output from the app, showing any errors, is piped to the Kudu console.
    
 ##### Framework-depdendent deployment running on a preview release
 
-*Requires installation of the the ASP.NET Core {VERSION} (x86) Runtime site extension.*
+*Requires installing the ASP.NET Core {VERSION} (x86) Runtime site extension.*
 
-1. Execute `cd D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.x32`, where `{X.Y}` is the runtime version.
-1. Run the app: `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`.
+1. `cd D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.x32` (`{X.Y}` is the runtime version)
+1. Run the app: `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`
 
 The console output from the app, showing any errors, is piped to the Kudu console.
 
@@ -91,20 +99,20 @@ The console output from the app, showing any errors, is piped to the Kudu consol
 ##### Current release
 
 * If the app is a 64-bit (x64) [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd):
-  1. Execute `cd D:\Program Files\dotnet`.
-  1. Run the app with `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`.
+  1. `cd D:\Program Files\dotnet`
+  1. Run the app: `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`
 * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd):
-  1. Execute `cd D:\home\site\wwwroot`.
-  1. Run the app with `{ASSEMBLY NAME}.exe`.
+  1. `cd D:\home\site\wwwroot`
+  1. Run the app: `{ASSEMBLY NAME}.exe`
 
 The console output from the app, showing any errors, is piped to the Kudu console.
 
 ##### Framework-depdendent deployment running on a preview release
 
-*Requires installation of the the ASP.NET Core {VERSION} (x64) Runtime site extension.*
+*Requires installing the ASP.NET Core {VERSION} (x64) Runtime site extension.*
 
-1. Execute `cd D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.x64`, where `{X.Y}` is the runtime version.
-1. Run the app: `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`.
+1. `cd D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.x64` (`{X.Y}` is the runtime version)
+1. Run the app: `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`
 
 The console output from the app, showing any errors, is piped to the Kudu console.
 

--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -71,6 +71,11 @@ Many startup errors don't produce useful information in the Application Event Lo
    * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app's executable. In the following command, substitute the name of the app's assembly for `<assembly_name>`: `<assembly_name>.exe`
 1. The console output from the app, showing any errors, is piped to the Kudu console.
 
+If you're testing a 64-bit framework-dependent deployment, you'll need to use dotnet.exe located in the **d:\Program Files\dotnet** directory. To do that:
+
+1. Enter `cd \Program Files\dotnet` to change into the directory containing the 64-bit version of dotnet.exe.
+1. In the console, run the app by executing the app's assembly using the following command and subtituting the name of the app's assembly for `<assembly_name>`: `dotnet \home\site\wwwroot\<assembly_name>.dll`
+
 ### ASP.NET Core Module stdout log
 
 The ASP.NET Core Module stdout log often records useful error messages not found in the Application Event Log. To enable and view stdout logs:

--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -89,7 +89,7 @@ The console output from the app, showing any errors, is piped to the Kudu consol
 #### Test a 64-bit (x64) app
 
 * If the app is a 64-bit (x64) [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd):
-  1. In the console, execute `cd D:\Program Files\dotnet` when running on the current release. When running on a preview release with the 64-bit site extension installed, execute `cd D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.x64`, where `{X.Y}` is the runtime version.
+  1. In the console, execute `cd D:\Program Files\dotnet` when running on the current release. When running on a preview release with the ASP.NET Core {VERSION} (x64) Runtime site extension installed, execute `cd D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.x64`, where `{X.Y}` is the runtime version.
   1. Run the app: `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`.
 * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app's executable with `{ASSEMBLY NAME}.exe`.
 

--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn how to diagnose problems with ASP.NET Core Azure App Service deployments.
 ms.author: riande
 ms.custom: mvc
-ms.date: 01/11/2019
+ms.date: 03/02/2019
 uid: host-and-deploy/azure-apps/troubleshoot
 ---
 # Troubleshoot ASP.NET Core on Azure App Service
@@ -65,16 +65,22 @@ Many startup errors don't produce useful information in the Application Event Lo
 
 1. Open **Advanced Tools** in the **Development Tools** area. Select the **Go&rarr;** button. The Kudu console opens in a new browser tab or window.
 1. Using the navigation bar at the top of the page, open **Debug console** and select **CMD**.
+
+#### Test a 32-bit (x86) app
+
 1. Open the folders to the path **site** > **wwwroot**.
 1. In the console, run the app by executing the app's assembly.
-   * If the app is a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd), run the app's assembly with *dotnet.exe*. In the following command, substitute the name of the app's assembly for `<assembly_name>`: `dotnet .\<assembly_name>.dll`
-   * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app's executable. In the following command, substitute the name of the app's assembly for `<assembly_name>`: `<assembly_name>.exe`
+   * If the app is a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd), run the app's assembly with `dotnet .\{ASSEMBLY NAME}.dll`.
+   * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app's executable with `{ASSEMBLY NAME}.exe`.
 1. The console output from the app, showing any errors, is piped to the Kudu console.
 
-If you're testing a 64-bit framework-dependent deployment, you'll need to use dotnet.exe located in the **d:\Program Files\dotnet** directory. To do that:
+#### Test a 64-bit (x64) app
 
-1. Enter `cd \Program Files\dotnet` to change into the directory containing the 64-bit version of dotnet.exe.
-1. In the console, run the app by executing the app's assembly using the following command and subtituting the name of the app's assembly for `<assembly_name>`: `dotnet \home\site\wwwroot\<assembly_name>.dll`
+* If the app is a 64-bit (x64) [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd), run the app using the 64-bit *dotnet.exe* located in the `D:\Program Files\dotnet` directory:
+  1. In the console, execute `cd \Program Files\dotnet` to change directories.
+  1. Run the app by executing the app's assembly with `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`.
+  1. The console output from the app, showing any errors, is piped to the Kudu console.
+* If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app's executable with `{ASSEMBLY NAME}.exe`.
 
 ### ASP.NET Core Module stdout log
 

--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -91,7 +91,7 @@ The console output from the app, showing any errors, is piped to the Kudu consol
 * If the app is a 64-bit (x64) [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd):
   1. In the console, execute `cd D:\Program Files\dotnet` when running on the current release. When running on a preview release with the ASP.NET Core {VERSION} (x64) Runtime site extension installed, execute `cd D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.x64`, where `{X.Y}` is the runtime version.
   1. Run the app: `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`.
-* If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app's executable with `{ASSEMBLY NAME}.exe`.
+* If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app's executable with `{ASSEMBLY NAME}.exe` from the `\home\site\wwwroot` directory.
 
 The console output from the app, showing any errors, is piped to the Kudu console.
 

--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -80,7 +80,7 @@ Many startup errors don't produce useful information in the Application Event Lo
    * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd):
 
      ```console
-     {ASSEMBLY NAME}.exe`
+     {ASSEMBLY NAME}.exe
      ```
    
 The console output from the app, showing any errors, is piped to the Kudu console.

--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn how to diagnose problems with ASP.NET Core Azure App Service deployments.
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/02/2019
+ms.date: 03/04/2019
 uid: host-and-deploy/azure-apps/troubleshoot
 ---
 # Troubleshoot ASP.NET Core on Azure App Service
@@ -69,18 +69,20 @@ Many startup errors don't produce useful information in the Application Event Lo
 #### Test a 32-bit (x86) app
 
 1. Open the folders to the path **site** > **wwwroot**.
-1. In the console, run the app by executing the app's assembly.
+1. In the console, run the app:
    * If the app is a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd), run the app's assembly with `dotnet .\{ASSEMBLY NAME}.dll`.
    * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app's executable with `{ASSEMBLY NAME}.exe`.
-1. The console output from the app, showing any errors, is piped to the Kudu console.
+
+The console output from the app, showing any errors, is piped to the Kudu console.
 
 #### Test a 64-bit (x64) app
 
-* If the app is a 64-bit (x64) [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd), run the app using the 64-bit *dotnet.exe* located in the `D:\Program Files\dotnet` directory:
-  1. In the console, execute `cd \Program Files\dotnet` to change directories.
-  1. Run the app by executing the app's assembly with `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`.
-  1. The console output from the app, showing any errors, is piped to the Kudu console.
+* If the app is a 64-bit (x64) [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd):
+  1. In the console, execute `cd D:\Program Files\dotnet`.
+  1. Run the app: `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`.
 * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app's executable with `{ASSEMBLY NAME}.exe`.
+
+The console output from the app, showing any errors, is piped to the Kudu console.
 
 ### ASP.NET Core Module stdout log
 

--- a/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
+++ b/aspnetcore/host-and-deploy/azure-apps/troubleshoot.md
@@ -68,10 +68,21 @@ Many startup errors don't produce useful information in the Application Event Lo
 
 #### Test a 32-bit (x86) app
 
+##### Current release
+
 1. Open the folders to the path **site** > **wwwroot**.
 1. In the console, run the app:
    * If the app is a [framework-dependent deployment](/dotnet/core/deploying/#framework-dependent-deployments-fdd), run the app's assembly with `dotnet .\{ASSEMBLY NAME}.dll`.
    * If the app is a [self-contained deployment](/dotnet/core/deploying/#self-contained-deployments-scd), run the app's executable with `{ASSEMBLY NAME}.exe`.
+   
+The console output from the app, showing any errors, is piped to the Kudu console.
+   
+##### Framework-depdendent deployment running on a preview release
+
+*Requires installation of the the ASP.NET Core {VERSION} (x86) Runtime site extension.*
+
+1. Execute `cd D:\home\SiteExtensions\AspNetCoreRuntime.{X.Y}.x32`, where `{X.Y}` is the runtime version.
+1. Run the app: `dotnet \home\site\wwwroot\{ASSEMBLY NAME}.dll`.
 
 The console output from the app, showing any errors, is piped to the Kudu console.
 


### PR DESCRIPTION
Added info on how you can start a 64-bit app using the 64-bit version of dotnet.exe.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->