### PR TITLE
Duplicate ToC  nodes for tutorial series

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -142,8 +142,8 @@
               uid: data/ef-mvc/inheritance
             - name: Advanced topics
               uid: data/ef-mvc/advanced
-  - name: Fundamentals
-    items: 
+- name: Fundamentals
+  items: 
     - name: Overview
       uid: fundamentals/index
     - name: The Startup class

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -46,7 +46,7 @@
               uid: tutorials/razor-pages/model
             - name: Scaffolding
               uid: tutorials/razor-pages/page
-            - name: Work with a DB
+            - name: Work with a database
               uid: tutorials/razor-pages/sql
             - name: Update the pages
               uid: tutorials/razor-pages/da1
@@ -58,8 +58,30 @@
               uid: tutorials/razor-pages/validation
         - name: MVC
           displayName: tutorial
-          uid: tutorials/first-mvc-app/index
-    - name: Real-time web apps
+          items: 
+            - name: Overview
+              uid: tutorials/first-mvc-app/index
+            - name: Get started
+              uid: tutorials/first-mvc-app/start-mvc
+            - name: Add a controller
+              uid: tutorials/first-mvc-app/adding-controller
+            - name: Add a view
+              uid: tutorials/first-mvc-app/adding-view
+            - name: Add a model
+              uid: tutorials/first-mvc-app/adding-model
+            - name: Work with a database
+              uid: tutorials/first-mvc-app/working-with-sql
+            - name: Controller actions and views
+              uid: tutorials/first-mvc-app/controller-methods-views
+            - name: Add search
+              uid: tutorials/first-mvc-app/search
+            - name: Add a new field
+              uid: tutorials/first-mvc-app/new-field
+            - name: Add validation
+              uid: tutorials/first-mvc-app/validation
+            - name: Examine the Details and Delete methods
+              uid: tutorials/first-mvc-app/details
+          - name: Real-time web apps
       items: 
         - name: SignalR with JavaScript
           displayName: tutorial
@@ -71,17 +93,57 @@
       items: 
         - name: EF Core with Razor Pages
           displayName: tutorial
-          uid: data/ef-rp/index
-        - name: EF Core with MVC, existing DB
+          items: 
+            - name: Overview
+              uid: data/ef-rp/index
+            - name: Get started
+              uid: data/ef-rp/intro
+            - name: Create, Read, Update, and Delete
+              uid: data/ef-rp/crud
+            - name: Sort, filter, page, and group
+              uid: data/ef-rp/sort-filter-page
+            - name: Migrations
+              uid: data/ef-rp/migrations
+            - name: Create a complex data model
+              uid: data/ef-rp/complex-data-model
+            - name: Read related data
+              uid: data/ef-rp/read-related-data
+            - name: Update related data
+              uid: data/ef-rp/update-related-data
+            - name: Handle concurrency conflicts
+              uid: data/ef-rp/concurrency
+        - name: EF Core with MVC, existing database
           displayName: tutorial
           href: /ef/core/get-started/aspnetcore/existing-db
-        - name: EF Core with MVC, new DB
+        - name: EF Core with MVC, new database
           displayName: tutorial
           href: /ef/core/get-started/aspnetcore/new-db
-        - name: EF Core with MVC, long tutorial
-          uid: data/ef-mvc/index
-- name: Fundamentals
-  items: 
+        - name: EF Core with MVC, 10 tutorials
+          items: 
+            - name: Overview
+              uid: data/ef-mvc/index
+            - name: Get started
+              uid: data/ef-mvc/intro
+            - name: Create, Read, Update, and Delete
+              uid: data/ef-mvc/crud
+            - name: Sort, filter, page, and group
+              uid: data/ef-mvc/sort-filter-page
+            - name: Migrations
+              uid: data/ef-mvc/migrations
+            - name: Create a complex data model
+              uid: data/ef-mvc/complex-data-model
+            - name: Read related data
+              uid: data/ef-mvc/read-related-data
+            - name: Update related data
+              uid: data/ef-mvc/update-related-data
+            - name: Handle concurrency conflicts
+              uid: data/ef-mvc/concurrency
+            - name: Inheritance
+              uid: data/ef-mvc/inheritance
+            - name: Advanced topics
+              uid: data/ef-mvc/advanced
+  - name: Fundamentals
+    items: 
     - name: Overview
       uid: fundamentals/index
     - name: The Startup class
