### PR TITLE
Contextual ToC updates

### DIFF
--- a/aspnetcore/breadcrumb/TOC.yml
+++ b/aspnetcore/breadcrumb/TOC.yml
@@ -33,22 +33,16 @@
   topicHref: /aspnet/index#pivot=core
   items:
     - name: ASP.NET Core
-      tocHref: /azure/applicationinsights/
-      topicHref: /aspnet/core/index
-    - name: ASP.NET Core
       tocHref: /azure/visual-studio/
       topicHref: /aspnet/core/index
     - name: ASP.NET Core
       tocHref: /azure/devops/
       topicHref: /aspnet/core/index
     - name: ASP.NET Core
-      tocHref: /azure/app-service/
-      topicHref: /aspnet/core/index
-    - name: ASP.NET Core
-      tocHref: /azure/devops/
-      topicHref: /aspnet/core/index
-    - name: ASP.NET Core
       tocHref: /azure/devops/pipelines
+      topicHref: /aspnet/core/index
+    - name: ASP.NET Core
+      tocHref: /azure/app-service/
       topicHref: /aspnet/core/index
     - name: ASP.NET Core
       tocHref: /azure/signalr/

--- a/aspnetcore/breadcrumb/TOC.yml
+++ b/aspnetcore/breadcrumb/TOC.yml
@@ -53,3 +53,9 @@
     - name: ASP.NET Core
       tocHref: /azure/signalr/
       topicHref: /aspnet/core/index
+    - name: ASP.NET Core
+      tocHref: /azure/azure-monitor/
+      topicHref: /aspnet/core/index
+    - name: ASP.NET Core
+      tocHref: /azure/azure-monitor/app/
+      topicHref: /aspnet/core/index

--- a/aspnetcore/breadcrumb/TOC.yml
+++ b/aspnetcore/breadcrumb/TOC.yml
@@ -38,3 +38,18 @@
     - name: ASP.NET Core
       tocHref: /azure/visual-studio/
       topicHref: /aspnet/core/index
+    - name: ASP.NET Core
+      tocHref: /azure/devops/
+      topicHref: /aspnet/core/index
+    - name: ASP.NET Core
+      tocHref: /azure/app-service/
+      topicHref: /aspnet/core/index
+    - name: ASP.NET Core
+      tocHref: /azure/devops/
+      topicHref: /aspnet/core/index
+    - name: ASP.NET Core
+      tocHref: /azure/devops/pipelines
+      topicHref: /aspnet/core/index
+    - name: ASP.NET Core
+      tocHref: /azure/signalr/
+      topicHref: /aspnet/core/index

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -7,7 +7,7 @@
     - name: Compare ASP.NET Core and ASP.NET
       uid: fundamentals/choose-between-aspnet-and-aspnetcore
     - name: Compare .NET Core and .NET Framework
-      href: /dotnet/standard/choosing-core-framework-server?toc=/aspnet/core/toc.json
+      href: /dotnet/standard/choosing-core-framework-server?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
 - name: Get started
   uid: getting-started
 - name: What's new
@@ -114,10 +114,10 @@
               uid: data/ef-rp/concurrency
         - name: EF Core with MVC, existing database
           displayName: tutorial
-          href: /ef/core/get-started/aspnetcore/existing-db?toc=/aspnet/core/toc.json
+          href: /ef/core/get-started/aspnetcore/existing-db?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
         - name: EF Core with MVC, new database
           displayName: tutorial
-          href: /ef/core/get-started/aspnetcore/new-db?toc=/aspnet/core/toc.json
+          href: /ef/core/get-started/aspnetcore/new-db?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
         - name: EF Core with MVC, 10 tutorials
           items: 
             - name: Overview
@@ -416,7 +416,7 @@
           uid: signalr/scale
         - name: Azure SignalR Service
           displayName: signalr
-          href: /azure/azure-signalr/signalr-overview?toc=/aspnet/core/toc.json
+          href: /azure/azure-signalr/signalr-overview?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
         - name: Redis backplane
           displayName: signalr
           uid: signalr/redis-backplane
@@ -449,17 +449,17 @@
 - name: Test, debug, and troubleshoot
   items: 
     - name: Unit testing
-      href: /dotnet/core/testing/unit-testing-with-dotnet-test?toc=/aspnet/core/toc.json
+      href: /dotnet/core/testing/unit-testing-with-dotnet-test?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
     - name: Razor Pages unit tests
       uid: test/razor-pages-tests
     - name: Test controllers
       uid: mvc/controllers/testing
     - name: Remote debugging
-      href: /visualstudio/debugger/remote-debugging-azure?toc=/aspnet/core/toc.json
+      href: /visualstudio/debugger/remote-debugging-azure
     - name: Snapshot debugging
-      href: /azure/application-insights/app-insights-snapshot-debugger?toc=/aspnet/core/toc.json
+      href: /azure/azure-monitor/app/snapshot-debugger?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
     - name: Snapshot debugging in Visual Studio
