### PR TITLE
Updated for consistency

### DIFF
--- a/aspnetcore/tutorials/build-your-first-razor-components-app/samples/3.x/RazorComponents/Components/Pages/ToDo.razor
+++ b/aspnetcore/tutorials/build-your-first-razor-components-app/samples/3.x/RazorComponents/Components/Pages/ToDo.razor
@@ -1,6 +1,6 @@
 @page "/todo"
 
-<h1>Todo (@todos.Where(todo => !todo.IsDone).Count())</h1>
+<h1>Todo (@todos.Count(todo => !todo.IsDone))</h1>
 
 <ul>
     @foreach (var todo in todos)


### PR DESCRIPTION
The step explaining this code shows usage of `Count(predicate)` instead of `Where(predicate).Count()`.

See step 14/15 of the given example.