### PR TITLE
Reset buffer before receiving socket messages

### DIFF
--- a/aspnetcore/fundamentals/websockets/samples/1.x/WebSocketsSample/Startup.cs
+++ b/aspnetcore/fundamentals/websockets/samples/1.x/WebSocketsSample/Startup.cs
@@ -81,6 +81,7 @@ namespace EchoApp
             {
                 await webSocket.SendAsync(new ArraySegment<byte>(buffer, 0, result.Count), result.MessageType, result.EndOfMessage, CancellationToken.None);
 
+                Array.Clear(buffer, 0, result.Count);
                 result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
             }
             await webSocket.CloseAsync(result.CloseStatus.Value, result.CloseStatusDescription, CancellationToken.None);

--- a/aspnetcore/fundamentals/websockets/samples/2.x/WebSocketsSample/Startup.cs
+++ b/aspnetcore/fundamentals/websockets/samples/2.x/WebSocketsSample/Startup.cs
@@ -103,6 +103,7 @@ namespace EchoApp
             {
                 await webSocket.SendAsync(new ArraySegment<byte>(buffer, 0, result.Count), result.MessageType, result.EndOfMessage, CancellationToken.None);
 
+                Array.Clear(buffer, 0, result.Count);
                 result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
             }
             await webSocket.CloseAsync(result.CloseStatus.Value, result.CloseStatusDescription, CancellationToken.None);


### PR DESCRIPTION
Fixes #11776 

When the buffer is not clean, messages can overlap one on another. This fixes this issue by resetting the buffer all over again before awaiting for new messages from the client.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->