### PR TITLE
How to make session cookies essential/GDPR

### DIFF
--- a/aspnetcore/security/gdpr.md
+++ b/aspnetcore/security/gdpr.md
@@ -69,7 +69,9 @@ The [Tempdata provider](xref:fundamentals/app-state#tempdata) cookie isn't essen
 
 [!code-csharp[Main](gdpr/sample/RP/Startup.cs?name=snippet1)]
 
-[Session state](xref:fundamentals/app-state) cookies are not essential. Session state isn't functional when tracking is disabled.
+[Session state](xref:fundamentals/app-state) cookies are not essential. Session state isn't functional when tracking is disabled. The following code makes session cookies essential:
+
+[!code-csharp[Main](gdpr/sample/RP/Startup.cs?name=snippet2)]
 
 <a name="pd"></a>
 

--- a/aspnetcore/security/gdpr.md
+++ b/aspnetcore/security/gdpr.md
@@ -71,7 +71,7 @@ The [Tempdata provider](xref:fundamentals/app-state#tempdata) cookie isn't essen
 
 [Session state](xref:fundamentals/app-state) cookies are not essential. Session state isn't functional when tracking is disabled. The following code makes session cookies essential:
 
-[!code-csharp[Main](gdpr/sample/RP/Startup.cs?name=snippet2)]
+[!code-csharp[](gdpr/sample/RP/Startup.cs?name=snippet2)]
 
 <a name="pd"></a>
 

--- a/aspnetcore/security/gdpr/sample/RP/Startup.cs
+++ b/aspnetcore/security/gdpr/sample/RP/Startup.cs
@@ -41,6 +41,13 @@ namespace RPCC
             });
             #endregion
 
+            #region snippet2
+            services.AddSession(options =>
+            {
+                options.Cookie.IsEssential = true;
+            });
+            #endregion
+
             services.AddDbContext<ApplicationDbContext>(options =>
                 options.UseSqlServer(
                     Configuration.GetConnectionString("DefaultConnection")));


### PR DESCRIPTION
Fixes #11088 
[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/security/gdpr?view=aspnetcore-2.1&branch=pr-en-us-11306#tempdata-provider-and-session-state-cookies-are-not-essential)