### PR TITLE
Migration section on runtime comp

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -111,4 +111,4 @@ If you call `AddJsonProtocol`, replace it with `AddNewtonsoftJsonProtocol`.
   
 ## Opt in to runtime compilation
   
-In 3.0, runtime compilation is an opt-in scenario. To enable runtime compilation, see <xref:core/mvc/views/view-compilation#runtime-compilation>.
+In 3.0, runtime compilation is an opt-in scenario. To enable runtime compilation, see <xref:mvc/views/view-compilation#runtime-compilation>.

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -4,7 +4,7 @@ author: tdykstra
 description: Learn how to migrate an ASP.NET Core 2.2 project to ASP.NET Core 3.0.
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 01/04/2019
+ms.date: 03/02/2019
 uid: migration/22-to-30
 ---
 # Migrate from ASP.NET Core 2.2 to 3.0 Preview 2
@@ -72,9 +72,7 @@ The following code shows the ASP.NET Core 2.2 template-generated `Program` class
 
 <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> remains in 3.0 and is the type of the `webBuilder` seen in the preceding code sample. <xref:Microsoft.AspNetCore.Hosting.WebHostBuilder> will be deprecated in a future release and replaced by `HostBuilder`.
 
-## Moving from WebHostBuilder to HostBuilder
-
-The most significant change from `WebHostBuilder` to `HostBuilder` is in [dependency injection (DI)](xref:fundamentals/dependency-injection). When using `HostBuilder`, you can only inject <xref:Microsoft.Extensions.Configuration.IConfiguration> and <xref:Microsoft.AspNetCore.Hosting.IHostingEnvironment> into Startup's constructor. The `HostBuilder` DI constraints:
+The most significant change from `WebHostBuilder` to `HostBuilder` is in [dependency injection (DI)](xref:fundamentals/dependency-injection). When using `HostBuilder`, you can only inject <xref:Microsoft.Extensions.Configuration.IConfiguration> and <xref:Microsoft.AspNetCore.Hosting.IHostingEnvironment> into `Startup`'s constructor. The `HostBuilder` DI constraints:
 
 * Enable the DI container to be built only one time.
 * Avoids the resulting object lifetime issues like resolving multiple instances of singletons.
@@ -110,3 +108,7 @@ If you call `AddJsonProtocol`, replace it with `AddNewtonsoftJsonProtocol`.
       .AddNewtonsoftJsonProtocol(...) // 3.0
       .Build()
   ```
+  
+## Opt in to runtime compilation
+  
+In 3.0, runtime compilation is an opt-in scenario. To enable runtime compilation, see <xref:core/mvc/views/view-compilation#runtime-compilation>.

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -5,7 +5,7 @@ description: Learn how compilation of Razor files occurs in an ASP.NET Core app.
 monikerRange: '>= aspnetcore-1.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/13/2019
+ms.date: 03/02/2019
 uid: mvc/views/view-compilation
 ---
 # Razor file compilation in ASP.NET Core
@@ -32,7 +32,7 @@ A Razor file is compiled at runtime, when the associated Razor Page or MVC view 
 
 ::: moniker range=">= aspnetcore-3.0"
 
-Razor files are compiled at both build and publish time using the [Razor SDK](xref:razor-pages/sdk). Runtime compilation may be optionally enabled by configuring your application
+Razor files are compiled at both build and publish time using the [Razor SDK](xref:razor-pages/sdk). Runtime compilation may be optionally enabled by configuring your application.
 
 ::: moniker-end
 
@@ -87,7 +87,7 @@ Prepare the app for a [framework-dependent deployment](/dotnet/core/deploying/#f
 dotnet publish -c Release
 ```
 
-A *<project_name>.PrecompiledViews.dll* file, containing the compiled Razor files, is produced when precompilation succeeds. For example, the screenshot below depicts the contents of *Index.cshtml* within *WebApplication1.PrecompiledViews.dll*:
+A *\<project_name>.PrecompiledViews.dll* file, containing the compiled Razor files, is produced when precompilation succeeds. For example, the screenshot below depicts the contents of *Index.cshtml* within *WebApplication1.PrecompiledViews.dll*:
 
 ![Razor views inside DLL](view-compilation/_static/razor-views-in-dll.png)
 
@@ -116,18 +116,19 @@ For guidance and examples of setting the app's compatibility version, see <xref:
 
 ::: moniker range=">= aspnetcore-3.0"
 
-Runtime compilation is enabled using the `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` package. To enable runtime compilation, apps must
+Runtime compilation is enabled using the `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` package. To enable runtime compilation, apps must:
 
-* install the [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/) NuGet package.
+* Install the [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/) NuGet package.
 * Update the application's `ConfigureServices` to include a call to `AddMvcRazorRuntimeCompilation`:
 
-```csharp
-services
-    .AddMvc()
-    .AddMvcRazorRuntimeCompilation()
-```
+  ```csharp
+  services
+      .AddMvc()
+      .AddMvcRazorRuntimeCompilation()
+  ```
 
 For runtime compilation to work when deployed, apps must additionally modify their project files to set the `PreserveCompilationReferences` to `true`.
+
 [!code-xml[](view-compilation/sample/RuntimeCompilation.csproj?highlight=3)]
 
 ::: moniker-end


### PR DESCRIPTION
Fixes #11232

This heading ...

> \#\# Moving from WebHostBuilder to HostBuilder

... didn't seem to make sense because the prior section is addressing the same migration aspect. These two sections were probably added at different times (guessing), which would explain the (accidental) appearance of both.

I see a handful of little super-nits in the view comp file beyond the few that I touch here (mostly punctuation on this PR), but I'll leave those unless you want me to edit the file.