-      href: /visualstudio/debugger/debug-live-azure-applications?toc=/aspnet/core/toc.json
+      href: /visualstudio/debugger/debug-live-azure-applications
     - name: Integration tests
       uid: test/integration-tests
     - name: Load and stress testing
@@ -493,9 +493,9 @@
             - name: Handle concurrency conflicts
               uid: data/ef-rp/concurrency
         - name: EF Core with MVC, new database
-          href: /ef/core/get-started/aspnetcore/new-db?toc=/aspnet/core/toc.json
+          href: /ef/core/get-started/aspnetcore/new-db?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
         - name: EF Core with MVC, existing database
-          href: /ef/core/get-started/aspnetcore/existing-db?toc=/aspnet/core/toc.json
+          href: /ef/core/get-started/aspnetcore/existing-db?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
         - name: EF Core with MVC, 10 tutorials
           items: 
             - name: Overview
@@ -525,13 +525,13 @@
     - name: Azure Storage with Visual Studio
       items: 
         - name: Connected Services
-          href: /azure/vs-azure-tools-connected-services-storage?toc=/aspnet/core/toc.json
+          href: /visualstudio/azure/vs-azure-tools-connected-services-storage
         - name: Blob storage
-          href: /azure/visual-studio/vs-storage-aspnet5-getting-started-blobs?toc=/aspnet/core/toc.json
+          href: /azure/visual-studio/vs-storage-aspnet5-getting-started-blobs?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
         - name: Queue storage
-          href: /azure/visual-studio/vs-storage-aspnet5-getting-started-queues?toc=/aspnet/core/toc.json
+          href: /azure/visual-studio/vs-storage-aspnet5-getting-started-queues?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
         - name: Table storage
-          href: /azure/visual-studio/vs-storage-aspnet5-getting-started-tables?toc=/aspnet/core/toc.json
+          href: /azure/visual-studio/vs-storage-aspnet5-getting-started-tables?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
 - name: Client-side development
   items: 
     - name: Razor Components
@@ -641,16 +641,16 @@
           uid: tutorials/publish-to-azure-webapp-using-vs
         - name: Publish with Visual Studio for Mac
           displayName: azure, deploy, publish
-          href: /visualstudio/mac/publish-app-svc?toc=/aspnet/core/toc.json
+          href: /visualstudio/mac/publish-app-svc?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
         - name: Publish with CLI tools
           displayName: azure, deploy, publish
-          href: /azure/app-service/app-service-web-tutorial-dotnetcore-sqldb?toc=/aspnet/core/toc.json
+          href: /azure/app-service/app-service-web-tutorial-dotnetcore-sqldb?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
         - name: Publish with Visual Studio and Git
           displayName: azure, deploy, publish
           uid: host-and-deploy/azure-apps/azure-continuous-deployment
         - name: Continuous deployment with Azure Pipelines
           displayName: azure, deploy, publish
-          href: /azure/devops/pipelines/get-started-yaml?toc=/aspnet/core/toc.json
+          href: /azure/devops/pipelines/get-started-yaml
         - name: ASP.NET Core Module
           displayName: azure, deploy, publish
           uid: host-and-deploy/aspnet-core-module
@@ -733,7 +733,7 @@
           uid: host-and-deploy/docker/visual-studio-tools-for-docker
         - name: Publish to a Docker image
           displayName: deploy, publish, docker
-          href: /visualstudio/containers/vs-azure-tools-docker-hosting-web-apps-in-docker?toc=/aspnet/core/toc.json
+          href: /visualstudio/containers/vs-azure-tools-docker-hosting-web-apps-in-docker?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
         - name: Sample Docker images
           displayName: deploy, publish, docker
           href: https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/README.md
@@ -748,7 +748,7 @@
       uid: host-and-deploy/visual-studio-publish-profiles
     - name: Visual Studio for Mac publish to folder
       displayName: deploy, publish
-      href: /visualstudio/mac/publish-folder?toc=/aspnet/core/toc.json
+      href: /visualstudio/mac/publish-folder?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
     - name: Directory structure
       displayName: deploy, publish
       uid: host-and-deploy/directory-structure
@@ -833,7 +833,7 @@
         - name: Secure ASP.NET Core apps with IdentityServer4
           href: https://identityserver4.readthedocs.io/
         - name: Secure ASP.NET Core apps with Azure App Service authentication (Easy Auth)
-          href: /azure/app-service/app-service-authentication-overview?toc=/aspnet/core/toc.json
+          href: /azure/app-service/overview-authentication-authorization?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
         - name: Individual user accounts
           uid: security/authentication/individual
     - name: Authorization


### PR DESCRIPTION
Contextual ToC and breadcrumbs for 16 of 20 links to other docs.ms.com doc sets.

Does not work with these, so the query strings were removed from them:

* /visualstudio/debugger/remote-debugging-azure
* /visualstudio/debugger/debug-live-azure-applications
* /visualstudio/azure/vs-azure-tools-connected-services-storage
* /azure/devops/pipelines/get-started-yaml
