### PR TITLE
Drop & re-create instead of migrations for sqlite

### DIFF
--- a/aspnetcore/includes/RP-mvc-shared/sqlite-warn.md
+++ b/aspnetcore/includes/RP-mvc-shared/sqlite-warn.md
@@ -1,13 +1,15 @@
 
 > [!NOTE]
-> Many schema change operations are not supported by the EF Core SQLite provider. For example, adding a column is supported, but removing a column is not supported. If a migration is created to remove a column, the `ef migrations add` command succeeds but the `ef database update` command fails. Some of these limitations can be overcome by manually writing migrations code to perform a table rebuild. A table rebuild involves:
+> Many schema change operations are not supported by the EF Core SQLite provider. For example, adding a column is supported, but removing or changing a column is not supported. If a migration is created to remove or change a column, the `ef migrations add` command succeeds but the `ef database update` command fails. Due to these limitations, this tutorial doesn't use migrations for SQLite schema changes. Instead, when the schema changes, you drop and re-create the database.
+
+You can work around the SQLite limitations by manually writing migrations code to perform a table rebuild. A table rebuild involves:
 
 >* Renaming the existing table.
 >* Creating a new table.
 >* Copying data from the old table to the new table.
 >* Dropping the old table.
 
-For more information, see the following resources:
+This tutorial doesn't show how to do a table rebuild. For more information, see the following resources:
 > * [SQLite EF Core Database Provider Limitations](/ef/core/providers/sqlite/limitations)
 > * [Customize migration code](/ef/core/managing-schemas/migrations/#customize-migration-code)
 > * [Data seeding](/ef/core/modeling/data-seeding)

--- a/aspnetcore/includes/RP-mvc-shared/sqlite-warn.md
+++ b/aspnetcore/includes/RP-mvc-shared/sqlite-warn.md
@@ -1,15 +1,16 @@
 
 > [!NOTE]
 > For this tutorial you use the Entity Framework Core *migrations* feature where possible. Migrations updates the database schema to match changes in the data model. However, migrations can only do the kinds of changes that the EF Core provider supports, and the SQLite provider's capabilities are limited. For example, adding a column is supported, but removing or changing a column is not supported. If a migration is created to remove or change a column, the `ef migrations add` command succeeds but the `ef database update` command fails. Due to these limitations, this tutorial doesn't use migrations for SQLite schema changes. Instead, when the schema changes, you drop and re-create the database.
-
-The workaround for the SQLite limitations is to manually write migrations code to perform a table rebuild when something in the table changes. A table rebuild involves:
-
+>
+>The workaround for the SQLite limitations is to manually write migrations code to perform a table rebuild when something in the table changes. A table rebuild involves:
+>
 >* Renaming the existing table.
 >* Creating a new table.
 >* Copying data from the old table to the new table.
 >* Dropping the old table.
-
-For more information, see the following resources:
+>
+>For more information, see the following resources:
+>
 > * [SQLite EF Core Database Provider Limitations](/ef/core/providers/sqlite/limitations)
 > * [Customize migration code](/ef/core/managing-schemas/migrations/#customize-migration-code)
 > * [Data seeding](/ef/core/modeling/data-seeding)

--- a/aspnetcore/includes/RP-mvc-shared/sqlite-warn.md
+++ b/aspnetcore/includes/RP-mvc-shared/sqlite-warn.md
@@ -1,15 +1,15 @@
 
 > [!NOTE]
-> Many schema change operations are not supported by the EF Core SQLite provider. For example, adding a column is supported, but removing or changing a column is not supported. If a migration is created to remove or change a column, the `ef migrations add` command succeeds but the `ef database update` command fails. Due to these limitations, this tutorial doesn't use migrations for SQLite schema changes. Instead, when the schema changes, you drop and re-create the database.
+> For this tutorial you use the Entity Framework Core *migrations* feature where possible. Migrations updates the database schema to match changes in the data model. However, migrations can only do the kinds of changes that the EF Core provider supports, and the SQLite provider's capabilities are limited. For example, adding a column is supported, but removing or changing a column is not supported. If a migration is created to remove or change a column, the `ef migrations add` command succeeds but the `ef database update` command fails. Due to these limitations, this tutorial doesn't use migrations for SQLite schema changes. Instead, when the schema changes, you drop and re-create the database.
 
-You can work around the SQLite limitations by manually writing migrations code to perform a table rebuild. A table rebuild involves:
+The workaround for the SQLite limitations is to manually write migrations code to perform a table rebuild when something in the table changes. A table rebuild involves:
 
 >* Renaming the existing table.
 >* Creating a new table.
 >* Copying data from the old table to the new table.
 >* Dropping the old table.
 
-This tutorial doesn't show how to do a table rebuild. For more information, see the following resources:
+For more information, see the following resources:
 > * [SQLite EF Core Database Provider Limitations](/ef/core/providers/sqlite/limitations)
 > * [Customize migration code](/ef/core/managing-schemas/migrations/#customize-migration-code)
 > * [Data seeding](/ef/core/modeling/data-seeding)

--- a/aspnetcore/tutorials/first-mvc-app/new-field.md
+++ b/aspnetcore/tutorials/first-mvc-app/new-field.md
@@ -92,23 +92,22 @@ Update-Database
 
 The `Add-Migration` command tells the migration framework to examine the current `Movie` model with the current `Movie` DB schema and create the necessary code to migrate the DB to the new model.
 
+The name "Rating" is arbitrary and is used to name the migration file. It's helpful to use a meaningful name for the migration file.
+
+If all the records in the DB are deleted, the initialize method will seed the DB and include the `Rating` field.
+
 # [Visual Studio Code / Visual Studio for Mac](#tab/visual-studio-code+visual-studio-mac)
 
 [!INCLUDE[](~/includes/RP-mvc-shared/sqlite-warn.md)]
 
-Run the following command:
+Delete the database and use migrations to re-create the database. To delete the database, delete the database file (*MvcMovie.db*). Then run the `ef database update` command: 
 
-```cli
-dotnet ef migrations add Rating
+```console
 dotnet ef database update
 ```
 
 ---  
 <!-- End of VS tabs -->
-
-The name "Rating" is arbitrary and is used to name the migration file. It's helpful to use a meaningful name for the migration file.
-
-If all the records in the DB are deleted, the initialize method will seed the DB and include the `Rating` field.
 
 Run the app and verify you can create/edit/display movies with a `Rating` field. You should add the `Rating` field to the `Edit`, `Details`, and `Delete` view templates.
 

--- a/aspnetcore/tutorials/first-mvc-app/working-with-sql.md
+++ b/aspnetcore/tutorials/first-mvc-app/working-with-sql.md
@@ -63,6 +63,7 @@ Note the key icon next to `ID`. By default, EF will make a property named `ID` t
 # [Visual Studio Code / Visual Studio for Mac](#tab/visual-studio-code+visual-studio-mac)
 
 [!INCLUDE[](~/includes/rp/sqlite.md)]
+[!INCLUDE[](~/includes/RP-mvc-shared/sqlite-warn.md)]
 
 ---  
 <!-- End of VS tabs -->

--- a/aspnetcore/tutorials/razor-pages/new-field.md
+++ b/aspnetcore/tutorials/razor-pages/new-field.md
@@ -110,15 +110,15 @@ Another option is to delete the database and use migrations to re-create the dat
 <!-- Code -------------------------->
 # [Visual Studio Code / Visual Studio for Mac](#tab/visual-studio-code+visual-studio-mac)
 
-<!-- copy/paste this tab to the next. Not worth an include  -->
+### Drop and re-create the database
+
+[!INCLUDE[](~/includes/RP-mvc-shared/sqlite-warn.md)]
 
 Delete the database and use migrations to re-create the database. To delete the database, delete the database file (*MvcMovie.db*). Then run the `ef database update` command: 
 
 ```console
 dotnet ef database update
 ```
-
-[!INCLUDE[](~/includes/RP-mvc-shared/sqlite-warn.md)]
 
 ---  
 <!-- End of VS tabs -->

--- a/aspnetcore/tutorials/razor-pages/new-field.md
+++ b/aspnetcore/tutorials/razor-pages/new-field.md
@@ -112,35 +112,13 @@ Another option is to delete the database and use migrations to re-create the dat
 
 <!-- copy/paste this tab to the next. Not worth an include  -->
 
-Run the following .NET Core CLI commands:
-
-```console
-dotnet ef migrations add Rating
-dotnet ef database update
-```
-
-The `ef migrations add` command tells the framework to:
-
-* Compare the `Movie` model with the `Movie` DB schema.
-* Create code to migrate the DB schema to the new model.
-
-The name "Rating" is arbitrary and is used to name the migration file. It's helpful to use a meaningful name for the migration file.
-
-The `ef database update` command tells the framework to apply the schema changes to the database.
-
-If you delete all the records in the DB, the initializer will seed the DB and include the `Rating` field. You can do this with the delete links in the browser or by using a SQLite tool.
-
-Another option is to delete the database and use migrations to re-create the database. To delete the database, delete the database file (*MvcMovie.db*). Then run the `ef database update` command: 
+Delete the database and use migrations to re-create the database. To delete the database, delete the database file (*MvcMovie.db*). Then run the `ef database update` command: 
 
 ```console
 dotnet ef database update
 ```
 
-> [!NOTE]
-> Many schema change operations are not supported by the EF Core SQLite provider. For example, adding a column is supported, but removing a column is not supported. If you add a migration to remove a column, the `ef migrations add` command succeeds but the `ef database update` command fails. You can work around some of the limitations by manually writing migrations code to perform a table rebuild. A table rebuild involves renaming the existing table, creating a new table, copying data to the new table, and dropping the old table. For more information, see the following resources:
-> * [SQLite EF Core Database Provider Limitations](/ef/core/providers/sqlite/limitations)
-> * [Customize migration code](/ef/core/managing-schemas/migrations/#customize-migration-code)
-> * [Data seeding](/ef/core/modeling/data-seeding)
+[!INCLUDE[](~/includes/RP-mvc-shared/sqlite-warn.md)]
 
 ---  
 <!-- End of VS tabs -->

--- a/aspnetcore/tutorials/razor-pages/sql.md
+++ b/aspnetcore/tutorials/razor-pages/sql.md
@@ -88,11 +88,13 @@ Note the key icon next to `ID`. By default, EF creates a property named `ID` for
 # [Visual Studio Code](#tab/visual-studio-code)
 
 [!INCLUDE[](~/includes/rp/sqlite.md)]
+[!INCLUDE[](~/includes/RP-mvc-shared/sqlite-warn.md)]
 
 <!-- Mac -------------------------->
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 
 [!INCLUDE[](~/includes/rp/sqlite.md)]
+[!INCLUDE[](~/includes/RP-mvc-shared/sqlite-warn.md)]
 
 ---  
 <!-- End of VS tabs -->


### PR DESCRIPTION
Fixes #9991 

[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/sql?view=aspnetcore-1.0&branch=pr-en-us-11364) (use ToC to view work-with-SQL and add-field tutorials in both RP and MVC series