### PR TITLE
Change Database Name from ContosoUniversity1

### DIFF
--- a/aspnetcore/data/ef-rp/intro.md
+++ b/aspnetcore/data/ef-rp/intro.md
@@ -272,9 +272,9 @@ In *Program.cs*, modify the `Main` method to call `Initialize`:
 Delete any student records and restart the app. If the DB is not initialized, set a break point in `Initialize` to diagnose the problem.
 
 ## View the DB
-The database name is generated from the context name we provided earlier plus a dash and a GUID. Thus, the database name will be "SchoolContext-Unique GUID". The GUID will be different for each user.
+The database name is generated from the context name you provided earlier plus a dash and a GUID. Thus, the database name will be "SchoolContext-{GUID}". The GUID will be different for each user.
 Open **SQL Server Object Explorer** (SSOX) from the **View** menu in Visual Studio.
-In SSOX, click **(localdb)\MSSQLLocalDB > Databases > ContosoUniversity1**.
+In SSOX, click **(localdb)\MSSQLLocalDB > Databases > SchoolContext-{GUID}**.
 
 Expand the **Tables** node.
 

--- a/aspnetcore/data/ef-rp/intro.md
+++ b/aspnetcore/data/ef-rp/intro.md
@@ -272,7 +272,7 @@ In *Program.cs*, modify the `Main` method to call `Initialize`:
 Delete any student records and restart the app. If the DB is not initialized, set a break point in `Initialize` to diagnose the problem.
 
 ## View the DB
-
+The database name is generated from the context name we provided earlier plus a dash and a GUID. Thus, the database name will be "SchoolContext-Unique GUID". The GUID will be different for each user.
 Open **SQL Server Object Explorer** (SSOX) from the **View** menu in Visual Studio.
 In SSOX, click **(localdb)\MSSQLLocalDB > Databases > ContosoUniversity1**.
 


### PR DESCRIPTION
At the ## View the DB section the author describes how to find and view the table data within the EF-Core generated database.
The database name is listed as ContosoUniversity1. This is incorrect.
The database name generated is based on the dbContext name we used earlier in the course - "SchoolContext".
The database name will be generated as <dbContextName>-GUID, where the dbContextName is "SchoolContext", plus a dash (ASCII Character 45 (decimal) / 0x2D (hexadecimal), plus a GUID.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->