### PR TITLE
Razor Components Preview3/JS interop updates

### DIFF
--- a/aspnetcore/client-side/spa/blazor/get-started.md
+++ b/aspnetcore/client-side/spa/blazor/get-started.md
@@ -26,7 +26,7 @@ To create your first Blazor project in Visual Studio:
 1. Make the Blazor templates available for use with the .NET Core CLI by running the following command in a command shell:
 
    ```console
-   dotnet new -i Microsoft.AspNetCore.Blazor.Templates::0.8.0-preview-19104-04
+   dotnet new -i Microsoft.AspNetCore.Blazor.Templates::0.9.0-preview3-19154-02
    ```
 
 1. Select **File** > **New Project** > **Web** > **ASP.NET Core Web Application**.
@@ -91,7 +91,7 @@ Prerequisites:
 1. Add the Blazor templates by running the following command in a command shell:
 
    ```console
-   dotnet new -i Microsoft.AspNetCore.Blazor.Templates::0.8.0-preview-19104-04
+   dotnet new -i Microsoft.AspNetCore.Blazor.Templates::0.9.0-preview3-19154-02
    ```
 
 1. Create your first Blazor project in a command shell:

--- a/aspnetcore/razor-components/common/samples/3.x/BlazorSample/BlazorSample.csproj
+++ b/aspnetcore/razor-components/common/samples/3.x/BlazorSample/BlazorSample.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="0.8.0-preview-19104-04" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.8.0-preview-19104-04" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="0.9.0-preview3-19154-02" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.9.0-preview3-19154-02" PrivateAssets="all" />
 
-    <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="0.8.0-preview-19104-04" />
+    <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="0.9.0-preview3-19154-02" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/razor-components/common/samples/3.x/BlazorSample/JsInteropClasses/ExampleJsInterop.cs
+++ b/aspnetcore/razor-components/common/samples/3.x/BlazorSample/JsInteropClasses/ExampleJsInterop.cs
@@ -10,26 +10,33 @@ namespace BlazorSample.JsInteropClasses
     #region snippet1
     public class ExampleJsInterop
     {
-        public static Task<string> Prompt(string text)
+        private readonly IJSRuntime _jsRuntime;
+
+        public ExampleJsInterop(IJSRuntime jsRuntime)
+        {
+            _jsRuntime = jsRuntime;
+        }
+
+        public Task<string> Prompt(string text)
         {
             // showPrompt is implemented in wwwroot/exampleJsInterop.js
-            return JSRuntime.Current.InvokeAsync<string>(
+            return _jsRuntime.InvokeAsync<string>(
                 "exampleJsFunctions.showPrompt",
                 text);
         }
 
-        public static Task<string> Display(string welcomeMessage)
+        public Task<string> Display(string welcomeMessage)
         {
             // displayWelcome is implemented in wwwroot/exampleJsInterop.js
-            return JSRuntime.Current.InvokeAsync<string>(
+            return _jsRuntime.InvokeAsync<string>(
                 "exampleJsFunctions.displayWelcome",
                 welcomeMessage);
         }
         
-        public static Task CallHelloHelperSayHello(string name)
+        public Task CallHelloHelperSayHello(string name)
         {
             // sayHello is implemented in wwwroot/exampleJsInterop.js
-            return JSRuntime.Current.InvokeAsync<object>(
+            return _jsRuntime.InvokeAsync<object>(
                 "exampleJsFunctions.sayHello",
                 new DotNetObjectRef(new HelloHelper(name)));
         }

--- a/aspnetcore/razor-components/common/samples/3.x/BlazorSample/Pages/JSInterop.cshtml
+++ b/aspnetcore/razor-components/common/samples/3.x/BlazorSample/Pages/JSInterop.cshtml
@@ -1,6 +1,6 @@
 @page "/JSInterop"
 @using BlazorSample.JsInteropClasses
-@using Microsoft.JSInterop;
+@inject IJSRuntime JSRuntime
 
 <h1>JavaScript Interop</h1>
 
@@ -15,8 +15,9 @@
 @functions {
     public async void TriggerJsPrompt()
     {
-        var name = await ExampleJsInterop.Prompt("What's your name?");
-        await ExampleJsInterop.Display($"Hello {name}! Welcome to Blazor!");
+        var exampleJsInterop = new ExampleJsInterop(JSRuntime);
+        var name = await exampleJsInterop.Prompt("What's your name?");
+        await exampleJsInterop.Display($"Hello {name}! Welcome to Blazor!");
     }
 }
 
@@ -64,6 +65,7 @@
 @functions {
     public async void TriggerNetInstanceMethod()
     {
-        await ExampleJsInterop.CallHelloHelperSayHello("Blazor");
+        var exampleJsInterop = new ExampleJsInterop(JSRuntime);
+        await exampleJsInterop.CallHelloHelperSayHello("Blazor");
     }
 }

--- a/aspnetcore/razor-components/common/samples/3.x/BlazorSample/wwwroot/exampleJsInterop.js
+++ b/aspnetcore/razor-components/common/samples/3.x/BlazorSample/wwwroot/exampleJsInterop.js
@@ -5,12 +5,12 @@
   displayWelcome: function (welcomeMessage) {
     document.getElementById('welcome').innerText = welcomeMessage;
   },
-    returnArrayAsyncJs: function () {
-      DotNet.invokeMethodAsync('BlazorSample', 'ReturnArrayAsync')
-        .then(data => {
-          data.push(4);
-            console.log(data);
-    })
+  returnArrayAsyncJs: function () {
+    DotNet.invokeMethodAsync('BlazorSample', 'ReturnArrayAsync')
+      .then(data => {
+        data.push(4);
+          console.log(data);
+    });
   },
   sayHello: function (dotnetHelper) {
     return dotnetHelper.invokeMethodAsync('SayHello')


### PR DESCRIPTION
Fixes #11308 

[Internal Review Topic (JS Interop)](https://review.docs.microsoft.com/en-us/aspnet/core/razor-components/javascript-interop?view=aspnetcore-3.0&branch=pr-en-us-11314)

There's still a broken tutorial app (the RC one). I'll work on that separately. The tutorial text requires updates to accompany that sample's updates.

Cross-references:

* [[Discussion] Microsoft.Interop.JSRuntime.Current has been removed](https://github.com/aspnet/AspNetCore/issues/8117)
* [Reconsider static JSRuntime.Current](https://github.com/aspnet/AspNetCore/issues/6828)