### PR TITLE
Added security toc item for "Application Security - OWASP" for issue …

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -972,6 +972,8 @@
       uid: security/cookie-sharing
     - name: IP safelist
       uid: security/ip-safelist
+    - name: Application security - OWASP
+      href: https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/DotNet_Security_Cheat_Sheet.md
 - name: Performance
   items:
     - name: Overview


### PR DESCRIPTION
…#11015

This fixes only part one of #11015.  So I will not auto-close the issue.   This adds a link to the Application security - OWASP Cheat Sheet in the TOC.
