### PR TITLE
Clarify service lifetimes

### DIFF
--- a/aspnetcore/fundamentals/middleware/extensibility.md
+++ b/aspnetcore/fundamentals/middleware/extensibility.md
@@ -5,7 +5,7 @@ description: Learn how to use strongly-typed middleware with a factory-based act
 monikerRange: '>= aspnetcore-2.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/14/2018
+ms.date: 03/27/2019
 uid: fundamentals/middleware/extensibility
 ---
 # Factory-based middleware activation in ASP.NET Core
@@ -18,10 +18,10 @@ By [Luke Latham](https://github.com/guardrex)
 
 Benefits:
 
-* Activation per request (injection of scoped services)
+* Activation per client request (injection of scoped services)
 * Strong typing of middleware
 
-`IMiddleware` is activated per request, so scoped services can be injected into the middleware's constructor.
+`IMiddleware` is activated per client request (connection), so scoped services can be injected into the middleware's constructor.
 
 [View or download sample code](https://github.com/aspnet/Docs/tree/master/aspnetcore/fundamentals/middleware/extensibility/sample) ([how to download](xref:index#how-to-download-a-sample))
 

--- a/aspnetcore/razor-components/dependency-injection.md
+++ b/aspnetcore/razor-components/dependency-injection.md
@@ -5,7 +5,7 @@ description: See how Blazor and Razor Components apps can use services by inject
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/19/2019
+ms.date: 03/27/2019
 uid: razor-components/dependency-injection
 ---
 # Razor Components dependency injection
@@ -47,8 +47,8 @@ Services can be configured with the lifetimes shown in the following table.
 
 | Lifetime | Description |
 | -------- | ----------- |
-| <xref:Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton*> | DI creates a *single instance* of the service. All components requiring this service receive a reference to this instance. |
-| <xref:Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Transient*> | Whenever a component requires this service, it receives a *new instance* of the service. |
+| <xref:Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton*> | DI creates a *single instance* of the service. All components requiring a `Singleton` service receive an instance of the same service. |
+| <xref:Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Transient*> | Whenever a component obtains an instance of a `Transient` service from the service container, it receives a *new instance* of the service. |
 | <xref:Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped*> | Client-side Blazor doesn't currently have the concept of DI scopes. `Scoped` behaves like `Singleton`. However, ASP.NET Core Razor Components support the `Scoped` lifetime. In a Razor Component, a scoped service registration is scoped to the connection. For this reason, using scoped services is preferred for services that should be scoped to the current user, even if the current intent is to run client-side in the browser. |
 
 The DI system is based on the DI system in ASP.NET Core. For more information, see <xref:fundamentals/dependency-injection>.


### PR DESCRIPTION
Fixes #11707 

* Clarify the overloaded term "request" by stating explicitly "client request (connection)" or "service request" (i.e., from the container).
* Doubt we need engineering on this one.

cc: @ScottHutchinson