### PR TITLE
fix: MD003/heading-style/header-style

### DIFF
--- a/aspnetcore/grpc/basics.md
+++ b/aspnetcore/grpc/basics.md
@@ -7,7 +7,7 @@ ms.author: johluo
 ms.date: 03/08/2019
 uid: grpc/basics
 ---
-# gRPC services with C#
+# gRPC services with C\#
 
 This document outlines the basic concepts needed to write [gRPC](https://grpc.io/docs/guides/) apps in C#. The topics covered here apply to both [C-core](https://grpc.io/blog/grpc-stacks) based and ASP.NET Core based gRPC apps.
 

--- a/aspnetcore/includes/RP/model2.md
+++ b/aspnetcore/includes/RP/model2.md
@@ -1,8 +1,8 @@
 <a name="dc"></a>
 
-### 
+### Add a database context class
 
-Add the following `RazorPagesMovieContext` class to the *Models* folder:  
+Add the following `RazorPagesMovieContext` class to the *Models* folder:
 
 [!code-csharp[](~/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie22/Data/RazorPagesMovieContext.cs)]
 


### PR DESCRIPTION

- Escape trailing # that gets flagged as closed_atx
- Restore old heading text
- Spacing in empty tab