### PR TITLE
Add notes on using clients with Azure SignalR Service serverless mode

### DIFF
--- a/aspnetcore/signalr/dotnet-client.md
+++ b/aspnetcore/signalr/dotnet-client.md
@@ -83,4 +83,4 @@ Handle errors with a try-catch statement. Inspect the `Exception` object to dete
 * [Hubs](xref:signalr/hubs)
 * [JavaScript client](xref:signalr/javascript-client)
 * [Publish to Azure](xref:signalr/publish-to-azure-web-app)
-* [Azure SignalR Service serverless documentation](https://docs.microsoft.com/azure/azure-signalr/signalr-concept-serverless-development-config)
+* [Azure SignalR Service serverless documentation](/azure/azure-signalr/signalr-concept-serverless-development-config)

--- a/aspnetcore/signalr/dotnet-client.md
+++ b/aspnetcore/signalr/dotnet-client.md
@@ -59,6 +59,9 @@ In a `Closed` handler that restarts the connection, consider waiting for some ra
 
 [!code-csharp[InvokeAsync method](dotnet-client/sample/signalrchatclient/MainWindow.xaml.cs?name=snippet_InvokeAsync)]
 
+> [!NOTE]
+> If you are using Azure SignalR Service in *Serverless mode*, you cannot call hub methods from a client. For more information, see the [SignalR Service documentation](https://docs.microsoft.com/azure/azure-signalr/signalr-concept-serverless-development-config).
+
 ## Call client methods from hub
 
 Define methods the hub calls using `connection.On` after building, but before starting the connection.
@@ -80,3 +83,4 @@ Handle errors with a try-catch statement. Inspect the `Exception` object to dete
 * [Hubs](xref:signalr/hubs)
 * [JavaScript client](xref:signalr/javascript-client)
 * [Publish to Azure](xref:signalr/publish-to-azure-web-app)
+* [Azure SignalR Service serverless documentation](https://docs.microsoft.com/azure/azure-signalr/signalr-concept-serverless-development-config)

--- a/aspnetcore/signalr/dotnet-client.md
+++ b/aspnetcore/signalr/dotnet-client.md
@@ -5,7 +5,7 @@ description: Information about the ASP.NET Core SignalR .NET Client
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 09/10/2018
+ms.date: 03/14/2019
 uid: signalr/dotnet-client
 ---
 
@@ -60,7 +60,7 @@ In a `Closed` handler that restarts the connection, consider waiting for some ra
 [!code-csharp[InvokeAsync method](dotnet-client/sample/signalrchatclient/MainWindow.xaml.cs?name=snippet_InvokeAsync)]
 
 > [!NOTE]
-> If you are using Azure SignalR Service in *Serverless mode*, you cannot call hub methods from a client. For more information, see the [SignalR Service documentation](https://docs.microsoft.com/azure/azure-signalr/signalr-concept-serverless-development-config).
+> If you're using Azure SignalR Service in *Serverless mode*, you cannot call hub methods from a client. For more information, see the [SignalR Service documentation](/azure/azure-signalr/signalr-concept-serverless-development-config).
 
 ## Call client methods from hub
 

--- a/aspnetcore/signalr/java-client.md
+++ b/aspnetcore/signalr/java-client.md
@@ -102,4 +102,4 @@ HubConnection hubConnection = HubConnectionBuilder.create("YOUR HUB URL HERE")
 * <xref:signalr/hubs>
 * <xref:signalr/javascript-client>
 * <xref:signalr/publish-to-azure-web-app>
-* [Azure SignalR Service serverless documentation](https://docs.microsoft.com/azure/azure-signalr/signalr-concept-serverless-development-config)
+* [Azure SignalR Service serverless documentation](/azure/azure-signalr/signalr-concept-serverless-development-config)

--- a/aspnetcore/signalr/java-client.md
+++ b/aspnetcore/signalr/java-client.md
@@ -5,7 +5,7 @@ description: Learn how to use the ASP.NET Core SignalR Java client.
 monikerRange: '>= aspnetcore-2.2'
 ms.author: mimengis
 ms.custom: mvc
-ms.date: 11/07/2018
+ms.date: 03/14/2019
 uid: signalr/java-client
 ---
 # ASP.NET Core SignalR Java client
@@ -45,7 +45,7 @@ A call to `send` invokes a hub method. Pass the hub method name and any argument
 [!code-java[send method](java-client/sample/src/main/java/Chat.java?range=28)]
 
 > [!NOTE]
-> If you are using Azure SignalR Service in *Serverless mode*, you cannot call hub methods from a client. For more information, see the [SignalR Service documentation](https://docs.microsoft.com/azure/azure-signalr/signalr-concept-serverless-development-config).
+> If you're using Azure SignalR Service in *Serverless mode*, you cannot call hub methods from a client. For more information, see the [SignalR Service documentation](/azure/azure-signalr/signalr-concept-serverless-development-config).
 
 ## Call client methods from hub
 

--- a/aspnetcore/signalr/java-client.md
+++ b/aspnetcore/signalr/java-client.md
@@ -44,6 +44,9 @@ A call to `send` invokes a hub method. Pass the hub method name and any argument
 
 [!code-java[send method](java-client/sample/src/main/java/Chat.java?range=28)]
 
+> [!NOTE]
+> If you are using Azure SignalR Service in *Serverless mode*, you cannot call hub methods from a client. For more information, see the [SignalR Service documentation](https://docs.microsoft.com/azure/azure-signalr/signalr-concept-serverless-development-config).
+
 ## Call client methods from hub
 
 Use `hubConnection.on` to define methods on the client that the hub can call. Define the methods after building but before starting the connection.
@@ -99,3 +102,4 @@ HubConnection hubConnection = HubConnectionBuilder.create("YOUR HUB URL HERE")
 * <xref:signalr/hubs>
 * <xref:signalr/javascript-client>
 * <xref:signalr/publish-to-azure-web-app>
+* [Azure SignalR Service serverless documentation](https://docs.microsoft.com/azure/azure-signalr/signalr-concept-serverless-development-config)

--- a/aspnetcore/signalr/javascript-client.md
+++ b/aspnetcore/signalr/javascript-client.md
@@ -58,6 +58,9 @@ JavaScript clients call public methods on hubs via the [invoke](/javascript/api/
 
   [!code-javascript[Call hub methods](javascript-client/sample/wwwroot/js/chat.js?range=24)]
 
+> [!NOTE]
+> If you are using Azure SignalR Service in *Serverless mode*, you cannot call hub methods from a client. For more information, see the [SignalR Service documentation](https://docs.microsoft.com/azure/azure-signalr/signalr-concept-serverless-development-config).
+
 ## Call client methods from hub
 
 To receive messages from the hub, define a method using the [on](/javascript/api/%40aspnet/signalr/hubconnection#on) method of the `HubConnection`.
@@ -113,3 +116,4 @@ A real-world implementation would use an exponential back-off or retry a specifi
 * [.NET client](xref:signalr/dotnet-client)
 * [Publish to Azure](xref:signalr/publish-to-azure-web-app)
 * [Cross-Origin Requests (CORS)](xref:security/cors)
+* [Azure SignalR Service serverless documentation](https://docs.microsoft.com/azure/azure-signalr/signalr-concept-serverless-development-config)

--- a/aspnetcore/signalr/javascript-client.md
+++ b/aspnetcore/signalr/javascript-client.md
@@ -5,7 +5,7 @@ description: Overview of ASP.NET Core SignalR JavaScript client.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 11/14/2018
+ms.date: 03/14/2019
 uid: signalr/javascript-client
 ---
 # ASP.NET Core SignalR JavaScript client
@@ -59,7 +59,7 @@ JavaScript clients call public methods on hubs via the [invoke](/javascript/api/
   [!code-javascript[Call hub methods](javascript-client/sample/wwwroot/js/chat.js?range=24)]
 
 > [!NOTE]
-> If you are using Azure SignalR Service in *Serverless mode*, you cannot call hub methods from a client. For more information, see the [SignalR Service documentation](https://docs.microsoft.com/azure/azure-signalr/signalr-concept-serverless-development-config).
+> If you're using Azure SignalR Service in *Serverless mode*, you cannot call hub methods from a client. For more information, see the [SignalR Service documentation](/azure/azure-signalr/signalr-concept-serverless-development-config).
 
 ## Call client methods from hub
 
@@ -116,4 +116,4 @@ A real-world implementation would use an exponential back-off or retry a specifi
 * [.NET client](xref:signalr/dotnet-client)
 * [Publish to Azure](xref:signalr/publish-to-azure-web-app)
 * [Cross-Origin Requests (CORS)](xref:security/cors)
-* [Azure SignalR Service serverless documentation](https://docs.microsoft.com/azure/azure-signalr/signalr-concept-serverless-development-config)
+* [Azure SignalR Service serverless documentation](/azure/azure-signalr/signalr-concept-serverless-development-config)


### PR DESCRIPTION
Add note that SignalR clients cannot call hub methods if used with SignalR Service in serverless mode.