@@ -131,7 +193,7 @@
               uid: tutorials/razor-pages/model
             - name: Scaffolding
               uid: tutorials/razor-pages/page
-            - name: Work with a DB
+            - name: Work with a database
               uid: tutorials/razor-pages/sql
             - name: Update the pages
               uid: tutorials/razor-pages/da1
@@ -166,7 +228,7 @@
               uid: tutorials/first-mvc-app/adding-view
             - name: Add a model
               uid: tutorials/first-mvc-app/adding-model
-            - name: Work with a DB
+            - name: Work with a database
               uid: tutorials/first-mvc-app/working-with-sql
             - name: Controller actions and views
               uid: tutorials/first-mvc-app/controller-methods-views
@@ -430,11 +492,11 @@
               uid: data/ef-rp/update-related-data
             - name: Handle concurrency conflicts
               uid: data/ef-rp/concurrency
-        - name: EF Core with MVC, new DB
+        - name: EF Core with MVC, new database
           href: /ef/core/get-started/aspnetcore/new-db
-        - name: EF Core with MVC, existing DB
+        - name: EF Core with MVC, existing database
           href: /ef/core/get-started/aspnetcore/existing-db
-        - name: EF Core with MVC, long tutorial
+        - name: EF Core with MVC, 10 tutorials
           items: 
             - name: Overview
               uid: data/ef-mvc/index

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -37,7 +37,25 @@
       items: 
         - name: Razor Pages
           displayName: tutorial
-          uid: tutorials/razor-pages/index
+          items: 
+            - name: Overview
+              uid: tutorials/razor-pages/index
+            - name: Get started
+              uid: tutorials/razor-pages/razor-pages-start
+            - name: Add a model
+              uid: tutorials/razor-pages/model
+            - name: Scaffolding
+              uid: tutorials/razor-pages/page
+            - name: Work with a DB
+              uid: tutorials/razor-pages/sql
+            - name: Update the pages
+              uid: tutorials/razor-pages/da1
+            - name: Add search
+              uid: tutorials/razor-pages/search
+            - name: Add a new field
+              uid: tutorials/razor-pages/new-field
+            - name: Add validation
+              uid: tutorials/razor-pages/validation
         - name: MVC
           displayName: tutorial
           uid: tutorials/first-mvc-app/index

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -81,7 +81,7 @@
               uid: tutorials/first-mvc-app/validation
             - name: Examine the Details and Delete methods
               uid: tutorials/first-mvc-app/details
-          - name: Real-time web apps
+    - name: Real-time web apps
       items: 
         - name: SignalR with JavaScript
           displayName: tutorial


### PR DESCRIPTION
Fixes #10207

[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/razor-pages-start?view=aspnetcore-2.2&branch=pr-en-us-11293&tabs=visual-studio)

@Rick-Anderson @scottaddie @wadepickett I've implemented this for one series -- all tutorials in the RP Intro series are duplicated under the Tutorials top-level node and the subject area top-level node (Web apps).  When you click on a link in the ToC, only the node you clicked on is highlighted, but when you get to one of these tutorials some other way, like clicking Next or Previous buttons, the same tutorial in both places in the ToC is highlighted.  Since you'd normally be using Next/Previous in a series, most of the time you'd see two nodes highlighted, which is not ideal.  Is it worth putting up with this behavior to make the individual tutorials more discoverable in the ToC?